### PR TITLE
feat: per-miner earnings ledger and RPC query

### DIFF
--- a/crates/qfc-node/src/producer.rs
+++ b/crates/qfc-node/src/producer.rs
@@ -470,7 +470,7 @@ impl BlockProducer {
 
         // Distribute to inference miners proportional to FLOPS, or redistribute if none
         let miner_reward = if !inference_proofs.is_empty() {
-            self.distribute_miner_rewards(&miner_pool, inference_proofs)?
+            self.distribute_miner_rewards(&miner_pool, inference_proofs, block_height, now)?
         } else {
             U256::ZERO
         };
@@ -582,6 +582,8 @@ impl BlockProducer {
         &self,
         total_reward: &U256,
         proofs: &[InferenceProof],
+        block_height: u64,
+        timestamp: u64,
     ) -> anyhow::Result<U256> {
         if proofs.is_empty() || total_reward.is_zero() {
             return Ok(U256::ZERO);
@@ -595,21 +597,42 @@ impl BlockProducer {
 
         let mut distributed = U256::ZERO;
 
-        // Aggregate FLOPS per miner (a miner may have multiple proofs)
+        // Aggregate FLOPS and task count per miner (a miner may have multiple proofs)
         let mut miner_flops: std::collections::HashMap<qfc_types::Address, u64> =
+            std::collections::HashMap::new();
+        let mut miner_task_count: std::collections::HashMap<qfc_types::Address, u32> =
             std::collections::HashMap::new();
         for proof in proofs {
             *miner_flops.entry(proof.validator).or_default() += proof.flops_estimated;
+            *miner_task_count.entry(proof.validator).or_default() += 1;
         }
+
+        let db = self.chain.db();
 
         for (miner, flops) in &miner_flops {
             let reward = *total_reward * U256::from_u64(*flops) / U256::from_u64(total_flops);
             if !reward.is_zero() {
                 state.add_balance(miner, reward)?;
                 distributed = distributed + reward;
+
+                // Store per-miner earning record
+                let task_count = miner_task_count.get(miner).copied().unwrap_or(1);
+                let earning = qfc_types::MinerEarning::new(
+                    *miner,
+                    block_height,
+                    reward,
+                    *flops,
+                    task_count,
+                    timestamp,
+                );
+                let key = qfc_types::encode_miner_earning_key(miner, block_height);
+                if let Err(e) = db.put(qfc_storage::cf::MINER_EARNINGS, &key, &earning.to_bytes()) {
+                    tracing::warn!("Failed to store miner earning record: {}", e);
+                }
+
                 debug!(
-                    "Miner {} inference reward: {} ({} FLOPS / {} total)",
-                    miner, reward, flops, total_flops
+                    "Miner {} inference reward: {} ({} FLOPS / {} total, {} tasks)",
+                    miner, reward, flops, total_flops, task_count
                 );
             }
         }

--- a/crates/qfc-rpc/src/qfc.rs
+++ b/crates/qfc-rpc/src/qfc.rs
@@ -248,6 +248,16 @@ pub trait QfcApi {
     #[subscription(name = "subscribeTaskStatus" => "taskStatus", unsubscribe = "unsubscribeTaskStatus", item = RpcPublicTaskStatus)]
     async fn subscribe_task_status(&self, task_id: String) -> SubscriptionResult;
 
+    /// Get miner earnings history.
+    /// Returns per-block earning records for a miner address.
+    /// `period` can be: "day" (last 24h), "week", "month", or "all".
+    #[method(name = "getMinerEarnings")]
+    async fn get_miner_earnings(
+        &self,
+        address: String,
+        period: String,
+    ) -> RpcResult<RpcMinerEarnings>;
+
     // ---- v2.0: Bridge endpoints ----
 
     /// Get bridge status (validators, TVL, pending operations)
@@ -446,6 +456,42 @@ pub struct RpcProofResult {
     pub spot_checked: bool,
     /// Detail message
     pub message: String,
+}
+
+// ============ v2.0: Miner Earnings RPC Types ============
+
+/// Miner earnings summary and history
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcMinerEarnings {
+    /// Miner address
+    pub address: String,
+    /// Total earnings in wei (hex string)
+    pub total_earnings: String,
+    /// Total FLOPS contributed
+    pub total_flops: String,
+    /// Total tasks completed
+    pub total_tasks: String,
+    /// Current balance in wei (hex string)
+    pub balance: String,
+    /// Earning records (newest first)
+    pub records: Vec<RpcEarningRecord>,
+}
+
+/// A single earning record for one block
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcEarningRecord {
+    /// Block height
+    pub block_height: String,
+    /// Reward earned in wei (hex string)
+    pub reward: String,
+    /// FLOPS contributed
+    pub flops: String,
+    /// Number of tasks in this block
+    pub task_count: u32,
+    /// Block timestamp (ms since epoch)
+    pub timestamp: String,
 }
 
 // ============ v2.0: Model Governance RPC Types ============

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -4,14 +4,15 @@ use crate::error::RpcError;
 use crate::eth::EthApiServer;
 use crate::qfc::{
     QfcApiServer, RpcAccountRentInfo, RpcBridgeDeposit, RpcBridgeStatus, RpcBridgeWithdrawal,
-    RpcComputeInfo, RpcEpoch, RpcEstimateInferenceFee, RpcFaucetResponse, RpcInferenceFeeEstimate,
-    RpcInferenceProofSubmission, RpcInferenceStats, RpcInferenceTask, RpcMinerStatusReport,
-    RpcModel, RpcModelProposal, RpcNodeInfo, RpcParameterOverride, RpcParameterProposal,
-    RpcProofResult, RpcProposeModelRequest, RpcProposeParameterRequest, RpcProposeSpendRequest,
-    RpcPublicTaskStatus, RpcRegisterMinerRequest, RpcRegisterMinerResult, RpcSpendProposal,
-    RpcSubmitPublicTask, RpcTaskRequest, RpcTreasuryInfo, RpcUndelegation, RpcUserOperation,
-    RpcUserOperationStatus, RpcValidator, RpcValidatorMetrics, RpcValidatorScoreBreakdown,
-    RpcVoteModelRequest, RpcVoteParameterRequest, RpcVoteSpendRequest,
+    RpcComputeInfo, RpcEarningRecord, RpcEpoch, RpcEstimateInferenceFee, RpcFaucetResponse,
+    RpcInferenceFeeEstimate, RpcInferenceProofSubmission, RpcInferenceStats, RpcInferenceTask,
+    RpcMinerEarnings, RpcMinerStatusReport, RpcModel, RpcModelProposal, RpcNodeInfo,
+    RpcParameterOverride, RpcParameterProposal, RpcProofResult, RpcProposeModelRequest,
+    RpcProposeParameterRequest, RpcProposeSpendRequest, RpcPublicTaskStatus,
+    RpcRegisterMinerRequest, RpcRegisterMinerResult, RpcSpendProposal, RpcSubmitPublicTask,
+    RpcTaskRequest, RpcTreasuryInfo, RpcUndelegation, RpcUserOperation, RpcUserOperationStatus,
+    RpcValidator, RpcValidatorMetrics, RpcValidatorScoreBreakdown, RpcVoteModelRequest,
+    RpcVoteParameterRequest, RpcVoteSpendRequest,
 };
 use crate::txpool::{TxPoolApiServer, TxPoolContent, TxPoolStatus};
 use crate::types::{BlockNumber, BlockTag, CallRequest, RpcBlock, RpcReceipt, RpcTransaction};
@@ -2235,6 +2236,98 @@ impl QfcApiServer for RpcServer {
                 value: value.to_string(),
             })
             .collect())
+    }
+
+    // ---- v2.0: Miner Earnings ----
+
+    async fn get_miner_earnings(
+        &self,
+        address: String,
+        period: String,
+    ) -> RpcResult<RpcMinerEarnings> {
+        let addr_hex = address.strip_prefix("0x").unwrap_or(&address);
+        let addr_bytes = hex::decode(addr_hex).map_err(|e| {
+            jsonrpsee::types::ErrorObjectOwned::owned(
+                -32602,
+                format!("Invalid address: {}", e),
+                None::<()>,
+            )
+        })?;
+        let miner_address = qfc_types::Address::from_slice(&addr_bytes).ok_or_else(|| {
+            jsonrpsee::types::ErrorObjectOwned::owned(
+                -32602,
+                "Address must be 20 bytes",
+                None::<()>,
+            )
+        })?;
+
+        // Determine time cutoff based on period
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let cutoff_ms = match period.as_str() {
+            "day" => now_ms.saturating_sub(24 * 3600 * 1000),
+            "week" => now_ms.saturating_sub(7 * 24 * 3600 * 1000),
+            "month" => now_ms.saturating_sub(30 * 24 * 3600 * 1000),
+            "all" | _ => 0,
+        };
+
+        // Scan MINER_EARNINGS CF for this address
+        let db = self.chain.db();
+        let start_key = qfc_types::encode_miner_earning_key(&miner_address, 0);
+
+        let mut records = Vec::new();
+        let mut total_earnings = qfc_types::U256::ZERO;
+        let mut total_flops: u64 = 0;
+        let mut total_tasks: u64 = 0;
+
+        if let Ok(iter) = db.iter_from("miner_earnings", &start_key) {
+            for (key, value) in iter {
+                // Stop when we leave this miner's prefix
+                if key.len() != 28 || &key[0..20] != miner_address.as_bytes() {
+                    break;
+                }
+
+                if let Ok(earning) = qfc_types::MinerEarning::from_bytes(&value) {
+                    // Skip records before cutoff
+                    if earning.timestamp < cutoff_ms {
+                        continue;
+                    }
+
+                    total_earnings = total_earnings + earning.reward;
+                    total_flops += earning.flops;
+                    total_tasks += earning.task_count as u64;
+
+                    records.push(RpcEarningRecord {
+                        block_height: format!("0x{:x}", earning.block_height),
+                        reward: format!("0x{:x}", earning.reward.0),
+                        flops: format!("0x{:x}", earning.flops),
+                        task_count: earning.task_count,
+                        timestamp: format!("{}", earning.timestamp),
+                    });
+                }
+            }
+        }
+
+        // Reverse so newest records come first
+        records.reverse();
+
+        // Current balance
+        let balance = self
+            .chain
+            .state()
+            .get_balance(&miner_address)
+            .unwrap_or_default();
+
+        Ok(RpcMinerEarnings {
+            address: format!("0x{}", addr_hex),
+            total_earnings: format!("0x{:x}", total_earnings.0),
+            total_flops: format!("0x{:x}", total_flops),
+            total_tasks: format!("0x{:x}", total_tasks),
+            balance: format!("0x{:x}", balance.0),
+            records,
+        })
     }
 
     // ---- v2.0: Cross-chain bridge endpoints ----

--- a/crates/qfc-storage/src/schema.rs
+++ b/crates/qfc-storage/src/schema.rs
@@ -51,6 +51,10 @@ pub mod cf {
     /// Used to look up transactions/receipts by Ethereum-computed hash
     pub const ETH_TX_INDEX: &str = "eth_tx_index";
 
+    /// Miner earnings: miner_address (20 bytes) + block_height (u64 BE) -> MinerEarning
+    /// Indexed by miner address for efficient per-miner queries
+    pub const MINER_EARNINGS: &str = "miner_earnings";
+
     /// All column families
     pub const ALL: &[&str] = &[
         BLOCK_HEADERS,
@@ -69,6 +73,7 @@ pub mod cf {
         CHECKPOINTS,
         WORK_PROOFS,
         ETH_TX_INDEX,
+        MINER_EARNINGS,
     ];
 }
 

--- a/crates/qfc-types/src/validator.rs
+++ b/crates/qfc-types/src/validator.rs
@@ -710,6 +710,71 @@ impl RewardDistribution {
     }
 }
 
+// ============ Miner Earnings Ledger ============
+
+/// Per-miner earning record for a single block
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub struct MinerEarning {
+    /// Miner address
+    pub miner: Address,
+    /// Block height where reward was earned
+    pub block_height: u64,
+    /// Reward amount in wei
+    pub reward: U256,
+    /// FLOPS contributed in this block
+    pub flops: u64,
+    /// Number of tasks completed in this block
+    pub task_count: u32,
+    /// Timestamp of the block
+    pub timestamp: u64,
+}
+
+impl MinerEarning {
+    pub fn new(
+        miner: Address,
+        block_height: u64,
+        reward: U256,
+        flops: u64,
+        task_count: u32,
+        timestamp: u64,
+    ) -> Self {
+        Self {
+            miner,
+            block_height,
+            reward,
+            flops,
+            task_count,
+            timestamp,
+        }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        borsh::to_vec(self).expect("serialization should not fail")
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, borsh::io::Error> {
+        borsh::from_slice(bytes)
+    }
+}
+
+/// Encode a miner earnings key: miner_address (20 bytes) + block_height (u64 BE)
+pub fn encode_miner_earning_key(miner: &Address, block_height: u64) -> [u8; 28] {
+    let mut key = [0u8; 28];
+    key[0..20].copy_from_slice(miner.as_bytes());
+    key[20..28].copy_from_slice(&block_height.to_be_bytes());
+    key
+}
+
+/// Decode a miner earnings key
+pub fn decode_miner_earning_key(bytes: &[u8]) -> Option<(Address, u64)> {
+    if bytes.len() != 28 {
+        return None;
+    }
+    let address = Address::from_slice(&bytes[0..20])?;
+    let height = u64::from_be_bytes(bytes[20..28].try_into().ok()?);
+    Some((address, height))
+}
+
 // ============ Delegation System ============
 
 /// Delegation record: a delegator's stake in a validator
@@ -1093,5 +1158,44 @@ mod tests {
         assert_eq!(slashing.offense, SlashableOffense::DoubleSign);
         assert_eq!(slashing.block_height, evidence.height);
         assert_eq!(slashing.reporter, reporter);
+    }
+
+    #[test]
+    fn test_miner_earning_serialization() {
+        let miner = Address::from_slice(&[1u8; 20]).unwrap();
+        let earning = MinerEarning::new(
+            miner,
+            42,
+            U256::from_u64(1_000_000_000_000_000_000), // 1 QFC
+            50_000_000,
+            3,
+            1700000000000,
+        );
+        let bytes = earning.to_bytes();
+        let decoded = MinerEarning::from_bytes(&bytes).unwrap();
+        assert_eq!(earning, decoded);
+    }
+
+    #[test]
+    fn test_miner_earning_key_encoding() {
+        let miner = Address::from_slice(&[0xAB; 20]).unwrap();
+        let key = encode_miner_earning_key(&miner, 12345);
+        let (decoded_addr, decoded_height) = decode_miner_earning_key(&key).unwrap();
+        assert_eq!(decoded_addr, miner);
+        assert_eq!(decoded_height, 12345);
+    }
+
+    #[test]
+    fn test_miner_earning_key_ordering() {
+        let miner = Address::from_slice(&[1u8; 20]).unwrap();
+        let key1 = encode_miner_earning_key(&miner, 100);
+        let key2 = encode_miner_earning_key(&miner, 200);
+        // Same miner, higher block should sort after
+        assert!(key1 < key2);
+
+        // Different miner should have different prefix
+        let miner2 = Address::from_slice(&[2u8; 20]).unwrap();
+        let key3 = encode_miner_earning_key(&miner2, 100);
+        assert_ne!(&key1[0..20], &key3[0..20]);
     }
 }


### PR DESCRIPTION
## Summary

- Added `MinerEarning` type — records reward, FLOPS, task count per miner per block
- New `MINER_EARNINGS` RocksDB column family indexed by `miner_address + block_height`
- Block producer now stores earning records in `distribute_miner_rewards()`
- New RPC endpoint `qfc_getMinerEarnings(address, period)` returns earnings history with day/week/month/all filtering

**RPC example:**
```bash
curl -X POST http://127.0.0.1:8545 -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"qfc_getMinerEarnings","params":["0x...", "day"],"id":1}'
```

**Response:**
```json
{
  "address": "0x...",
  "totalEarnings": "0x...",
  "totalFlops": "0x...",
  "totalTasks": "0x...",
  "balance": "0x...",
  "records": [
    { "blockHeight": "0x2a", "reward": "0x...", "flops": "0x...", "taskCount": 3, "timestamp": "..." }
  ]
}
```

Closes #52. Prerequisite for: CLI TUI dashboard, Explorer miner page, qfc-design#24.

## Test plan
- [x] All tests pass (`cargo test --all`)
- [x] Unit tests for `MinerEarning` serialization and key encoding
- [x] Clean build, `cargo fmt` clean
- [ ] Integration: run node with miner, verify earnings appear via RPC

— Kevin Zhang, qfc-core 首席程序员

🤖 Generated with [Claude Code](https://claude.com/claude-code)