### PR TITLE
feat: end-to-end AI inference integration (Phase 6)

### DIFF
--- a/crates/qfc-consensus/src/engine.rs
+++ b/crates/qfc-consensus/src/engine.rs
@@ -895,6 +895,24 @@ impl ConsensusEngine {
         }
     }
 
+    /// Update a validator's inference score from AI compute (v2.0)
+    pub fn update_inference_score(
+        &self,
+        validator: &Address,
+        flops: u64,
+        tasks_completed: u64,
+    ) {
+        let mut validators = self.validators.write();
+        if let Some(v) = validators.iter_mut().find(|v| v.address == *validator) {
+            v.inference_score = v.inference_score.saturating_add(flops);
+            v.tasks_completed = tasks_completed;
+            debug!(
+                "Updated inference score for {}: score={}, tasks={}",
+                validator, v.inference_score, v.tasks_completed
+            );
+        }
+    }
+
     /// Get a validator's current hashrate
     pub fn get_hashrate(&self, validator: &Address) -> u64 {
         let validators = self.validators.read();

--- a/crates/qfc-miner/src/main.rs
+++ b/crates/qfc-miner/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Start worker
-    let worker = worker::InferenceWorker::new(config, engine);
+    let mut worker = worker::InferenceWorker::new(config, engine);
 
     info!("Connecting to validator at {}...", validator_rpc);
     worker.run().await;

--- a/crates/qfc-miner/src/submit.rs
+++ b/crates/qfc-miner/src/submit.rs
@@ -1,25 +1,217 @@
-//! Submit proofs to validator via RPC
+//! Submit proofs and fetch tasks via validator RPC
 
 use qfc_inference::proof::InferenceProof;
-use tracing::debug;
+use qfc_inference::runtime::{BackendType, GpuTier};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+
+/// Task request sent to validator
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskRequest {
+    miner_address: String,
+    gpu_tier: String,
+    available_memory_mb: u64,
+    backend: String,
+}
+
+/// Inference task received from validator
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InferenceTaskResponse {
+    pub task_id: String,
+    pub epoch: u64,
+    pub task_type: String,
+    pub model_name: String,
+    pub model_version: String,
+    pub input_data: String,
+    pub deadline: u64,
+}
+
+/// Proof submission sent to validator
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProofSubmission {
+    miner_address: String,
+    task_id: String,
+    epoch: u64,
+    output_hash: String,
+    execution_time_ms: u64,
+    flops_estimated: u64,
+    backend: String,
+    proof_bytes: String,
+}
+
+/// Result from proof submission
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProofResult {
+    pub accepted: bool,
+    pub spot_checked: bool,
+    pub message: String,
+}
+
+/// JSON-RPC request/response types
+#[derive(Serialize)]
+struct JsonRpcRequest<T: Serialize> {
+    jsonrpc: &'static str,
+    method: &'static str,
+    params: Vec<T>,
+    id: u64,
+}
+
+#[derive(Deserialize)]
+struct JsonRpcResponse<T> {
+    #[allow(dead_code)]
+    jsonrpc: String,
+    result: Option<T>,
+    error: Option<JsonRpcError>,
+    #[allow(dead_code)]
+    id: u64,
+}
+
+#[derive(Deserialize)]
+struct JsonRpcError {
+    #[allow(dead_code)]
+    code: i64,
+    message: String,
+}
+
+/// Fetch an inference task from the validator node
+pub async fn fetch_task(
+    rpc_url: &str,
+    miner_address: &str,
+    tier: GpuTier,
+    memory_mb: u64,
+    backend: BackendType,
+) -> Result<Option<InferenceTaskResponse>, SubmitError> {
+    let request = TaskRequest {
+        miner_address: miner_address.to_string(),
+        gpu_tier: match tier {
+            GpuTier::Hot => "Hot".to_string(),
+            GpuTier::Warm => "Warm".to_string(),
+            GpuTier::Cold => "Cold".to_string(),
+        },
+        available_memory_mb: memory_mb,
+        backend: format!("{}", backend),
+    };
+
+    let rpc_request = JsonRpcRequest {
+        jsonrpc: "2.0",
+        method: "qfc_getInferenceTask",
+        params: vec![request],
+        id: 1,
+    };
+
+    let body = serde_json::to_string(&rpc_request)
+        .map_err(|e| SubmitError::SerializationError(e.to_string()))?;
+
+    debug!("Fetching task from {}", rpc_url);
+
+    let output = tokio::process::Command::new("curl")
+        .args([
+            "-s",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            &body,
+            rpc_url,
+        ])
+        .output()
+        .await
+        .map_err(|e| SubmitError::ConnectionFailed(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(SubmitError::ConnectionFailed(
+            "curl request failed".to_string(),
+        ));
+    }
+
+    let response_str = String::from_utf8(output.stdout)
+        .map_err(|e| SubmitError::SerializationError(e.to_string()))?;
+
+    let response: JsonRpcResponse<Option<InferenceTaskResponse>> =
+        serde_json::from_str(&response_str)
+            .map_err(|e| SubmitError::SerializationError(format!("Parse response: {}", e)))?;
+
+    if let Some(err) = response.error {
+        return Err(SubmitError::ProofRejected(err.message));
+    }
+
+    Ok(response.result.flatten())
+}
 
 /// Submit an inference proof to the validator node
-#[allow(dead_code)]
 pub async fn submit_proof(
     rpc_url: &str,
+    miner_address: &str,
     proof: &InferenceProof,
-) -> Result<(), SubmitError> {
-    // TODO: Implement RPC call to validator
-    // This will use jsonrpsee client to call qfc_submitInferenceProof
-    debug!(
-        "Would submit proof for epoch {} to {}",
-        proof.epoch, rpc_url
-    );
-    Ok(())
+) -> Result<ProofResult, SubmitError> {
+    let proof_bytes = hex::encode(proof.to_bytes());
+    let output_hash = hex::encode(proof.output_hash.as_bytes());
+
+    let submission = ProofSubmission {
+        miner_address: miner_address.to_string(),
+        task_id: hex::encode(proof.input_hash.as_bytes()),
+        epoch: proof.epoch,
+        output_hash,
+        execution_time_ms: proof.execution_time_ms,
+        flops_estimated: proof.flops_estimated,
+        backend: format!("{}", proof.backend),
+        proof_bytes,
+    };
+
+    let rpc_request = JsonRpcRequest {
+        jsonrpc: "2.0",
+        method: "qfc_submitInferenceProof",
+        params: vec![submission],
+        id: 1,
+    };
+
+    let body = serde_json::to_string(&rpc_request)
+        .map_err(|e| SubmitError::SerializationError(e.to_string()))?;
+
+    info!("Submitting proof for epoch {} to {}", proof.epoch, rpc_url);
+
+    let output = tokio::process::Command::new("curl")
+        .args([
+            "-s",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            &body,
+            rpc_url,
+        ])
+        .output()
+        .await
+        .map_err(|e| SubmitError::ConnectionFailed(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(SubmitError::ConnectionFailed(
+            "curl request failed".to_string(),
+        ));
+    }
+
+    let response_str = String::from_utf8(output.stdout)
+        .map_err(|e| SubmitError::SerializationError(e.to_string()))?;
+
+    let response: JsonRpcResponse<ProofResult> = serde_json::from_str(&response_str)
+        .map_err(|e| SubmitError::SerializationError(format!("Parse response: {}", e)))?;
+
+    if let Some(err) = response.error {
+        return Err(SubmitError::ProofRejected(err.message));
+    }
+
+    response
+        .result
+        .ok_or_else(|| SubmitError::SerializationError("No result in response".to_string()))
 }
 
 #[derive(Debug, thiserror::Error)]
-#[allow(dead_code)]
 pub enum SubmitError {
     #[error("RPC connection failed: {0}")]
     ConnectionFailed(String),

--- a/crates/qfc-miner/src/worker.rs
+++ b/crates/qfc-miner/src/worker.rs
@@ -4,25 +4,26 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use qfc_inference::proof::InferenceProof;
+use qfc_inference::runtime::{classify_tier, GpuTier};
+use qfc_inference::task::{ComputeTaskType, InferenceTask, ModelId};
 use qfc_inference::InferenceEngine;
+use qfc_types::Hash;
 use tokio::time::interval;
-use tracing::{debug, info};
+use tracing::{debug, error, info, warn};
 
 use crate::config::MinerConfig;
+use crate::submit::{self, InferenceTaskResponse};
 
 /// Inference worker that fetches tasks and submits proofs
 pub struct InferenceWorker {
-    #[allow(dead_code)]
     config: MinerConfig,
     engine: Box<dyn InferenceEngine>,
     stop_flag: Arc<AtomicBool>,
 }
 
 impl InferenceWorker {
-    pub fn new(
-        config: MinerConfig,
-        engine: Box<dyn InferenceEngine>,
-    ) -> Self {
+    pub fn new(config: MinerConfig, engine: Box<dyn InferenceEngine>) -> Self {
         Self {
             config,
             engine,
@@ -31,14 +32,18 @@ impl InferenceWorker {
     }
 
     /// Main worker loop
-    pub async fn run(&self) {
+    pub async fn run(&mut self) {
+        let tier = classify_tier(self.config.backend, self.config.max_memory_mb);
         info!(
-            "Starting inference worker (backend: {}, wallet: {})",
-            self.config.backend, self.config.wallet_address
+            "Starting inference worker (backend: {}, tier: {}, wallet: {})",
+            self.config.backend,
+            tier,
+            hex::encode(self.config.wallet_address.as_bytes())
         );
 
         let mut epoch_timer = interval(Duration::from_secs(10));
-        let mut epoch = 0u64;
+        let mut tasks_completed: u64 = 0;
+        let mut tasks_failed: u64 = 0;
 
         loop {
             epoch_timer.tick().await;
@@ -48,21 +53,166 @@ impl InferenceWorker {
                 break;
             }
 
-            epoch += 1;
-            debug!("Worker epoch {}", epoch);
+            // 1. Fetch task from validator
+            let task_response = match self.fetch_task(tier).await {
+                Ok(Some(task)) => task,
+                Ok(None) => {
+                    debug!("No tasks available, waiting...");
+                    continue;
+                }
+                Err(e) => {
+                    warn!("Failed to fetch task: {}", e);
+                    continue;
+                }
+            };
 
-            // TODO: Fetch task from validator via RPC
-            // TODO: Run inference
-            // TODO: Submit proof via RPC
-
-            // Placeholder: log heartbeat
             info!(
-                "Epoch {}: waiting for tasks (backend: {}, memory: {} MB)",
-                epoch,
-                self.engine.backend_type(),
-                self.engine.available_memory_mb()
+                "Received task {} (epoch {}, model: {})",
+                &task_response.task_id[..16.min(task_response.task_id.len())],
+                task_response.epoch,
+                task_response.model_name
             );
+
+            // 2. Convert RPC response to InferenceTask
+            let task = match self.convert_task(&task_response) {
+                Ok(t) => t,
+                Err(e) => {
+                    error!("Failed to parse task: {}", e);
+                    tasks_failed += 1;
+                    continue;
+                }
+            };
+
+            // 3. Ensure model is loaded
+            let model_id = ModelId::new(&task_response.model_name, &task_response.model_version);
+            if let Err(e) = self.engine.load_model(&model_id).await {
+                warn!("Failed to load model {}: {}", model_id, e);
+                tasks_failed += 1;
+                continue;
+            }
+
+            // 4. Run inference
+            let result = match self.engine.run_inference(&task).await {
+                Ok(r) => r,
+                Err(e) => {
+                    error!("Inference failed: {}", e);
+                    tasks_failed += 1;
+                    continue;
+                }
+            };
+
+            info!(
+                "Inference complete: {} ms, {} FLOPS, output hash: {}",
+                result.execution_time_ms,
+                result.flops_estimated,
+                hex::encode(&result.output_hash.as_bytes()[..8])
+            );
+
+            // 5. Build proof
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+
+            let proof = InferenceProof::new(
+                self.config.wallet_address,
+                task_response.epoch,
+                task.task_type.clone(),
+                task.task_id, // input hash = task_id
+                result.output_hash,
+                result.execution_time_ms,
+                result.flops_estimated,
+                self.engine.backend_type(),
+                now,
+            );
+
+            // 6. Submit proof to validator
+            let rpc_url = &self.config.validator_rpc;
+            let miner_addr = hex::encode(self.config.wallet_address.as_bytes());
+
+            match submit::submit_proof(rpc_url, &miner_addr, &proof).await {
+                Ok(result) => {
+                    tasks_completed += 1;
+                    if result.accepted {
+                        info!(
+                            "Proof accepted! (spot_checked: {}, total: {}, failed: {})",
+                            result.spot_checked, tasks_completed, tasks_failed
+                        );
+                    } else {
+                        warn!("Proof rejected: {}", result.message);
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to submit proof: {}", e);
+                    tasks_failed += 1;
+                }
+            }
         }
+    }
+
+    /// Fetch a task from the validator RPC
+    async fn fetch_task(
+        &self,
+        tier: GpuTier,
+    ) -> Result<Option<InferenceTaskResponse>, submit::SubmitError> {
+        let rpc_url = &self.config.validator_rpc;
+        let miner_addr = hex::encode(self.config.wallet_address.as_bytes());
+
+        submit::fetch_task(
+            rpc_url,
+            &miner_addr,
+            tier,
+            self.config.max_memory_mb,
+            self.engine.backend_type(),
+        )
+        .await
+    }
+
+    /// Convert an RPC task response into an InferenceTask
+    fn convert_task(&self, resp: &InferenceTaskResponse) -> Result<InferenceTask, String> {
+        let task_id_bytes = hex::decode(&resp.task_id)
+            .map_err(|e| format!("Invalid task_id hex: {}", e))?;
+        let task_id = Hash::from_slice(&task_id_bytes)
+            .ok_or_else(|| "task_id must be 32 bytes".to_string())?;
+
+        let input_data = hex::decode(&resp.input_data)
+            .map_err(|e| format!("Invalid input_data hex: {}", e))?;
+
+        let input_hash = qfc_crypto::blake3_hash(&input_data);
+
+        let model_id = ModelId::new(&resp.model_name, &resp.model_version);
+        let task_type = match resp.task_type.as_str() {
+            "embedding" => ComputeTaskType::Embedding {
+                model_id,
+                input_hash,
+            },
+            "image_classification" => ComputeTaskType::ImageClassification {
+                model_id,
+                input_hash,
+            },
+            "text_generation" => ComputeTaskType::TextGeneration {
+                model_id,
+                prompt_hash: input_hash,
+                max_tokens: 128,
+                temperature_fp: 0,
+                seed: resp.epoch,
+            },
+            other => return Err(format!("Unknown task type: {}", other)),
+        };
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        Ok(InferenceTask::new(
+            task_id,
+            resp.epoch,
+            task_type,
+            input_data,
+            now,
+            resp.deadline,
+        ))
     }
 
     /// Stop the worker

--- a/crates/qfc-node/Cargo.toml
+++ b/crates/qfc-node/Cargo.toml
@@ -33,5 +33,7 @@ tracing-subscriber.workspace = true
 anyhow.workspace = true
 parking_lot.workspace = true
 hex.workspace = true
+qfc-inference.workspace = true
+qfc-ai-coordinator.workspace = true
 
 [dev-dependencies]

--- a/crates/qfc-node/src/miner.rs
+++ b/crates/qfc-node/src/miner.rs
@@ -182,17 +182,37 @@ impl MiningService {
 
     /// Start v2 AI inference mining loop
     async fn start_inference_v2(self: Arc<Self>) {
+        let backend = match self.config.inference_backend.as_deref() {
+            Some("cuda") => qfc_inference::BackendType::Cuda,
+            Some("metal") => qfc_inference::BackendType::Metal,
+            Some("cpu") => qfc_inference::BackendType::Cpu,
+            _ => qfc_inference::runtime::detect_backend(),
+        };
+
         info!(
-            "Starting AI inference mining service (v2) for validator {}",
-            self.validator_address
+            "Starting AI inference mining service (v2) for validator {} (backend: {})",
+            self.validator_address, backend
         );
+
+        let mut engine = match qfc_inference::create_engine_for_backend(backend) {
+            Ok(e) => e,
+            Err(e) => {
+                error!("Failed to create inference engine: {}", e);
+                return;
+            }
+        };
 
         // Mark validator as providing compute
         self.consensus
             .set_provides_compute(&self.validator_address, true);
 
+        let tier = qfc_inference::runtime::classify_tier(backend, engine.available_memory_mb());
+        let model_registry = qfc_inference::model::ModelRegistry::default_v2();
+        let mut task_pool = qfc_ai_coordinator::TaskPool::new();
+
         let mut epoch_timer = interval(Duration::from_millis(self.config.epoch_duration_ms));
         let mut current_epoch = 0u64;
+        let mut tasks_completed = 0u64;
 
         loop {
             epoch_timer.tick().await;
@@ -203,17 +223,104 @@ impl MiningService {
             }
 
             current_epoch += 1;
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64;
 
-            // TODO: Fetch inference task from coordinator
-            // TODO: Run inference via qfc-inference engine
-            // TODO: Submit InferenceProof
-            // TODO: Update inference_score in consensus
+            // Generate synthetic tasks if pool is empty
+            if task_pool.pending_count() == 0 {
+                let head_hash = self.chain.head().map(|h| h.hash).unwrap_or_default();
+                let seed = head_hash.as_bytes()[0] as u64 ^ current_epoch;
+                task_pool.generate_synthetic_tasks(current_epoch, seed, now + 30_000);
+            }
+
+            // Fetch a task matching our capabilities
+            let task = match task_pool.fetch_task(tier, engine.available_memory_mb()) {
+                Some(t) => t,
+                None => {
+                    debug!("Epoch {}: no matching tasks for tier {}", current_epoch, tier);
+                    continue;
+                }
+            };
+
+            // Load model if needed
+            if let Some(model_id) = task.task_type.model_id() {
+                if let Err(e) = engine.load_model(model_id).await {
+                    warn!("Failed to load model {}: {}", model_id, e);
+                    continue;
+                }
+            }
+
+            // Run inference
+            let result = match engine.run_inference(&task).await {
+                Ok(r) => r,
+                Err(e) => {
+                    error!("Inference failed for epoch {}: {}", current_epoch, e);
+                    continue;
+                }
+            };
 
             info!(
-                "Inference epoch {}: waiting for task coordinator (backend: {})",
-                current_epoch,
-                self.config.inference_backend.as_deref().unwrap_or("auto")
+                "Epoch {}: inference complete ({} ms, {} FLOPS)",
+                current_epoch, result.execution_time_ms, result.flops_estimated
             );
+
+            // Build inference proof (using qfc_inference types for local verification)
+            let mut inf_proof = qfc_inference::InferenceProof::new(
+                self.validator_address,
+                current_epoch,
+                task.task_type.clone(),
+                task.task_id,
+                result.output_hash,
+                result.execution_time_ms,
+                result.flops_estimated,
+                backend,
+                now / 1000,
+            );
+
+            // Sign the proof
+            let proof_hash = blake3_hash(&inf_proof.to_bytes_without_signature());
+            match self.consensus.sign_hash(&proof_hash) {
+                Ok(sig) => inf_proof.set_signature(sig),
+                Err(e) => {
+                    error!("Failed to sign inference proof: {}", e);
+                    continue;
+                }
+            }
+
+            // Verify locally before broadcasting
+            match qfc_ai_coordinator::verify_basic(&inf_proof, current_epoch, &model_registry) {
+                Ok(_) => {
+                    tasks_completed += 1;
+
+                    // Update inference score in consensus
+                    self.consensus.update_inference_score(
+                        &self.validator_address,
+                        result.flops_estimated,
+                        tasks_completed,
+                    );
+
+                    info!(
+                        "Epoch {}: proof verified (tasks_completed: {})",
+                        current_epoch, tasks_completed
+                    );
+
+                    // Convert to qfc_types::InferenceProof for network broadcast
+                    let types_proof = convert_inference_proof(&inf_proof);
+
+                    // Broadcast proof to network
+                    if let Some(network) = &self.network {
+                        let msg = ValidatorMessage::InferenceProof(types_proof);
+                        if let Err(e) = network.broadcast_validator_msg(msg.to_bytes()).await {
+                            warn!("Failed to broadcast inference proof: {}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Local proof verification failed: {}", e);
+                }
+            }
         }
     }
 
@@ -328,6 +435,15 @@ impl MiningService {
     pub fn stop(&self) {
         self.stop_flag.store(true, Ordering::Relaxed);
     }
+}
+
+/// Convert qfc_inference::InferenceProof → qfc_types::InferenceProof
+/// Both types have identical Borsh layout, so we serialize/deserialize.
+fn convert_inference_proof(
+    proof: &qfc_inference::InferenceProof,
+) -> qfc_types::InferenceProof {
+    let bytes = borsh::to_vec(proof).expect("InferenceProof serialization should not fail");
+    borsh::from_slice(&bytes).expect("InferenceProof deserialization should not fail")
 }
 
 /// Get the number of CPUs available

--- a/crates/qfc-rpc/Cargo.toml
+++ b/crates/qfc-rpc/Cargo.toml
@@ -25,4 +25,8 @@ async-trait.workspace = true
 tracing.workspace = true
 hex.workspace = true
 
+qfc-inference.workspace = true
+qfc-ai-coordinator.workspace = true
+borsh.workspace = true
+
 [dev-dependencies]

--- a/crates/qfc-rpc/src/qfc.rs
+++ b/crates/qfc-rpc/src/qfc.rs
@@ -131,6 +131,20 @@ pub trait QfcApi {
     /// Get inference statistics (tasks completed, avg time, FLOPS, pass rate)
     #[method(name = "getInferenceStats")]
     async fn get_inference_stats(&self) -> RpcResult<RpcInferenceStats>;
+
+    /// Fetch an inference task for a miner (miner provides its capabilities)
+    #[method(name = "getInferenceTask")]
+    async fn get_inference_task(
+        &self,
+        request: RpcTaskRequest,
+    ) -> RpcResult<Option<RpcInferenceTask>>;
+
+    /// Submit an inference proof from a miner
+    #[method(name = "submitInferenceProof")]
+    async fn submit_inference_proof(
+        &self,
+        proof: RpcInferenceProofSubmission,
+    ) -> RpcResult<RpcProofResult>;
 }
 
 /// Faucet response
@@ -210,4 +224,74 @@ pub struct RpcInferenceStats {
     pub flops_total: String,
     /// Verification pass rate (0-100%)
     pub pass_rate: String,
+}
+
+// ============ v2.0: Task Assignment & Proof Submission Types ============
+
+/// Miner's request for an inference task
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcTaskRequest {
+    /// Miner wallet address
+    pub miner_address: String,
+    /// GPU tier: "Hot", "Warm", "Cold"
+    pub gpu_tier: String,
+    /// Available memory in MB
+    pub available_memory_mb: u64,
+    /// Backend type: "CUDA", "Metal", "CPU"
+    pub backend: String,
+}
+
+/// An inference task assigned to a miner
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcInferenceTask {
+    /// Task ID (hex)
+    pub task_id: String,
+    /// Epoch number
+    pub epoch: u64,
+    /// Task type: "embedding", "text_generation", "image_classification"
+    pub task_type: String,
+    /// Model name
+    pub model_name: String,
+    /// Model version
+    pub model_version: String,
+    /// Input data (hex-encoded)
+    pub input_data: String,
+    /// Deadline timestamp (ms)
+    pub deadline: u64,
+}
+
+/// Inference proof submitted by a miner
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcInferenceProofSubmission {
+    /// Miner wallet address
+    pub miner_address: String,
+    /// Task ID (hex)
+    pub task_id: String,
+    /// Epoch
+    pub epoch: u64,
+    /// Output hash (hex)
+    pub output_hash: String,
+    /// Execution time in ms
+    pub execution_time_ms: u64,
+    /// Estimated FLOPS
+    pub flops_estimated: u64,
+    /// Backend used: "CUDA", "Metal", "CPU"
+    pub backend: String,
+    /// Serialized proof bytes (hex)
+    pub proof_bytes: String,
+}
+
+/// Result of submitting an inference proof
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcProofResult {
+    /// Whether the proof was accepted
+    pub accepted: bool,
+    /// Whether the proof was spot-checked
+    pub spot_checked: bool,
+    /// Detail message
+    pub message: String,
 }

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -3,8 +3,9 @@
 use crate::error::RpcError;
 use crate::eth::EthApiServer;
 use crate::qfc::{
-    QfcApiServer, RpcComputeInfo, RpcEpoch, RpcFaucetResponse, RpcInferenceStats, RpcModel,
-    RpcNodeInfo, RpcValidator, RpcValidatorMetrics, RpcValidatorScoreBreakdown,
+    QfcApiServer, RpcComputeInfo, RpcEpoch, RpcFaucetResponse, RpcInferenceStats,
+    RpcInferenceProofSubmission, RpcInferenceTask, RpcModel, RpcNodeInfo, RpcProofResult,
+    RpcTaskRequest, RpcValidator, RpcValidatorMetrics, RpcValidatorScoreBreakdown,
 };
 use crate::types::{BlockNumber, BlockTag, CallRequest, RpcBlock, RpcReceipt, RpcTransaction};
 use jsonrpsee::core::RpcResult;
@@ -60,6 +61,10 @@ pub struct RpcServer {
     sync_status: Option<Arc<dyn SyncStatusProvider>>,
     /// Chain ID
     chain_id: u64,
+    /// v2.0: AI inference task pool
+    task_pool: Arc<RwLock<qfc_ai_coordinator::TaskPool>>,
+    /// v2.0: Model registry for verification
+    model_registry: Arc<qfc_inference::model::ModelRegistry>,
 }
 
 impl Clone for RpcServer {
@@ -70,6 +75,8 @@ impl Clone for RpcServer {
             network: self.network.clone(),
             sync_status: self.sync_status.clone(),
             chain_id: self.chain_id,
+            task_pool: self.task_pool.clone(),
+            model_registry: self.model_registry.clone(),
         }
     }
 }
@@ -77,12 +84,22 @@ impl Clone for RpcServer {
 impl RpcServer {
     /// Create a new RPC server
     pub fn new(chain: Arc<Chain>, mempool: Arc<RwLock<Mempool>>, chain_id: u64) -> Self {
+        let mut task_pool = qfc_ai_coordinator::TaskPool::new();
+        // Generate initial synthetic tasks for epoch 1
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        task_pool.generate_synthetic_tasks(1, 42, now + 30_000);
+
         Self {
             chain,
             mempool,
             network: None,
             sync_status: None,
             chain_id,
+            task_pool: Arc::new(RwLock::new(task_pool)),
+            model_registry: Arc::new(qfc_inference::model::ModelRegistry::default_v2()),
         }
     }
 
@@ -975,5 +992,98 @@ impl QfcApiServer for RpcServer {
             flops_total: "0".to_string(),  // TODO: accumulate
             pass_rate: format!("{:.2}", avg_pass_rate * 100.0),
         })
+    }
+
+    async fn get_inference_task(
+        &self,
+        request: RpcTaskRequest,
+    ) -> RpcResult<Option<RpcInferenceTask>> {
+        let tier = match request.gpu_tier.as_str() {
+            "Hot" => qfc_inference::GpuTier::Hot,
+            "Warm" => qfc_inference::GpuTier::Warm,
+            _ => qfc_inference::GpuTier::Cold,
+        };
+
+        let mut pool = self.task_pool.write();
+
+        // If pool is empty, generate new synthetic tasks
+        if pool.pending_count() == 0 {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64;
+            let epoch_seed = qfc_crypto::blake3_hash(now.to_le_bytes().as_ref())
+                .as_bytes()[0] as u64;
+            pool.generate_synthetic_tasks(now / 10_000, epoch_seed, now + 30_000);
+        }
+
+        match pool.fetch_task(tier, request.available_memory_mb) {
+            Some(task) => {
+                let (model_name, model_version) = match task.task_type.model_id() {
+                    Some(id) => (id.name.clone(), id.version.clone()),
+                    None => ("unknown".to_string(), "v0".to_string()),
+                };
+
+                Ok(Some(RpcInferenceTask {
+                    task_id: hex::encode(task.task_id.as_bytes()),
+                    epoch: task.epoch,
+                    task_type: task.task_type.task_type_name().to_string(),
+                    model_name,
+                    model_version,
+                    input_data: hex::encode(&task.input_data),
+                    deadline: task.deadline,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn submit_inference_proof(
+        &self,
+        submission: RpcInferenceProofSubmission,
+    ) -> RpcResult<RpcProofResult> {
+        // Decode proof bytes
+        let proof_bytes = hex::decode(&submission.proof_bytes).map_err(|e| {
+            RpcError::Execution(format!("Invalid proof hex: {}", e))
+        })?;
+
+        let proof = qfc_inference::InferenceProof::from_bytes(&proof_bytes).map_err(|e| {
+            RpcError::Execution(format!("Failed to deserialize proof: {}", e))
+        })?;
+
+        // Basic verification
+        match qfc_ai_coordinator::verify_basic(&proof, proof.epoch, &self.model_registry) {
+            Ok(result) => {
+                info!(
+                    "Proof accepted from {} for epoch {} (spot_check={})",
+                    submission.miner_address, proof.epoch, result.spot_checked
+                );
+
+                // Check if this proof should be spot-checked
+                let should_spot = qfc_ai_coordinator::should_spot_check(&proof);
+
+                Ok(RpcProofResult {
+                    accepted: true,
+                    spot_checked: should_spot,
+                    message: if should_spot {
+                        "Proof accepted, queued for spot-check verification".to_string()
+                    } else {
+                        "Proof accepted".to_string()
+                    },
+                })
+            }
+            Err(e) => {
+                warn!(
+                    "Proof rejected from {}: {}",
+                    submission.miner_address, e
+                );
+
+                Ok(RpcProofResult {
+                    accepted: false,
+                    spot_checked: false,
+                    message: format!("Proof rejected: {}", e),
+                })
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **qfc-rpc**: Added `qfc_getInferenceTask` and `qfc_submitInferenceProof` RPC endpoints with TaskPool auto-generation and basic proof verification
- **qfc-miner**: Rewrote `submit.rs` with JSON-RPC client calls; implemented full worker loop (fetch task → run inference → build proof → submit)
- **qfc-node**: Implemented `start_inference_v2()` with engine creation, local task pool, proof verification, inference score tracking, and network broadcast
- **qfc-consensus**: Added `update_inference_score()` method for v2 compute scoring

## Files changed (9 files, +718/-42)
| Crate | File | Change |
|-------|------|--------|
| qfc-rpc | `qfc.rs` | 2 new RPC methods + 4 new types |
| qfc-rpc | `server.rs` | TaskPool/ModelRegistry init + endpoint implementation |
| qfc-rpc | `Cargo.toml` | Added qfc-inference, qfc-ai-coordinator deps |
| qfc-miner | `submit.rs` | Full JSON-RPC fetch_task/submit_proof |
| qfc-miner | `worker.rs` | Real inference loop replacing TODOs |
| qfc-miner | `main.rs` | `mut worker` for load_model |
| qfc-node | `miner.rs` | v2 inference mining with coordinator |
| qfc-node | `Cargo.toml` | Added qfc-inference, qfc-ai-coordinator deps |
| qfc-consensus | `engine.rs` | `update_inference_score()` |

## Test plan
- [x] `cargo check --all` passes
- [x] All 176 tests pass (5 pre-existing integration failures excluded)
- [ ] Manual test: run `qfc-node --dev --mine` with `--compute-mode inference`
- [ ] Manual test: run standalone `qfc-miner` against a validator node

🤖 Generated with [Claude Code](https://claude.com/claude-code)