### PR TITLE
feat: Qwen2.5-0.5B text generation for inference mining

### DIFF
--- a/crates/qfc-ai-coordinator/src/task_types.rs
+++ b/crates/qfc-ai-coordinator/src/task_types.rs
@@ -28,12 +28,13 @@ pub fn task_requirements(task_type: &ComputeTaskType) -> TaskRequirements {
             ..
         } => {
             let (tier, memory) = model_tier_and_memory(&model_id.name);
+            let params = estimate_model_params(&model_id.name);
             TaskRequirements {
                 min_tier: tier,
                 min_memory_mb: memory,
                 model_id: Some(model_id.clone()),
-                estimated_flops: 2 * 7_000_000_000u64 * (*max_tokens as u64),
-                timeout_ms: 30_000,
+                estimated_flops: 2 * params * (*max_tokens as u64),
+                timeout_ms: if params < 1_000_000_000 { 60_000 } else { 120_000 },
             }
         }
         ComputeTaskType::ImageClassification { model_id, .. } => TaskRequirements {
@@ -70,8 +71,29 @@ fn model_tier_and_memory(model_name: &str) -> (GpuTier, u64) {
         (GpuTier::Warm, 6_000)
     } else if model_name.contains("3b") || model_name.contains("3B") {
         (GpuTier::Cold, 3_000)
+    } else if model_name.contains("0.5b") || model_name.contains("0.5B") {
+        (GpuTier::Cold, 1_024)
     } else {
         (GpuTier::Cold, 2_000)
+    }
+}
+
+/// Estimate model parameter count from name
+fn estimate_model_params(model_name: &str) -> u64 {
+    if model_name.contains("70b") || model_name.contains("70B") {
+        70_000_000_000
+    } else if model_name.contains("13b") || model_name.contains("13B") {
+        13_000_000_000
+    } else if model_name.contains("7b") || model_name.contains("7B") {
+        7_000_000_000
+    } else if model_name.contains("3b") || model_name.contains("3B") {
+        3_000_000_000
+    } else if model_name.contains("1b") || model_name.contains("1B") {
+        1_000_000_000
+    } else if model_name.contains("0.5b") || model_name.contains("0.5B") {
+        500_000_000
+    } else {
+        7_000_000_000 // default
     }
 }
 
@@ -153,17 +175,29 @@ mod tests {
         // 1 GFLOP * 1e12 * 1x (Cold) = 1e12, but min is 1e14
         assert_eq!(fee, 100_000_000_000_000); // minimum 0.0001 QFC
 
-        let text_gen = ComputeTaskType::TextGeneration {
+        let text_gen_7b = ComputeTaskType::TextGeneration {
             model_id: ModelId::new("llama-7b", "v1"),
             prompt_hash: Hash::ZERO,
             max_tokens: 100,
             temperature_fp: 0,
             seed: 42,
         };
-        let fee = estimate_base_fee(&text_gen);
+        let fee = estimate_base_fee(&text_gen_7b);
         // 2 * 7B * 100 tokens = 1.4T FLOPS = 1400 GFLOPS
         // 1400 * 1e12 * 1.5 (Warm) = 2.1e15
         assert!(fee > 1_000_000_000_000_000); // > 0.001 QFC
+
+        let text_gen_0_5b = ComputeTaskType::TextGeneration {
+            model_id: ModelId::new("qfc-llm-0.5b", "v1.0"),
+            prompt_hash: Hash::ZERO,
+            max_tokens: 64,
+            temperature_fp: 0,
+            seed: 42,
+        };
+        let fee = estimate_base_fee(&text_gen_0_5b);
+        // 2 * 500M * 64 = 64G FLOPS = 64 GFLOPS
+        // 64 * 1e12 * 1x (Cold) = 6.4e13, but min is 1e14
+        assert_eq!(fee, 100_000_000_000_000); // minimum 0.0001 QFC
     }
 
     #[test]

--- a/crates/qfc-inference/src/backend/cpu.rs
+++ b/crates/qfc-inference/src/backend/cpu.rs
@@ -18,9 +18,12 @@ pub struct CpuEngine {
     loaded_models: Vec<ModelId>,
     /// Available system memory in MB
     available_memory_mb: u64,
-    /// Loaded candle models (when candle feature enabled)
+    /// Loaded candle models for embedding/classification (when candle feature enabled)
     #[cfg(feature = "candle")]
     candle_models: HashMap<String, Box<dyn LoadedModel>>,
+    /// Loaded Qwen2 models for text generation (needs &mut self for KV cache)
+    #[cfg(feature = "candle")]
+    qwen_models: HashMap<String, std::sync::Mutex<crate::models::qwen2::Qwen2TextGen>>,
     #[cfg(not(feature = "candle"))]
     _models: HashMap<String, ()>,
 }
@@ -33,6 +36,8 @@ impl CpuEngine {
             available_memory_mb: mem,
             #[cfg(feature = "candle")]
             candle_models: HashMap::new(),
+            #[cfg(feature = "candle")]
+            qwen_models: HashMap::new(),
             #[cfg(not(feature = "candle"))]
             _models: HashMap::new(),
         }
@@ -63,7 +68,6 @@ impl InferenceEngine for CpuEngine {
         #[cfg(feature = "candle")]
         {
             use crate::download::download_model;
-            use crate::models::bert::BertEmbedding;
             use candle_core::Device;
 
             tracing::info!("Loading model {} on CPU backend (candle)", model_id);
@@ -71,14 +75,28 @@ impl InferenceEngine for CpuEngine {
             let downloaded = download_model(&model_id.name)?;
             let device = Device::Cpu;
 
-            let loaded: Box<dyn LoadedModel> = Box::new(BertEmbedding::load(
-                &downloaded.weights_path,
-                &downloaded.tokenizer_path,
-                &downloaded.config_path,
-                &device,
-            )?);
+            if is_text_gen_model(&model_id.name) {
+                // Load as Qwen2 text generation model
+                let qwen = crate::models::qwen2::Qwen2TextGen::load(
+                    &downloaded.weights_path,
+                    &downloaded.tokenizer_path,
+                    &downloaded.config_path,
+                    &device,
+                )?;
+                self.qwen_models
+                    .insert(model_id.name.clone(), std::sync::Mutex::new(qwen));
+            } else {
+                // Load as BERT embedding/classification model
+                let loaded: Box<dyn LoadedModel> =
+                    Box::new(crate::models::bert::BertEmbedding::load(
+                        &downloaded.weights_path,
+                        &downloaded.tokenizer_path,
+                        &downloaded.config_path,
+                        &device,
+                    )?);
+                self.candle_models.insert(model_id.name.clone(), loaded);
+            }
 
-            self.candle_models.insert(model_id.name.clone(), loaded);
             self.loaded_models.push(model_id.clone());
             tracing::info!("Model {} loaded successfully on CPU", model_id);
         }
@@ -100,15 +118,37 @@ impl InferenceEngine for CpuEngine {
 
         #[cfg(feature = "candle")]
         let output = {
-            // Try to use loaded candle model
-            if let Some(model_name) = task.task_type.model_id().map(|m| &m.name) {
-                if let Some(model) = self.candle_models.get(model_name.as_str()) {
-                    model.forward(&task.input_data)?
-                } else {
-                    return Err(InferenceError::ModelNotLoaded(model_name.clone()));
+            match &task.task_type {
+                ComputeTaskType::TextGeneration {
+                    model_id,
+                    max_tokens,
+                    ..
+                } => {
+                    // Use Qwen2 text generation model
+                    if let Some(model_mutex) = self.qwen_models.get(model_id.name.as_str()) {
+                        let mut model = model_mutex.lock().map_err(|e| {
+                            InferenceError::ExecutionFailed(format!("Model lock failed: {}", e))
+                        })?;
+                        let prompt = std::str::from_utf8(&task.input_data).map_err(|e| {
+                            InferenceError::ExecutionFailed(format!("Invalid UTF-8 input: {}", e))
+                        })?;
+                        model.generate(prompt, *max_tokens)?
+                    } else {
+                        return Err(InferenceError::ModelNotLoaded(model_id.name.clone()));
+                    }
                 }
-            } else {
-                compute_deterministic_output(task)
+                _ => {
+                    // Embedding / classification — use LoadedModel trait
+                    if let Some(model_name) = task.task_type.model_id().map(|m| &m.name) {
+                        if let Some(model) = self.candle_models.get(model_name.as_str()) {
+                            model.forward(&task.input_data)?
+                        } else {
+                            return Err(InferenceError::ModelNotLoaded(model_name.clone()));
+                        }
+                    } else {
+                        compute_deterministic_output(task)
+                    }
+                }
             }
         };
 
@@ -157,6 +197,12 @@ impl InferenceEngine for CpuEngine {
     }
 }
 
+/// Check if a model name refers to a text generation (LLM) model
+#[cfg(feature = "candle")]
+fn is_text_gen_model(model_name: &str) -> bool {
+    model_name.starts_with("qfc-llm-")
+}
+
 /// Deterministic placeholder output (used by all backends during development)
 pub fn deterministic_placeholder(task: &InferenceTask) -> Vec<u8> {
     compute_deterministic_output(task)
@@ -191,8 +237,20 @@ fn compute_deterministic_output(task: &InferenceTask) -> Vec<u8> {
 /// Estimate FLOPS for a task based on type and execution time
 fn estimate_flops(task_type: &ComputeTaskType, _elapsed_ms: u64) -> u64 {
     match task_type {
-        ComputeTaskType::TextGeneration { max_tokens, .. } => {
-            2 * 7_000_000_000u64 * (*max_tokens as u64)
+        ComputeTaskType::TextGeneration {
+            model_id,
+            max_tokens,
+            ..
+        } => {
+            // Approximate FLOPS: 2 * params * tokens
+            let params = if model_id.name.contains("0.5b") || model_id.name.contains("0.5B") {
+                500_000_000u64
+            } else if model_id.name.contains("1b") || model_id.name.contains("1B") {
+                1_000_000_000u64
+            } else {
+                7_000_000_000u64
+            };
+            2 * params * (*max_tokens as u64)
         }
         ComputeTaskType::ImageClassification { .. } => 4_000_000_000u64,
         ComputeTaskType::Embedding { .. } => 1_000_000_000u64,

--- a/crates/qfc-inference/src/download.rs
+++ b/crates/qfc-inference/src/download.rs
@@ -44,6 +44,12 @@ pub fn get_hf_repo(model_name: &str) -> Option<HfModelRepo> {
             tokenizer_file: "tokenizer.json",
             config_file: "config.json",
         }),
+        "qfc-llm-0.5b" => Some(HfModelRepo {
+            repo_id: "Qwen/Qwen2.5-0.5B-Instruct",
+            weights_file: "model.safetensors",
+            tokenizer_file: "tokenizer.json",
+            config_file: "config.json",
+        }),
         _ => None,
     }
 }

--- a/crates/qfc-inference/src/model.rs
+++ b/crates/qfc-inference/src/model.rs
@@ -231,6 +231,16 @@ impl ModelRegistry {
                 size_mb: 440,
                 approved: true,
             },
+            ModelInfo {
+                id: ModelId::new("qfc-llm-0.5b", "v1.0"),
+                description:
+                    "Qwen2.5-0.5B-Instruct text generation model for Cold tier (CPU-friendly)"
+                        .to_string(),
+                min_memory_mb: 1024,
+                min_tier: GpuTier::Cold,
+                size_mb: 990,
+                approved: true,
+            },
         ];
 
         Self { models }
@@ -347,13 +357,13 @@ mod tests {
         let unknown = ModelId::new("unknown-model", "v1.0");
         assert!(!registry.is_approved(&unknown));
 
-        // Cold tier can run small and medium embedding models
+        // Cold tier can run small/medium embedding + Qwen 0.5B
         let cold_models = registry.models_for_tier(GpuTier::Cold);
-        assert_eq!(cold_models.len(), 2);
+        assert_eq!(cold_models.len(), 3);
 
         // Hot tier can run all models
         let hot_models = registry.models_for_tier(GpuTier::Hot);
-        assert_eq!(hot_models.len(), 3);
+        assert_eq!(hot_models.len(), 4);
     }
 
     #[test]

--- a/crates/qfc-inference/src/models/mod.rs
+++ b/crates/qfc-inference/src/models/mod.rs
@@ -6,9 +6,12 @@
 pub mod bert;
 
 #[cfg(feature = "candle")]
+pub mod qwen2;
+
+#[cfg(feature = "candle")]
 use crate::InferenceError;
 
-/// A loaded model ready for inference
+/// A loaded model ready for inference (embedding / classification)
 #[cfg(feature = "candle")]
 pub trait LoadedModel: Send + Sync {
     /// Run inference on raw input bytes, returning output bytes

--- a/crates/qfc-inference/src/models/qwen2.rs
+++ b/crates/qfc-inference/src/models/qwen2.rs
@@ -1,0 +1,205 @@
+//! Qwen2 text generation model using candle
+//!
+//! Supports Qwen2.5-0.5B for deterministic text generation.
+//! Uses greedy decoding (argmax) when temperature=0 to ensure
+//! reproducible outputs for proof verification (spot-check).
+
+use std::path::Path;
+
+use candle_core::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::qwen2::{Config as Qwen2Config, ModelForCausalLM};
+use tokenizers::Tokenizer;
+
+use crate::InferenceError;
+
+/// Qwen2-based text generation model
+pub struct Qwen2TextGen {
+    model: ModelForCausalLM,
+    tokenizer: Tokenizer,
+    device: Device,
+    /// EOS token ID for stopping generation
+    eos_token_id: u32,
+}
+
+impl Qwen2TextGen {
+    /// Load a Qwen2 model from downloaded files
+    pub fn load(
+        weights_path: &Path,
+        tokenizer_path: &Path,
+        config_path: &Path,
+        device: &Device,
+    ) -> Result<Self, InferenceError> {
+        // Load config
+        let config_str = std::fs::read_to_string(config_path).map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Failed to read config: {}", e))
+        })?;
+        let config: Qwen2Config = serde_json::from_str(&config_str).map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Failed to parse Qwen2 config: {}", e))
+        })?;
+
+        // Load tokenizer
+        let tokenizer = Tokenizer::from_file(tokenizer_path).map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Failed to load tokenizer: {}", e))
+        })?;
+
+        // Determine EOS token ID
+        let eos_token_id = tokenizer
+            .token_to_id("<|endoftext|>")
+            .or_else(|| tokenizer.token_to_id("<|im_end|>"))
+            .unwrap_or(151643); // Qwen2 default EOS
+
+        // Load model weights
+        let dtype = if device.is_cpu() {
+            DType::F32
+        } else {
+            DType::F16
+        };
+
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&[weights_path], dtype, device).map_err(|e| {
+                InferenceError::ExecutionFailed(format!("Failed to load model weights: {}", e))
+            })?
+        };
+
+        let model = ModelForCausalLM::new(&config, vb).map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Failed to build Qwen2 model: {}", e))
+        })?;
+
+        tracing::info!(
+            "Qwen2 model loaded (hidden_size={}, layers={}, device={:?})",
+            config.hidden_size,
+            config.num_hidden_layers,
+            device
+        );
+
+        Ok(Self {
+            model,
+            tokenizer,
+            device: device.clone(),
+            eos_token_id,
+        })
+    }
+
+    /// Generate text from a prompt using greedy decoding (deterministic).
+    ///
+    /// Returns generated token bytes (UTF-8 encoded text).
+    /// Temperature must be 0 for deterministic output suitable for spot-check.
+    pub fn generate(
+        &mut self,
+        prompt: &str,
+        max_tokens: u32,
+    ) -> Result<Vec<u8>, InferenceError> {
+        // Tokenize prompt
+        let encoding = self.tokenizer.encode(prompt, true).map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Tokenization failed: {}", e))
+        })?;
+
+        let prompt_tokens = encoding.get_ids().to_vec();
+        let prompt_len = prompt_tokens.len();
+
+        // Create input tensor
+        let mut tokens = prompt_tokens;
+        let mut generated_tokens: Vec<u32> = Vec::new();
+
+        // Clear KV cache for fresh generation
+        self.model.clear_kv_cache();
+
+        // Process prompt (prefill)
+        let input = Tensor::new(tokens.as_slice(), &self.device)
+            .map_err(|e| InferenceError::ExecutionFailed(format!("Tensor error: {}", e)))?
+            .unsqueeze(0)
+            .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?;
+
+        let logits = self
+            .model
+            .forward(&input, 0)
+            .map_err(|e| InferenceError::ExecutionFailed(format!("Forward pass failed: {}", e)))?;
+
+        // Greedy: pick argmax of last token logits
+        let next_token = logits
+            .squeeze(0)
+            .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+            .squeeze(0)
+            .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+            .argmax(0)
+            .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+            .to_scalar::<u32>()
+            .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?;
+
+        if next_token == self.eos_token_id {
+            return Ok(Vec::new());
+        }
+        generated_tokens.push(next_token);
+        tokens.push(next_token);
+
+        // Autoregressive decoding
+        for _ in 1..max_tokens {
+            let input = Tensor::new(&[*tokens.last().unwrap()], &self.device)
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+                .unsqueeze(0)
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?;
+
+            let seqlen_offset = tokens.len() - 1;
+            let logits = self
+                .model
+                .forward(&input, seqlen_offset)
+                .map_err(|e| {
+                    InferenceError::ExecutionFailed(format!("Decode step failed: {}", e))
+                })?;
+
+            let next_token = logits
+                .squeeze(0)
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+                .squeeze(0)
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+                .argmax(0)
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+                .to_scalar::<u32>()
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?;
+
+            if next_token == self.eos_token_id {
+                break;
+            }
+
+            generated_tokens.push(next_token);
+            tokens.push(next_token);
+        }
+
+        // Decode generated tokens to text
+        let text = self
+            .tokenizer
+            .decode(&generated_tokens, true)
+            .map_err(|e| InferenceError::ExecutionFailed(format!("Detokenize failed: {}", e)))?;
+
+        Ok(text.into_bytes())
+    }
+}
+
+/// Implement LoadedModel for Qwen2 (text generation mode)
+///
+/// `forward()` interprets the input as:
+///   - First 4 bytes (u32 LE): max_tokens
+///   - Remaining bytes: UTF-8 prompt text
+impl super::LoadedModel for Qwen2TextGen {
+    fn forward(&self, input: &[u8]) -> Result<Vec<u8>, InferenceError> {
+        // We need &mut self for KV cache, so this trait method can't work
+        // directly. Text generation uses generate() via the engine instead.
+        Err(InferenceError::ExecutionFailed(
+            "Use generate() for text generation tasks".to_string(),
+        ))
+    }
+
+    fn embedding_dim(&self) -> usize {
+        0 // Not an embedding model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_qwen2_type_compiles() {
+        // Verify the types compile correctly without needing model download
+        assert!(std::mem::size_of::<super::Qwen2TextGen>() > 0);
+    }
+}

--- a/crates/qfc-inference/src/task.rs
+++ b/crates/qfc-inference/src/task.rs
@@ -157,6 +157,8 @@ fn estimate_model_memory(model_name: &str) -> u64 {
         3_000
     } else if model_name.contains("1b") || model_name.contains("1B") {
         2_000
+    } else if model_name.contains("0.5b") || model_name.contains("0.5B") {
+        1_024
     } else {
         4_000 // default estimate
     }


### PR DESCRIPTION
## Summary

- Adds **Qwen2.5-0.5B-Instruct** as the first text generation model for inference mining (`qfc-llm-0.5b`)
- ~990MB model, runs on CPU (Cold tier) — lowest barrier for miners to participate in LLM tasks
- Uses candle-transformers' built-in `qwen2::ModelForCausalLM` with greedy decoding (temperature=0) for deterministic, spot-check verifiable outputs
- `ComputeTaskType::TextGeneration` was already defined but had no backend — this implements it

## Changes

| File | Change |
|------|--------|
| `models/qwen2.rs` | New: Qwen2 model loading, tokenization, autoregressive generation with KV-cache |
| `backend/cpu.rs` | Support `TextGeneration` tasks via `Mutex<Qwen2TextGen>`, model type routing |
| `download.rs` | Add `qfc-llm-0.5b` → `Qwen/Qwen2.5-0.5B-Instruct` HuggingFace mapping |
| `model.rs` | Register `qfc-llm-0.5b` in `ModelRegistry::default_v2()` |
| `task_types.rs` | 0.5B tier/memory/FLOPS estimation, `estimate_model_params()` helper |
| `task.rs` | 0.5B memory estimation (1024MB) |

## Test plan

- [x] All unit tests pass (qfc-inference: 32, qfc-ai-coordinator: all pass)
- [x] Full workspace build succeeds
- [ ] Test with `candle` feature: `cargo test -p qfc-inference --features candle` (downloads model ~990MB)
- [ ] Test on miner: load `qfc-llm-0.5b` and run TextGeneration task
- [ ] Verify determinism: same prompt + seed → same output hash (spot-check requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)