### PR TITLE
feat: GGUF quantized model loading infrastructure

### DIFF
--- a/crates/qfc-ai-coordinator/src/task_types.rs
+++ b/crates/qfc-ai-coordinator/src/task_types.rs
@@ -36,8 +36,10 @@ pub fn task_requirements(task_type: &ComputeTaskType) -> TaskRequirements {
                 estimated_flops: 2 * params * (*max_tokens as u64),
                 timeout_ms: if params < 1_000_000_000 {
                     60_000
-                } else {
+                } else if params <= 3_000_000_000 {
                     120_000
+                } else {
+                    180_000
                 },
             }
         }
@@ -74,7 +76,7 @@ fn model_tier_and_memory(model_name: &str) -> (GpuTier, u64) {
     } else if model_name.contains("7b") || model_name.contains("7B") {
         (GpuTier::Warm, 6_000)
     } else if model_name.contains("3b") || model_name.contains("3B") {
-        (GpuTier::Cold, 3_000)
+        (GpuTier::Warm, 4_096)
     } else if model_name.contains("0.5b") || model_name.contains("0.5B") {
         (GpuTier::Cold, 1_024)
     } else {

--- a/crates/qfc-inference/src/backend/cpu.rs
+++ b/crates/qfc-inference/src/backend/cpu.rs
@@ -24,6 +24,10 @@ pub struct CpuEngine {
     /// Loaded Qwen2 models for text generation (needs &mut self for KV cache)
     #[cfg(feature = "candle")]
     qwen_models: HashMap<String, std::sync::Mutex<crate::models::qwen2::Qwen2TextGen>>,
+    /// Loaded quantized Qwen2 models (GGUF format)
+    #[cfg(feature = "candle")]
+    quantized_models:
+        HashMap<String, std::sync::Mutex<crate::models::quantized_qwen2::QuantizedQwen2TextGen>>,
     #[cfg(not(feature = "candle"))]
     _models: HashMap<String, ()>,
 }
@@ -38,6 +42,8 @@ impl CpuEngine {
             candle_models: HashMap::new(),
             #[cfg(feature = "candle")]
             qwen_models: HashMap::new(),
+            #[cfg(feature = "candle")]
+            quantized_models: HashMap::new(),
             #[cfg(not(feature = "candle"))]
             _models: HashMap::new(),
         }
@@ -67,7 +73,7 @@ impl InferenceEngine for CpuEngine {
     async fn load_model(&mut self, model_id: &ModelId) -> Result<(), InferenceError> {
         #[cfg(feature = "candle")]
         {
-            use crate::download::download_model;
+            use crate::download::{download_model, get_hf_repo, ModelFormat};
             use candle_core::Device;
 
             tracing::info!("Loading model {} on CPU backend (candle)", model_id);
@@ -75,16 +81,35 @@ impl InferenceEngine for CpuEngine {
             let downloaded = download_model(&model_id.name)?;
             let device = Device::Cpu;
 
+            // Determine model format from registry
+            let format = get_hf_repo(&model_id.name)
+                .map(|r| r.format)
+                .unwrap_or(ModelFormat::Safetensors);
+
             if is_text_gen_model(&model_id.name) {
-                // Load as Qwen2 text generation model
-                let qwen = crate::models::qwen2::Qwen2TextGen::load(
-                    &downloaded.weights_path,
-                    &downloaded.tokenizer_path,
-                    &downloaded.config_path,
-                    &device,
-                )?;
-                self.qwen_models
-                    .insert(model_id.name.clone(), std::sync::Mutex::new(qwen));
+                match format {
+                    ModelFormat::Gguf => {
+                        // Load as quantized GGUF model
+                        let qmodel = crate::models::quantized_qwen2::QuantizedQwen2TextGen::load(
+                            &downloaded.weights_path,
+                            &downloaded.tokenizer_path,
+                            &device,
+                        )?;
+                        self.quantized_models
+                            .insert(model_id.name.clone(), std::sync::Mutex::new(qmodel));
+                    }
+                    ModelFormat::Safetensors => {
+                        // Load as Qwen2 FP32 text generation model
+                        let qwen = crate::models::qwen2::Qwen2TextGen::load(
+                            &downloaded.weights_path,
+                            &downloaded.tokenizer_path,
+                            &downloaded.config_path,
+                            &device,
+                        )?;
+                        self.qwen_models
+                            .insert(model_id.name.clone(), std::sync::Mutex::new(qwen));
+                    }
+                }
             } else {
                 // Load as BERT embedding/classification model
                 let loaded: Box<dyn LoadedModel> =
@@ -124,13 +149,19 @@ impl InferenceEngine for CpuEngine {
                     max_tokens,
                     ..
                 } => {
-                    // Use Qwen2 text generation model
-                    if let Some(model_mutex) = self.qwen_models.get(model_id.name.as_str()) {
+                    let prompt = std::str::from_utf8(&task.input_data).map_err(|e| {
+                        InferenceError::ExecutionFailed(format!("Invalid UTF-8 input: {}", e))
+                    })?;
+
+                    // Try quantized (GGUF) models first, then FP32 models
+                    if let Some(model_mutex) = self.quantized_models.get(model_id.name.as_str()) {
                         let mut model = model_mutex.lock().map_err(|e| {
                             InferenceError::ExecutionFailed(format!("Model lock failed: {}", e))
                         })?;
-                        let prompt = std::str::from_utf8(&task.input_data).map_err(|e| {
-                            InferenceError::ExecutionFailed(format!("Invalid UTF-8 input: {}", e))
+                        model.generate(prompt, *max_tokens)?
+                    } else if let Some(model_mutex) = self.qwen_models.get(model_id.name.as_str()) {
+                        let mut model = model_mutex.lock().map_err(|e| {
+                            InferenceError::ExecutionFailed(format!("Model lock failed: {}", e))
                         })?;
                         model.generate(prompt, *max_tokens)?
                     } else {
@@ -247,6 +278,10 @@ fn estimate_flops(task_type: &ComputeTaskType, _elapsed_ms: u64) -> u64 {
                 500_000_000u64
             } else if model_id.name.contains("1b") || model_id.name.contains("1B") {
                 1_000_000_000u64
+            } else if model_id.name.contains("3b") || model_id.name.contains("3B") {
+                3_000_000_000u64
+            } else if model_id.name.contains("7b") || model_id.name.contains("7B") {
+                7_000_000_000u64
             } else {
                 7_000_000_000u64
             };

--- a/crates/qfc-inference/src/download.rs
+++ b/crates/qfc-inference/src/download.rs
@@ -9,6 +9,16 @@ use std::path::PathBuf;
 #[cfg(feature = "candle")]
 use crate::InferenceError;
 
+/// Model format (safetensors vs GGUF quantized)
+#[cfg(feature = "candle")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ModelFormat {
+    /// Standard safetensors format (FP32/FP16)
+    Safetensors,
+    /// GGUF quantized format (Q4_K_M, Q5_K_M, etc.)
+    Gguf,
+}
+
 /// HuggingFace repo IDs for approved QFC benchmark models
 #[cfg(feature = "candle")]
 pub struct HfModelRepo {
@@ -20,6 +30,11 @@ pub struct HfModelRepo {
     pub tokenizer_file: &'static str,
     /// Config file name
     pub config_file: &'static str,
+    /// Model format
+    pub format: ModelFormat,
+    /// Tokenizer repo ID (if different from weights repo, e.g. GGUF models
+    /// use a separate repo for the GGUF file but tokenizer comes from the base repo)
+    pub tokenizer_repo_id: Option<&'static str>,
 }
 
 /// Get HuggingFace repo info for a QFC model name
@@ -31,24 +46,48 @@ pub fn get_hf_repo(model_name: &str) -> Option<HfModelRepo> {
             weights_file: "model.safetensors",
             tokenizer_file: "tokenizer.json",
             config_file: "config.json",
+            format: ModelFormat::Safetensors,
+            tokenizer_repo_id: None,
         }),
         "qfc-embed-medium" => Some(HfModelRepo {
             repo_id: "sentence-transformers/all-MiniLM-L12-v2",
             weights_file: "model.safetensors",
             tokenizer_file: "tokenizer.json",
             config_file: "config.json",
+            format: ModelFormat::Safetensors,
+            tokenizer_repo_id: None,
         }),
         "qfc-classify-small" => Some(HfModelRepo {
             repo_id: "google-bert/bert-base-uncased",
             weights_file: "model.safetensors",
             tokenizer_file: "tokenizer.json",
             config_file: "config.json",
+            format: ModelFormat::Safetensors,
+            tokenizer_repo_id: None,
         }),
         "qfc-llm-0.5b" => Some(HfModelRepo {
             repo_id: "Qwen/Qwen2.5-0.5B-Instruct",
             weights_file: "model.safetensors",
             tokenizer_file: "tokenizer.json",
             config_file: "config.json",
+            format: ModelFormat::Safetensors,
+            tokenizer_repo_id: None,
+        }),
+        "qfc-llm-3b" => Some(HfModelRepo {
+            repo_id: "Qwen/Qwen2.5-3B-Instruct-GGUF",
+            weights_file: "qwen2.5-3b-instruct-q4_k_m.gguf",
+            tokenizer_file: "tokenizer.json",
+            config_file: "config.json",
+            format: ModelFormat::Gguf,
+            tokenizer_repo_id: Some("Qwen/Qwen2.5-3B-Instruct"),
+        }),
+        "qfc-llm-7b" => Some(HfModelRepo {
+            repo_id: "Qwen/Qwen2.5-7B-Instruct-GGUF",
+            weights_file: "qwen2.5-7b-instruct-q4_k_m.gguf",
+            tokenizer_file: "tokenizer.json",
+            config_file: "config.json",
+            format: ModelFormat::Gguf,
+            tokenizer_repo_id: Some("Qwen/Qwen2.5-7B-Instruct"),
         }),
         _ => None,
     }
@@ -143,14 +182,25 @@ pub fn download_model(model_name: &str) -> Result<DownloadedModel, InferenceErro
         .join(".cache/qfc-models")
         .join(model_name);
 
+    // Download weights from the primary repo
     let weights_path = download_file(&repo, repo_info.repo_id, repo_info.weights_file, &cache_dir)?;
-    let tokenizer_path = download_file(
-        &repo,
-        repo_info.repo_id,
-        repo_info.tokenizer_file,
-        &cache_dir,
-    )?;
-    let config_path = download_file(&repo, repo_info.repo_id, repo_info.config_file, &cache_dir)?;
+
+    // For GGUF models, tokenizer and config come from the base (non-GGUF) repo
+    let (tokenizer_path, config_path) = if let Some(tok_repo_id) = repo_info.tokenizer_repo_id {
+        let tok_repo = api.model(tok_repo_id.to_string());
+        let tp = download_file(&tok_repo, tok_repo_id, repo_info.tokenizer_file, &cache_dir)?;
+        let cp = download_file(&tok_repo, tok_repo_id, repo_info.config_file, &cache_dir)?;
+        (tp, cp)
+    } else {
+        let tp = download_file(
+            &repo,
+            repo_info.repo_id,
+            repo_info.tokenizer_file,
+            &cache_dir,
+        )?;
+        let cp = download_file(&repo, repo_info.repo_id, repo_info.config_file, &cache_dir)?;
+        (tp, cp)
+    };
 
     tracing::info!("Model {} downloaded successfully", model_name);
 

--- a/crates/qfc-inference/src/model.rs
+++ b/crates/qfc-inference/src/model.rs
@@ -241,6 +241,26 @@ impl ModelRegistry {
                 size_mb: 990,
                 approved: true,
             },
+            ModelInfo {
+                id: ModelId::new("qfc-llm-3b", "v1.0"),
+                description:
+                    "Qwen2.5-3B-Instruct-GGUF (Q4_K_M) quantized text generation for Warm tier"
+                        .to_string(),
+                min_memory_mb: 4096,
+                min_tier: GpuTier::Warm,
+                size_mb: 2200,
+                approved: true,
+            },
+            ModelInfo {
+                id: ModelId::new("qfc-llm-7b", "v1.0"),
+                description:
+                    "Qwen2.5-7B-Instruct-GGUF (Q4_K_M) quantized text generation for Hot tier"
+                        .to_string(),
+                min_memory_mb: 8192,
+                min_tier: GpuTier::Hot,
+                size_mb: 4700,
+                approved: true,
+            },
         ];
 
         Self { models }
@@ -361,9 +381,13 @@ mod tests {
         let cold_models = registry.models_for_tier(GpuTier::Cold);
         assert_eq!(cold_models.len(), 3);
 
+        // Warm tier can run Cold models + 3B
+        let warm_models = registry.models_for_tier(GpuTier::Warm);
+        assert_eq!(warm_models.len(), 5);
+
         // Hot tier can run all models
         let hot_models = registry.models_for_tier(GpuTier::Hot);
-        assert_eq!(hot_models.len(), 4);
+        assert_eq!(hot_models.len(), 6);
     }
 
     #[test]

--- a/crates/qfc-inference/src/models/mod.rs
+++ b/crates/qfc-inference/src/models/mod.rs
@@ -9,6 +9,9 @@ pub mod bert;
 pub mod qwen2;
 
 #[cfg(feature = "candle")]
+pub mod quantized_qwen2;
+
+#[cfg(feature = "candle")]
 use crate::InferenceError;
 
 /// A loaded model ready for inference (embedding / classification)

--- a/crates/qfc-inference/src/models/quantized_qwen2.rs
+++ b/crates/qfc-inference/src/models/quantized_qwen2.rs
@@ -1,0 +1,153 @@
+//! Quantized Qwen2 text generation model using GGUF format
+//!
+//! Supports Q4_K_M and other GGUF quantization formats for running
+//! larger models (3B, 7B) on consumer hardware with reduced VRAM.
+//! Uses greedy decoding (argmax) for deterministic, verifiable output.
+
+use std::path::Path;
+
+use candle_core::{Device, Tensor};
+use candle_transformers::models::quantized_qwen2::ModelWeights;
+use tokenizers::Tokenizer;
+
+use crate::InferenceError;
+
+/// Quantized Qwen2 text generation model (GGUF format)
+pub struct QuantizedQwen2TextGen {
+    model: ModelWeights,
+    tokenizer: Tokenizer,
+    device: Device,
+    eos_token_id: u32,
+}
+
+impl QuantizedQwen2TextGen {
+    /// Load a quantized Qwen2 model from a GGUF file + tokenizer
+    pub fn load(
+        gguf_path: &Path,
+        tokenizer_path: &Path,
+        device: &Device,
+    ) -> Result<Self, InferenceError> {
+        // Load GGUF model
+        let mut file = std::fs::File::open(gguf_path).map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Failed to open GGUF file: {}", e))
+        })?;
+
+        let content = candle_core::quantized::gguf_file::Content::read(&mut file).map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Failed to read GGUF content: {}", e))
+        })?;
+
+        let model = ModelWeights::from_gguf(content, &mut file, device).map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Failed to load quantized Qwen2: {}", e))
+        })?;
+
+        // Load tokenizer
+        let tokenizer = Tokenizer::from_file(tokenizer_path).map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Failed to load tokenizer: {}", e))
+        })?;
+
+        let eos_token_id = tokenizer
+            .token_to_id("<|endoftext|>")
+            .or_else(|| tokenizer.token_to_id("<|im_end|>"))
+            .unwrap_or(151643);
+
+        tracing::info!("Quantized Qwen2 model loaded from {:?}", gguf_path);
+
+        Ok(Self {
+            model,
+            tokenizer,
+            device: device.clone(),
+            eos_token_id,
+        })
+    }
+
+    /// Generate text using greedy decoding (deterministic)
+    pub fn generate(&mut self, prompt: &str, max_tokens: u32) -> Result<Vec<u8>, InferenceError> {
+        let encoding = self
+            .tokenizer
+            .encode(prompt, true)
+            .map_err(|e| InferenceError::ExecutionFailed(format!("Tokenization failed: {}", e)))?;
+
+        let mut tokens = encoding.get_ids().to_vec();
+        let mut generated_tokens: Vec<u32> = Vec::new();
+
+        // Prefill: process all prompt tokens at once
+        let input = Tensor::new(tokens.as_slice(), &self.device)
+            .map_err(|e| InferenceError::ExecutionFailed(format!("Tensor error: {}", e)))?
+            .unsqueeze(0)
+            .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?;
+
+        let logits = self
+            .model
+            .forward(&input, 0)
+            .map_err(|e| InferenceError::ExecutionFailed(format!("Forward pass failed: {}", e)))?;
+
+        let next_token = logits
+            .squeeze(0)
+            .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+            .argmax(candle_core::D::Minus1)
+            .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+            .to_scalar::<u32>()
+            .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?;
+
+        if next_token == self.eos_token_id {
+            return Ok(Vec::new());
+        }
+        generated_tokens.push(next_token);
+        tokens.push(next_token);
+
+        // Autoregressive decoding
+        for _ in 1..max_tokens {
+            let input = Tensor::new(&[*tokens.last().unwrap()], &self.device)
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+                .unsqueeze(0)
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?;
+
+            let seqlen_offset = tokens.len() - 1;
+            let logits = self.model.forward(&input, seqlen_offset).map_err(|e| {
+                InferenceError::ExecutionFailed(format!("Decode step failed: {}", e))
+            })?;
+
+            let next_token = logits
+                .squeeze(0)
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+                .argmax(candle_core::D::Minus1)
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?
+                .to_scalar::<u32>()
+                .map_err(|e| InferenceError::ExecutionFailed(e.to_string()))?;
+
+            if next_token == self.eos_token_id {
+                break;
+            }
+
+            generated_tokens.push(next_token);
+            tokens.push(next_token);
+        }
+
+        let text = self
+            .tokenizer
+            .decode(&generated_tokens, true)
+            .map_err(|e| InferenceError::ExecutionFailed(format!("Detokenize failed: {}", e)))?;
+
+        Ok(text.into_bytes())
+    }
+}
+
+impl super::LoadedModel for QuantizedQwen2TextGen {
+    fn forward(&self, _input: &[u8]) -> Result<Vec<u8>, InferenceError> {
+        Err(InferenceError::ExecutionFailed(
+            "Use generate() for text generation tasks".to_string(),
+        ))
+    }
+
+    fn embedding_dim(&self) -> usize {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_quantized_qwen2_type_compiles() {
+        assert!(std::mem::size_of::<super::QuantizedQwen2TextGen>() > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `QuantizedQwen2TextGen` model wrapper for GGUF (Q4_K_M) quantized inference using `candle_core::quantized::gguf_file`
- Introduce `ModelFormat` enum (Safetensors vs GGUF) to route download and loading logic
- Support split downloads: GGUF weights from `-GGUF` HuggingFace repos, tokenizer from base repos
- Integrate quantized models into `CpuEngine` (load + inference routing)
- Register `qfc-llm-3b` (Warm tier, ~2.2GB Q4_K_M) and `qfc-llm-7b` (Hot tier, ~4.7GB Q4_K_M) in ModelRegistry
- Update tier/memory/timeout/FLOPS estimates in both `qfc-inference` and `qfc-ai-coordinator`

## Changed files
- `crates/qfc-inference/src/models/quantized_qwen2.rs` (new)
- `crates/qfc-inference/src/models/mod.rs`
- `crates/qfc-inference/src/download.rs`
- `crates/qfc-inference/src/backend/cpu.rs`
- `crates/qfc-inference/src/model.rs`
- `crates/qfc-ai-coordinator/src/task_types.rs`

## Test plan
- [x] `cargo build` passes
- [x] `cargo test -p qfc-inference -p qfc-ai-coordinator` — all 32 tests pass
- [x] `cargo fmt` clean
- [ ] CI green

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)