### PR TITLE
refactor: timestamp-deadline verification (replaces epoch check)

### DIFF
--- a/crates/qfc-ai-coordinator/benches/verification_bench.rs
+++ b/crates/qfc-ai-coordinator/benches/verification_bench.rs
@@ -8,6 +8,13 @@ use qfc_inference::task::{ComputeTaskType, ModelId};
 use qfc_inference::BackendType;
 use qfc_types::{Address, Hash};
 
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
 fn make_proof(output_byte: u8, flops: u64) -> InferenceProof {
     InferenceProof::new(
         Address::new([0x11; 20]),
@@ -21,19 +28,20 @@ fn make_proof(output_byte: u8, flops: u64) -> InferenceProof {
         100,
         flops,
         BackendType::Cpu,
-        1234567890,
+        now_secs(),
     )
 }
 
 fn bench_verify_basic(c: &mut Criterion) {
     let registry = ModelRegistry::default_v2();
     let proof = make_proof(0xAB, 1_000_000_000);
+    let now = now_secs();
 
     let mut group = c.benchmark_group("verify_basic");
     group.throughput(Throughput::Elements(1));
 
     group.bench_function("single_proof", |b| {
-        b.iter(|| verify_basic(black_box(&proof), black_box(1), black_box(&registry)))
+        b.iter(|| verify_basic(black_box(&proof), black_box(now), black_box(&registry)))
     });
 
     group.finish();
@@ -41,6 +49,7 @@ fn bench_verify_basic(c: &mut Criterion) {
 
 fn bench_verify_basic_batch(c: &mut Criterion) {
     let registry = ModelRegistry::default_v2();
+    let now = now_secs();
 
     let mut group = c.benchmark_group("verify_basic_batch");
 
@@ -53,7 +62,7 @@ fn bench_verify_basic_batch(c: &mut Criterion) {
         group.bench_function(format!("{}_proofs", count), |b| {
             b.iter(|| {
                 for proof in &proofs {
-                    let _ = verify_basic(black_box(proof), black_box(1), black_box(&registry));
+                    let _ = verify_basic(black_box(proof), black_box(now), black_box(&registry));
                 }
             })
         });

--- a/crates/qfc-ai-coordinator/src/verification.rs
+++ b/crates/qfc-ai-coordinator/src/verification.rs
@@ -1,15 +1,39 @@
 //! Spot-check verification logic for inference proofs
+//!
+//! Follows the industry pattern (Bittensor, Ritual, Gensyn) of using
+//! task-scoped deadlines instead of global epoch checks. Epochs are
+//! retained for reward attribution only — not for rejecting proofs.
 
 use qfc_inference::proof::InferenceProof;
 use qfc_inference::{InferenceEngine, InferenceTask};
 use qfc_types::Hash;
 use thiserror::Error;
 
+/// Maximum age of a proof in seconds (2 minutes).
+/// Proofs older than this are rejected to prevent replay attacks.
+/// This is deliberately generous — inference can take a while on slow hardware.
+const MAX_PROOF_AGE_SECS: u64 = 120;
+
+/// Maximum clock skew tolerance in seconds (10 seconds into the future)
+const MAX_FUTURE_SECS: u64 = 10;
+
 /// Verification errors
 #[derive(Debug, Error)]
 pub enum VerificationError {
-    #[error("Epoch mismatch: expected {expected}, got {got}")]
-    EpochMismatch { expected: u64, got: u64 },
+    #[error("Proof expired: submitted at {submitted}, but current time is {now} ({age_secs}s old, max {max_age_secs}s)")]
+    ProofExpired {
+        submitted: u64,
+        now: u64,
+        age_secs: u64,
+        max_age_secs: u64,
+    },
+
+    #[error("Proof timestamp is in the future: {submitted} > {now} + {tolerance}s")]
+    ProofFromFuture {
+        submitted: u64,
+        now: u64,
+        tolerance: u64,
+    },
 
     #[error("Model not in approved registry: {0}")]
     UnapprovedModel(String),
@@ -38,23 +62,35 @@ pub struct VerificationResult {
 /// Spot-check percentage (5% of proofs are re-executed)
 const SPOT_CHECK_RATE: f64 = 0.05;
 
-/// Verify an inference proof (basic checks, no re-execution)
+/// Verify an inference proof (basic checks, no re-execution).
+///
+/// Uses timestamp-based validation instead of epoch matching:
+/// - Proof must not be older than MAX_PROOF_AGE_SECS (prevents replay)
+/// - Proof must not be from the future (prevents clock manipulation)
+/// - Epoch is NOT checked here — it's only used for reward attribution
 pub fn verify_basic(
     proof: &InferenceProof,
-    expected_epoch: u64,
+    now_secs: u64,
     approved_models: &qfc_inference::model::ModelRegistry,
 ) -> Result<VerificationResult, VerificationError> {
-    // 1. Check epoch matches (allow ±5 tolerance — inference tasks take time to complete)
-    let diff = if proof.epoch >= expected_epoch {
-        proof.epoch - expected_epoch
-    } else {
-        expected_epoch - proof.epoch
-    };
-    if diff > 5 {
-        return Err(VerificationError::EpochMismatch {
-            expected: expected_epoch,
-            got: proof.epoch,
+    // 1. Check proof timestamp freshness (replaces epoch check)
+    if proof.timestamp > now_secs + MAX_FUTURE_SECS {
+        return Err(VerificationError::ProofFromFuture {
+            submitted: proof.timestamp,
+            now: now_secs,
+            tolerance: MAX_FUTURE_SECS,
         });
+    }
+    if now_secs > proof.timestamp {
+        let age = now_secs - proof.timestamp;
+        if age > MAX_PROOF_AGE_SECS {
+            return Err(VerificationError::ProofExpired {
+                submitted: proof.timestamp,
+                now: now_secs,
+                age_secs: age,
+                max_age_secs: MAX_PROOF_AGE_SECS,
+            });
+        }
     }
 
     // 2. Verify model is approved
@@ -125,9 +161,17 @@ mod tests {
     use qfc_inference::{BackendType, ComputeTaskType, InferenceTask, ModelId};
     use qfc_types::Address;
 
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
     #[test]
     fn test_verify_basic_pass() {
         let registry = ModelRegistry::default_v2();
+        let now = now_secs();
         let proof = InferenceProof::new(
             Address::default(),
             1,
@@ -140,20 +184,23 @@ mod tests {
             150,
             1_000_000_000, // 1 GFLOPS — reasonable for embedding
             BackendType::Cpu,
-            1234567890,
+            now,
         );
 
-        let result = verify_basic(&proof, 1, &registry).unwrap();
+        let result = verify_basic(&proof, now, &registry).unwrap();
         assert!(result.passed);
         assert!(!result.spot_checked);
     }
 
     #[test]
-    fn test_verify_basic_wrong_epoch() {
+    fn test_verify_basic_expired_proof() {
         let registry = ModelRegistry::default_v2();
+        let now = now_secs();
+        let old_timestamp = now - 200; // 200 seconds ago, > MAX_PROOF_AGE_SECS (120)
+
         let proof = InferenceProof::new(
             Address::default(),
-            10, // wrong epoch (>5 difference from expected)
+            1,
             ComputeTaskType::Embedding {
                 model_id: ModelId::new("qfc-embed-small", "v1.0"),
                 input_hash: Hash::ZERO,
@@ -163,20 +210,19 @@ mod tests {
             150,
             1_000_000_000,
             BackendType::Cpu,
-            1234567890,
+            old_timestamp,
         );
 
-        // Epoch 10 vs expected 1 → diff > 5 → error
-        let result = verify_basic(&proof, 1, &registry);
+        let result = verify_basic(&proof, now, &registry);
         assert!(matches!(
             result,
-            Err(VerificationError::EpochMismatch { .. })
+            Err(VerificationError::ProofExpired { .. })
         ));
 
-        // Epoch 6 vs expected 1 → diff = 5 → OK (±5 tolerance)
-        let proof_close = InferenceProof::new(
+        // 60 seconds ago — within 120s window — should pass
+        let recent_proof = InferenceProof::new(
             Address::default(),
-            6,
+            1,
             ComputeTaskType::Embedding {
                 model_id: ModelId::new("qfc-embed-small", "v1.0"),
                 input_hash: Hash::ZERO,
@@ -186,15 +232,44 @@ mod tests {
             150,
             1_000_000_000,
             BackendType::Cpu,
-            1234567890,
+            now - 60,
         );
-        let result_close = verify_basic(&proof_close, 1, &registry);
-        assert!(result_close.is_ok());
+        let result_recent = verify_basic(&recent_proof, now, &registry);
+        assert!(result_recent.is_ok());
+    }
+
+    #[test]
+    fn test_verify_basic_future_proof() {
+        let registry = ModelRegistry::default_v2();
+        let now = now_secs();
+        let future_timestamp = now + 30; // 30 seconds in the future, > MAX_FUTURE_SECS (10)
+
+        let proof = InferenceProof::new(
+            Address::default(),
+            1,
+            ComputeTaskType::Embedding {
+                model_id: ModelId::new("qfc-embed-small", "v1.0"),
+                input_hash: Hash::ZERO,
+            },
+            Hash::ZERO,
+            Hash::new([0xab; 32]),
+            150,
+            1_000_000_000,
+            BackendType::Cpu,
+            future_timestamp,
+        );
+
+        let result = verify_basic(&proof, now, &registry);
+        assert!(matches!(
+            result,
+            Err(VerificationError::ProofFromFuture { .. })
+        ));
     }
 
     #[test]
     fn test_verify_basic_unapproved_model() {
         let registry = ModelRegistry::default_v2();
+        let now = now_secs();
         let proof = InferenceProof::new(
             Address::default(),
             1,
@@ -207,15 +282,16 @@ mod tests {
             150,
             1_000_000_000,
             BackendType::Cpu,
-            1234567890,
+            now,
         );
 
-        let result = verify_basic(&proof, 1, &registry);
+        let result = verify_basic(&proof, now, &registry);
         assert!(matches!(result, Err(VerificationError::UnapprovedModel(_))));
     }
 
     #[test]
     fn test_spot_check_determinism() {
+        let now = now_secs();
         // The same proof should always get the same spot-check decision
         let proof = InferenceProof::new(
             Address::default(),
@@ -229,7 +305,7 @@ mod tests {
             150,
             1_000_000_000,
             BackendType::Cpu,
-            1234567890,
+            now,
         );
 
         let decision1 = should_spot_check(&proof);
@@ -262,6 +338,7 @@ mod tests {
 
         // Run inference to get the correct output hash
         let result = engine.run_inference(&task).await.unwrap();
+        let now = now_secs();
 
         // Build a proof with the correct output hash
         let proof = InferenceProof::new(
@@ -276,7 +353,7 @@ mod tests {
             150,
             1_000_000_000,
             BackendType::Cpu,
-            1234567890,
+            now,
         );
 
         // Spot-check should pass
@@ -308,6 +385,8 @@ mod tests {
             1234597890,
         );
 
+        let now = now_secs();
+
         // Build a proof with a TAMPERED output hash
         let proof = InferenceProof::new(
             Address::default(),
@@ -321,7 +400,7 @@ mod tests {
             150,
             1_000_000_000,
             BackendType::Cpu,
-            1234567890,
+            now,
         );
 
         // Spot-check should detect mismatch

--- a/crates/qfc-ai-coordinator/tests/concurrent_test.rs
+++ b/crates/qfc-ai-coordinator/tests/concurrent_test.rs
@@ -512,7 +512,10 @@ async fn test_concurrent_spot_check_verification() {
     use qfc_inference::backend::cpu::CpuEngine;
     use qfc_inference::InferenceEngine;
 
-    let engine = Arc::new(CpuEngine::new());
+    let mut engine = CpuEngine::new();
+    let model_id = ModelId::new("qfc-embed-small", "v1.0");
+    engine.load_model(&model_id).await.unwrap();
+    let engine = Arc::new(engine);
 
     // Build a task
     let task = InferenceTask::new(

--- a/crates/qfc-miner/src/submit.rs
+++ b/crates/qfc-miner/src/submit.rs
@@ -396,6 +396,7 @@ pub async fn report_miner_status(
 }
 
 /// Epoch response from validator
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EpochResponse {
@@ -403,6 +404,7 @@ pub struct EpochResponse {
 }
 
 /// Fetch current epoch number from the validator
+#[allow(dead_code)]
 pub async fn fetch_epoch(rpc_url: &str) -> Result<u64, SubmitError> {
     let rpc_request = serde_json::json!({
         "jsonrpc": "2.0",
@@ -450,7 +452,10 @@ pub async fn fetch_epoch(rpc_url: &str) -> Result<u64, SubmitError> {
         .ok_or_else(|| SubmitError::SerializationError("No result in response".to_string()))?;
 
     // Parse hex epoch number (strip 0x prefix)
-    let hex_str = epoch_resp.number.strip_prefix("0x").unwrap_or(&epoch_resp.number);
+    let hex_str = epoch_resp
+        .number
+        .strip_prefix("0x")
+        .unwrap_or(&epoch_resp.number);
     u64::from_str_radix(hex_str, 16)
         .map_err(|e| SubmitError::SerializationError(format!("Invalid epoch hex: {}", e)))
 }

--- a/crates/qfc-miner/src/worker.rs
+++ b/crates/qfc-miner/src/worker.rs
@@ -88,17 +88,16 @@ impl InferenceWorker {
                 task_response.model_name
             );
 
-            // 2. Epoch staleness check — skip before wasting compute
-            if let Ok(current_epoch) = submit::fetch_epoch(&self.config.validator_rpc).await {
-                let diff = if task_response.epoch >= current_epoch {
-                    task_response.epoch - current_epoch
-                } else {
-                    current_epoch - task_response.epoch
-                };
-                if diff > 5 {
+            // 2. Deadline check — skip if task already expired
+            {
+                let now_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64;
+                if now_ms > task_response.deadline {
                     warn!(
-                        "Task epoch {} is stale (validator at {}), skipping",
-                        task_response.epoch, current_epoch
+                        "Task already past deadline (deadline: {}, now: {}), skipping",
+                        task_response.deadline, now_ms
                     );
                     continue;
                 }
@@ -210,27 +209,9 @@ impl InferenceWorker {
             let signature = keypair.sign_hash(&proof_hash);
             proof.set_signature(signature);
 
-            // 6. Post-inference epoch check — don't submit if epoch drifted during inference
+            // 6. Submit proof to validator
             let rpc_url = &self.config.validator_rpc;
             let miner_addr = hex::encode(self.config.wallet_address.as_bytes());
-
-            if let Ok(current_epoch) = submit::fetch_epoch(rpc_url).await {
-                let diff = if task_response.epoch >= current_epoch {
-                    task_response.epoch - current_epoch
-                } else {
-                    current_epoch - task_response.epoch
-                };
-                if diff > 5 {
-                    warn!(
-                        "Epoch drifted during inference: task epoch {} → validator epoch {} (skipping submit)",
-                        task_response.epoch, current_epoch
-                    );
-                    tasks_failed += 1;
-                    continue;
-                }
-            }
-
-            // 7. Submit proof to validator
             match submit::submit_proof(rpc_url, &miner_addr, &proof).await {
                 Ok(result) => {
                     tasks_completed += 1;

--- a/crates/qfc-node/src/miner.rs
+++ b/crates/qfc-node/src/miner.rs
@@ -296,7 +296,11 @@ impl MiningService {
             }
 
             // Verify locally before broadcasting
-            match qfc_ai_coordinator::verify_basic(&inf_proof, current_epoch, &model_registry) {
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            match qfc_ai_coordinator::verify_basic(&inf_proof, now_secs, &model_registry) {
                 Ok(_) => {
                     tasks_completed += 1;
 

--- a/crates/qfc-node/src/sync.rs
+++ b/crates/qfc-node/src/sync.rs
@@ -987,13 +987,13 @@ impl SyncManager {
             }
         };
 
-        // 5. Run basic verification (epoch, model, FLOPS)
-        // Advance epoch if expired before checking, so we use a fresh epoch number
-        let head_hash = self.chain.head().map(|h| h.hash).unwrap_or_default();
-        let epoch_number =
-            consensus.maybe_advance_epoch(qfc_types::EPOCH_DURATION_SECS * 1000, head_hash);
+        // 5. Run basic verification (timestamp freshness, model, FLOPS)
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         if let Err(e) =
-            qfc_ai_coordinator::verify_basic(&inference_proof, epoch_number, &self.model_registry)
+            qfc_ai_coordinator::verify_basic(&inference_proof, now_secs, &self.model_registry)
         {
             warn!(
                 "Inference proof from {} failed basic verification: {}",

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -1676,11 +1676,12 @@ impl QfcApiServer for RpcServer {
             });
         }
 
-        // 5. Basic verification (epoch, model, FLOPS)
-        let current_epoch = consensus.get_epoch();
-        if let Err(e) =
-            qfc_ai_coordinator::verify_basic(&proof, current_epoch.number, &self.model_registry)
-        {
+        // 5. Basic verification (timestamp freshness, model, FLOPS)
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if let Err(e) = qfc_ai_coordinator::verify_basic(&proof, now_secs, &self.model_registry) {
             warn!("Proof rejected from {}: {}", submission.miner_address, e);
             return Ok(RpcProofResult {
                 accepted: false,


### PR DESCRIPTION
## Summary

- **Replace epoch-based proof verification with timestamp-deadline model**, following Bittensor/Ritual/Gensyn patterns
- `verify_basic()` now checks proof timestamp freshness (max **120s** age) instead of epoch diff
- Miner uses task `deadline` field instead of epoch checks
- Epoch kept in proof for **reward attribution only**, no longer used for rejection
- Fixes periodic "epoch mismatch" rejections (testnet#4)

## Changes

| File | Change |
|------|--------|
| `qfc-ai-coordinator/verification.rs` | `EpochMismatch` → `ProofExpired` + `ProofFromFuture` (120s window, 10s future tolerance) |
| `qfc-rpc/server.rs` | Pass `now_secs` instead of `epoch_number` to `verify_basic` |
| `qfc-node/sync.rs` | Same |
| `qfc-node/miner.rs` | Same |
| `qfc-miner/worker.rs` | Replace epoch checks with task deadline checks |
| `qfc-ai-coordinator/tests/concurrent_test.rs` | Fix ModelNotLoaded in spot-check test |
| `qfc-ai-coordinator/benches/verification_bench.rs` | Updated for new API |

## Design rationale

No major AI blockchain uses global epoch to gate individual inference results:
- **Bittensor**: per-request timeout (12s default), epoch only for reward distribution
- **Ritual**: subscription interval windows
- **Gensyn**: task-scoped checkpoint commits
- Replay prevention via signature + timestamp freshness, not epoch numbers

## Test plan

- [x] All unit tests pass (82 tests across qfc-ai-coordinator)
- [x] Full workspace lib tests pass
- [ ] Deploy to staging testnet and verify no more "epoch mismatch" rejections
- [ ] Verify proofs older than 120s are properly rejected (replay protection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)