### PR TITLE
feat: display miner reward estimates in logs

### DIFF
--- a/crates/qfc-miner/src/submit.rs
+++ b/crates/qfc-miner/src/submit.rs
@@ -49,6 +49,9 @@ pub struct ProofResult {
     pub accepted: bool,
     pub spot_checked: bool,
     pub message: String,
+    /// Estimated reward in wei (hex string), returned by validator on acceptance
+    #[serde(default)]
+    pub reward_estimate: Option<String>,
 }
 
 /// JSON-RPC request/response types

--- a/crates/qfc-miner/src/worker.rs
+++ b/crates/qfc-miner/src/worker.rs
@@ -52,6 +52,7 @@ impl InferenceWorker {
         let mut status_timer = interval(Duration::from_secs(30));
         let mut tasks_completed: u64 = 0;
         let mut tasks_failed: u64 = 0;
+        let mut total_earnings_wei: u128 = 0;
 
         loop {
             tokio::select! {
@@ -216,10 +217,27 @@ impl InferenceWorker {
                 Ok(result) => {
                     tasks_completed += 1;
                     if result.accepted {
-                        info!(
-                            "Proof accepted! (spot_checked: {}, total: {}, failed: {})",
-                            result.spot_checked, tasks_completed, tasks_failed
-                        );
+                        // Parse reward estimate and accumulate
+                        let reward_wei = result
+                            .reward_estimate
+                            .as_deref()
+                            .and_then(parse_hex_u128)
+                            .unwrap_or(0);
+                        total_earnings_wei += reward_wei;
+
+                        let reward_display = format_wei_as_qfc(reward_wei);
+                        let total_display = format_wei_as_qfc(total_earnings_wei);
+
+                        info!("╔══════════════════════════════════════════════════════╗");
+                        info!("║  ✅ PROOF ACCEPTED — REWARD EARNED                  ║");
+                        info!("║                                                      ║");
+                        info!("║  This task:  +{} QFC{}", reward_display, " ".repeat(36_usize.saturating_sub(reward_display.len())));
+                        info!("║  Session total: {} QFC{}", total_display, " ".repeat(33_usize.saturating_sub(total_display.len())));
+                        info!("║  Tasks: {} completed, {} failed{}", tasks_completed, tasks_failed, " ".repeat(24_usize.saturating_sub(format!("{}{}", tasks_completed, tasks_failed).len())));
+                        if result.spot_checked {
+                            info!("║  🔍 Spot-check: PASSED                              ║");
+                        }
+                        info!("╚══════════════════════════════════════════════════════╝");
                     } else {
                         warn!("Proof rejected: {}", result.message);
                     }
@@ -328,4 +346,20 @@ impl InferenceWorker {
     pub fn stop(&self) {
         self.stop_flag.store(true, Ordering::Relaxed);
     }
+}
+
+/// Parse a hex string like "0x1a2b" into u128
+fn parse_hex_u128(s: &str) -> Option<u128> {
+    let hex_str = s.strip_prefix("0x").unwrap_or(s);
+    u128::from_str_radix(hex_str, 16).ok()
+}
+
+/// Format wei amount as human-readable QFC (1 QFC = 1e18 wei)
+fn format_wei_as_qfc(wei: u128) -> String {
+    if wei == 0 {
+        return "0.000000".to_string();
+    }
+    let whole = wei / 1_000_000_000_000_000_000;
+    let frac = wei % 1_000_000_000_000_000_000;
+    format!("{}.{:06}", whole, frac / 1_000_000_000_000)
 }

--- a/crates/qfc-rpc/src/qfc.rs
+++ b/crates/qfc-rpc/src/qfc.rs
@@ -446,6 +446,11 @@ pub struct RpcProofResult {
     pub spot_checked: bool,
     /// Detail message
     pub message: String,
+    /// Estimated reward in wei (hex string). This is the miner's estimated
+    /// share based on base fee calculation. Actual reward is determined
+    /// at block production time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reward_estimate: Option<String>,
 }
 
 // ============ v2.0: Model Governance RPC Types ============

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -1647,6 +1647,7 @@ impl QfcApiServer for RpcServer {
                     accepted: false,
                     spot_checked: false,
                     message: "Unknown miner — register first via qfc_registerMiner".to_string(),
+                    reward_estimate: None,
                 });
             }
         };
@@ -1660,6 +1661,7 @@ impl QfcApiServer for RpcServer {
                         accepted: false,
                         spot_checked: false,
                         message: "Validator is inactive or jailed".to_string(),
+                        reward_estimate: None,
                     });
                 }
             }
@@ -1673,6 +1675,7 @@ impl QfcApiServer for RpcServer {
                 accepted: false,
                 spot_checked: false,
                 message: "Invalid proof signature".to_string(),
+                reward_estimate: None,
             });
         }
 
@@ -1687,6 +1690,7 @@ impl QfcApiServer for RpcServer {
                 accepted: false,
                 spot_checked: false,
                 message: format!("Proof rejected: {}", e),
+                reward_estimate: None,
             });
         }
 
@@ -1738,6 +1742,7 @@ impl QfcApiServer for RpcServer {
                                 spot_checked: true,
                                 message: "Proof rejected: spot-check failed (output hash mismatch)"
                                     .to_string(),
+                                reward_estimate: None,
                             });
                         }
                         Err(e) => {
@@ -1784,6 +1789,7 @@ impl QfcApiServer for RpcServer {
                         accepted: passed,
                         spot_checked: true,
                         message: format!("Challenge result: {:?}", verdict),
+                        reward_estimate: None,
                     });
                 }
             }
@@ -1804,6 +1810,7 @@ impl QfcApiServer for RpcServer {
                             accepted: false,
                             spot_checked: false,
                             message: "Redundant verification: inconsistent output".to_string(),
+                            reward_estimate: None,
                         });
                     }
                 } else {
@@ -1811,6 +1818,7 @@ impl QfcApiServer for RpcServer {
                         accepted: true,
                         spot_checked: false,
                         message: "Redundant verification: waiting for more submissions".to_string(),
+                        reward_estimate: None,
                     });
                 }
             }
@@ -1911,6 +1919,28 @@ impl QfcApiServer for RpcServer {
             spot_checked
         );
 
+        // Compute estimated miner reward based on base fee (15% miner pool)
+        let reward_est = {
+            let base_fee = qfc_ai_coordinator::estimate_base_fee(&proof.task_type);
+            // Miner gets ~15% of base fee per the reward distribution formula
+            let miner_share = base_fee * 15 / 100;
+            format!("0x{:x}", miner_share)
+        };
+
+        // Also query miner's current balance for the response
+        let balance = self
+            .chain
+            .state()
+            .get_balance(&proof.validator)
+            .unwrap_or_default();
+
+        info!(
+            "Miner {} reward estimate: {} wei (balance: {} QFC)",
+            proof.validator,
+            reward_est,
+            format_qfc_balance(balance),
+        );
+
         Ok(RpcProofResult {
             accepted: true,
             spot_checked,
@@ -1919,6 +1949,7 @@ impl QfcApiServer for RpcServer {
             } else {
                 "Proof accepted".to_string()
             },
+            reward_estimate: Some(reward_est),
         })
     }
 
@@ -2824,5 +2855,21 @@ impl TxPoolApiServer for RpcServer {
             pending: format!("0x{:x}", size),
             queued: "0x0".to_string(),
         })
+    }
+}
+
+/// Format a U256 balance as human-readable QFC (1 QFC = 1e18 wei)
+fn format_qfc_balance(balance: qfc_types::U256) -> String {
+    let wei_str = format!("{}", balance);
+    if wei_str.len() <= 18 {
+        format!("0.{:0>18}", wei_str)
+    } else {
+        let (whole, frac) = wei_str.split_at(wei_str.len() - 18);
+        let frac_trimmed = frac.trim_end_matches('0');
+        if frac_trimmed.is_empty() {
+            whole.to_string()
+        } else {
+            format!("{}.{}", whole, &frac[..6.min(frac.len())])
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Validator returns estimated reward (15% miner pool share of base fee) in `RpcProofResult.reward_estimate` when a proof is accepted
- Miner worker displays a prominent box-style banner on each accepted proof showing per-task reward and cumulative session earnings in QFC
- Session-level earnings tracking so miners can see total income at a glance

**Example miner log output:**
```
╔══════════════════════════════════════════════════════╗
║  ✅ PROOF ACCEPTED — REWARD EARNED                  ║
║                                                      ║
║  This task:  +0.001500 QFC                           
║  Session total: 0.045000 QFC                         
║  Tasks: 30 completed, 2 failed                       
╚══════════════════════════════════════════════════════╝
```

## Changed files
- `crates/qfc-rpc/src/qfc.rs` — Added `reward_estimate: Option<String>` to `RpcProofResult`
- `crates/qfc-rpc/src/server.rs` — Compute and return reward estimate on proof acceptance; added `format_qfc_balance()` helper
- `crates/qfc-miner/src/submit.rs` — Added `reward_estimate` field to `ProofResult`
- `crates/qfc-miner/src/worker.rs` — Prominent banner-style reward logging with session earnings tracking

## Test plan
- [x] All 508 tests pass (`cargo test --all`)
- [x] Clean build with no warnings
- [ ] Manual test: run miner against testnet validator, verify reward banner appears on proof acceptance

— Kevin Zhang, qfc-core 首席程序员

🤖 Generated with [Claude Code](https://claude.com/claude-code)