### PR TITLE
feat: subscribeMinerEvents WebSocket subscription

### DIFF
--- a/crates/qfc-rpc/src/qfc.rs
+++ b/crates/qfc-rpc/src/qfc.rs
@@ -257,6 +257,10 @@ pub trait QfcApi {
         address: String,
         period: String,
     ) -> RpcResult<RpcMinerEarnings>;
+    /// Subscribe to miner earning events (WebSocket only).
+    /// Pushes RpcMinerEvent whenever the miner earns a reward or completes a task.
+    #[subscription(name = "subscribeMinerEvents" => "minerEvent", unsubscribe = "unsubscribeMinerEvents", item = RpcMinerEvent)]
+    async fn subscribe_miner_events(&self, address: String) -> SubscriptionResult;
 
     // ---- v2.0: Bridge endpoints ----
 
@@ -497,6 +501,32 @@ pub struct RpcEarningRecord {
     pub task_count: u32,
     /// Block timestamp (ms since epoch)
     pub timestamp: String,
+}
+
+// ============ v2.0: Miner Event Subscription Types ============
+
+/// Real-time miner event pushed via WebSocket subscription
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcMinerEvent {
+    /// Event type: "proof_accepted", "proof_rejected", "task_assigned", "reward_settled"
+    pub event_type: String,
+    /// Miner address
+    pub miner: String,
+    /// Block height (if applicable)
+    pub block_height: Option<String>,
+    /// Task type (e.g. "embedding", "text_generation")
+    pub task_type: Option<String>,
+    /// FLOPS contributed
+    pub flops: Option<String>,
+    /// Reward amount in wei (hex)
+    pub reward: Option<String>,
+    /// Whether spot-checked
+    pub spot_checked: Option<bool>,
+    /// Timestamp (ms since epoch)
+    pub timestamp: String,
+    /// Human-readable message
+    pub message: String,
 }
 
 // ============ v2.0: Model Governance RPC Types ============

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -6,7 +6,7 @@ use crate::qfc::{
     QfcApiServer, RpcAccountRentInfo, RpcBridgeDeposit, RpcBridgeStatus, RpcBridgeWithdrawal,
     RpcComputeInfo, RpcEarningRecord, RpcEpoch, RpcEstimateInferenceFee, RpcFaucetResponse,
     RpcInferenceFeeEstimate, RpcInferenceProofSubmission, RpcInferenceStats, RpcInferenceTask,
-    RpcMinerEarnings, RpcMinerStatusReport, RpcModel, RpcModelProposal, RpcNodeInfo,
+    RpcMinerEarnings, RpcMinerEvent, RpcMinerStatusReport, RpcModel, RpcModelProposal, RpcNodeInfo,
     RpcParameterOverride, RpcParameterProposal, RpcProofResult, RpcProposeModelRequest,
     RpcProposeParameterRequest, RpcProposeSpendRequest, RpcPublicTaskStatus,
     RpcRegisterMinerRequest, RpcRegisterMinerResult, RpcSpendProposal, RpcSubmitPublicTask,
@@ -2843,6 +2843,123 @@ impl QfcApiServer for RpcServer {
             } else {
                 break; // Task pruned
             }
+        }
+        Ok(())
+    }
+
+    async fn subscribe_miner_events(
+        &self,
+        pending: jsonrpsee::PendingSubscriptionSink,
+        address: String,
+    ) -> SubscriptionResult {
+        use jsonrpsee::SubscriptionMessage;
+
+        let miner_address = match Self::parse_address(&address) {
+            Ok(addr) => addr,
+            Err(e) => {
+                pending.reject(e).await;
+                return Ok(());
+            }
+        };
+
+        let sink = pending.accept().await?;
+        let chain = self.chain.clone();
+        let miner_hex = hex::encode(miner_address.as_bytes());
+
+        // Track last seen block height
+        let mut last_block = chain.block_number();
+
+        // Poll every 1s for new blocks containing this miner's proofs
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            if sink.is_closed() {
+                break;
+            }
+
+            let current_block = chain.block_number();
+            if current_block <= last_block {
+                continue;
+            }
+
+            for height in (last_block + 1)..=current_block {
+                if sink.is_closed() {
+                    break;
+                }
+                let block = match chain.get_block_by_number(height) {
+                    Ok(Some(b)) => b,
+                    _ => continue,
+                };
+
+                // Count this miner's proofs in the block for reward estimation
+                let miner_proofs: Vec<_> = block
+                    .inference_proofs
+                    .iter()
+                    .filter(|p| p.validator == miner_address)
+                    .collect();
+
+                if miner_proofs.is_empty() {
+                    continue;
+                }
+
+                let total_flops_in_block: u64 = block
+                    .inference_proofs
+                    .iter()
+                    .map(|p| p.flops_estimated)
+                    .sum();
+                let miner_flops: u64 = miner_proofs.iter().map(|p| p.flops_estimated).sum();
+
+                for proof in &miner_proofs {
+                    let event = RpcMinerEvent {
+                        event_type: "proof_accepted".to_string(),
+                        miner: format!("0x{}", miner_hex),
+                        block_height: Some(format!("0x{:x}", height)),
+                        task_type: Some(format!("{:?}", proof.task_type)),
+                        flops: Some(proof.flops_estimated.to_string()),
+                        reward: None,
+                        spot_checked: None,
+                        timestamp: format!("{}", block.header.timestamp),
+                        message: format!(
+                            "Proof included in block {} ({} FLOPS)",
+                            height, proof.flops_estimated
+                        ),
+                    };
+                    let msg = SubscriptionMessage::from_json(&event)?;
+                    if sink.send(msg).await.is_err() {
+                        return Ok(());
+                    }
+                }
+
+                // Emit a reward_settled event summarizing this miner's block reward
+                if total_flops_in_block > 0 {
+                    // 15% of block reward goes to miner pool, proportional to FLOPS
+                    let block_reward = U256::from_u128(qfc_types::BLOCK_REWARD);
+                    let miner_pool = block_reward * U256::from_u128(15) / U256::from_u128(100);
+                    let miner_reward = miner_pool * U256::from_u128(miner_flops as u128)
+                        / U256::from_u128(total_flops_in_block as u128);
+
+                    let event = RpcMinerEvent {
+                        event_type: "reward_settled".to_string(),
+                        miner: format!("0x{}", miner_hex),
+                        block_height: Some(format!("0x{:x}", height)),
+                        task_type: None,
+                        flops: Some(miner_flops.to_string()),
+                        reward: Some(format!("0x{:x}", miner_reward.0)),
+                        spot_checked: None,
+                        timestamp: format!("{}", block.header.timestamp),
+                        message: format!(
+                            "Reward settled: {} proofs, {} FLOPS in block {}",
+                            miner_proofs.len(),
+                            miner_flops,
+                            height,
+                        ),
+                    };
+                    let msg = SubscriptionMessage::from_json(&event)?;
+                    if sink.send(msg).await.is_err() {
+                        return Ok(());
+                    }
+                }
+            }
+            last_block = current_block;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Adds `subscribeMinerEvents` WebSocket subscription to `QfcApi` RPC trait
- Emits real-time `proof_accepted` and `reward_settled` events for a specific miner address
- Polls new blocks for the miner's inference proofs and estimates reward based on FLOPS share (15% of block reward)
- Defines `RpcMinerEvent` type with event_type, miner, block_height, task_type, flops, reward, spot_checked, timestamp, message

## Usage
```json
{"jsonrpc":"2.0","method":"subscribeMinerEvents","params":["0x<miner_address>"],"id":1}
```

Events pushed:
- `proof_accepted` — miner's proof included in a new block
- `reward_settled` — estimated reward for the block (15% × FLOPS share)

Part of qfc-design#24 (Miner Revenue Dashboard).

## Test plan
- [ ] `cargo check -p qfc-rpc` passes
- [ ] Subscribe via WebSocket client, submit inference proofs, verify events received
- [ ] Verify reward estimate matches expected 15% × FLOPS-proportional share

🤖 Generated with [Claude Code](https://claude.com/claude-code)