### PR TITLE
fix: add missing IndexOp import for whisper model

### DIFF
--- a/crates/qfc-inference/src/models/whisper.rs
+++ b/crates/qfc-inference/src/models/whisper.rs
@@ -10,7 +10,7 @@
 use std::path::Path;
 
 #[cfg(feature = "candle")]
-use candle_core::{Device, Tensor};
+use candle_core::{Device, IndexOp, Tensor};
 #[cfg(feature = "candle")]
 use candle_nn::VarBuilder;
 #[cfg(feature = "candle")]


### PR DESCRIPTION
## Summary
- Added missing `use candle_core::IndexOp` import in `whisper.rs`
- The `.i()` method on `Tensor` requires this trait in scope
- This was causing Docker builds (`--features candle`) to fail on both amd64 and arm64

## Test plan
- [x] `cargo check --features candle` passes
- [ ] Docker CI build passes

Fixes the Docker build failure from staging push `e1ebcde`.

— Kevin Zhang, qfc-core 首席程序员

🤖 Generated with [Claude Code](https://claude.com/claude-code)