### PR TITLE
fix: use consensus epoch in submit_public_task

### DIFF
--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -2532,9 +2532,10 @@ impl QfcApiServer for RpcServer {
             qfc_crypto::blake3_hash(&data)
         };
 
+        let current_epoch = self.chain.get_epoch();
         let task = qfc_inference::InferenceTask::new(
             task_id,
-            now / 10_000,
+            current_epoch.number,
             task_type,
             input_data,
             now,


### PR DESCRIPTION
## Summary

- `submit_public_task()` in `qfc-rpc/src/server.rs` still used `now_millis / 10_000` to calculate epoch, producing values like ~177 million instead of the correct ~711
- The same bug was already fixed in `get_inference_task()` (which now uses `self.chain.get_epoch()`), but `submit_public_task()` was missed
- This fix applies the same pattern: use `self.chain.get_epoch().number` for the epoch value

## Test plan

- [ ] Verify `cargo build` compiles successfully
- [ ] Verify `cargo test --all` passes
- [ ] Run miner against testnet and confirm proofs are no longer rejected with epoch mismatch
- [ ] Submit a public task via RPC and confirm it uses the correct epoch number

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)