### PR TITLE
feat: slashing alerts and daily summary webhook events

### DIFF
--- a/crates/qfc-rpc/src/qfc.rs
+++ b/crates/qfc-rpc/src/qfc.rs
@@ -530,7 +530,8 @@ pub struct RpcEarningRecord {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcMinerEvent {
-    /// Event type: "proof_accepted", "proof_rejected", "task_assigned", "reward_settled"
+    /// Event type: "proof_accepted", "proof_rejected", "task_assigned",
+    /// "reward_settled", "slashing_applied", "score_changed", "daily_summary"
     pub event_type: String,
     /// Miner address
     pub miner: String,
@@ -804,7 +805,8 @@ pub struct RpcRegisterWebhookRequest {
     pub miner_address: String,
     /// Webhook URL (must be HTTPS, or Discord/Telegram webhook URL)
     pub url: String,
-    /// Event types to receive: "all", "proof_accepted", "proof_rejected", "reward_settled"
+    /// Event types to receive: "all", "proof_accepted", "proof_rejected",
+    /// "reward_settled", "slashing_applied", "score_changed", "daily_summary"
     #[serde(default = "default_events")]
     pub events: Vec<String>,
     /// Ed25519 signature of the URL for authentication

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -1743,6 +1743,27 @@ impl QfcApiServer for RpcServer {
                                 hex::encode(&got.as_bytes()[..8]),
                             );
                             consensus.slash_validator(&proof.validator, 5, 6 * 60 * 60 * 1000);
+
+                            // Deliver slashing webhook notification
+                            crate::webhook::deliver(
+                                &self.webhook_store,
+                                &proof.validator,
+                                crate::webhook::WebhookPayload {
+                                    event_type: "slashing_applied".to_string(),
+                                    miner: hex::encode(proof.validator.as_bytes()),
+                                    block_height: None,
+                                    task_type: Some(format!("{:?}", proof.task_type)),
+                                    flops: None,
+                                    reward_wei: None,
+                                    spot_checked: Some(true),
+                                    timestamp: proof.timestamp,
+                                    message: format!(
+                                        "Slashing applied: 5% stake penalty, 6h jail. Reason: spot-check output hash mismatch (task {})",
+                                        hex::encode(&proof.input_hash.as_bytes()[..8]),
+                                    ),
+                                },
+                            );
+
                             return Ok(RpcProofResult {
                                 accepted: false,
                                 spot_checked: true,
@@ -1784,6 +1805,28 @@ impl QfcApiServer for RpcServer {
                                 &proof.validator,
                                 penalty.slash_percent,
                                 penalty.jail_duration_ms,
+                            );
+
+                            // Deliver slashing webhook for challenge failure
+                            crate::webhook::deliver(
+                                &self.webhook_store,
+                                &proof.validator,
+                                crate::webhook::WebhookPayload {
+                                    event_type: "slashing_applied".to_string(),
+                                    miner: hex::encode(proof.validator.as_bytes()),
+                                    block_height: None,
+                                    task_type: Some(format!("{:?}", proof.task_type)),
+                                    flops: None,
+                                    reward_wei: None,
+                                    spot_checked: Some(true),
+                                    timestamp: proof.timestamp,
+                                    message: format!(
+                                        "Slashing applied: {}% stake penalty, {}h jail. Reason: challenge verification failed (task {})",
+                                        penalty.slash_percent,
+                                        penalty.jail_duration_ms / (60 * 60 * 1000),
+                                        hex::encode(&proof.input_hash.as_bytes()[..8]),
+                                    ),
+                                },
                             );
                         }
                     }
@@ -2535,6 +2578,18 @@ impl QfcApiServer for RpcServer {
                 .ok_or_else(|| RpcError::Execution("Invalid signature length".to_string()))?;
             qfc_crypto::verify_hash_signature(public_key, &url_hash, &signature)
                 .map_err(|_| RpcError::Execution("Signature verification failed".to_string()))?;
+        }
+
+        // Validate event types
+        for event in &request.events {
+            if !crate::webhook::VALID_WEBHOOK_EVENTS.contains(&event.as_str()) {
+                return Err(RpcError::Execution(format!(
+                    "Invalid event type '{}'. Valid types: {}",
+                    event,
+                    crate::webhook::VALID_WEBHOOK_EVENTS.join(", "),
+                ))
+                .into());
+            }
         }
 
         // Validate URL

--- a/crates/qfc-rpc/src/webhook.rs
+++ b/crates/qfc-rpc/src/webhook.rs
@@ -46,6 +46,17 @@ pub struct WebhookPayload {
 /// Thread-safe webhook store: miner_address -> Vec<Webhook>
 pub type WebhookStore = Arc<RwLock<HashMap<qfc_types::Address, Vec<Webhook>>>>;
 
+/// All valid webhook event types that can be subscribed to
+pub const VALID_WEBHOOK_EVENTS: &[&str] = &[
+    "all",
+    "proof_accepted",
+    "proof_rejected",
+    "reward_settled",
+    "slashing_applied",
+    "score_changed",
+    "daily_summary",
+];
+
 /// Create a new empty webhook store
 pub fn new_store() -> WebhookStore {
     Arc::new(RwLock::new(HashMap::new()))
@@ -106,6 +117,48 @@ pub fn deliver(store: &WebhookStore, miner: &qfc_types::Address, payload: Webhoo
         tokio::spawn(async move {
             deliver_single(&url, &json, &hook_id).await;
         });
+    }
+}
+
+/// Format a u128 wei value as a human-readable QFC string (1 QFC = 1e18 wei)
+pub fn format_wei(wei: u128) -> String {
+    let s = format!("{}", wei);
+    if s.len() <= 18 {
+        format!("0.{:0>18} QFC", s)
+    } else {
+        let (whole, frac) = s.split_at(s.len() - 18);
+        format!("{}.{} QFC", whole, &frac[..4])
+    }
+}
+
+/// Build a daily summary payload for a miner.
+/// Can be called periodically to send daily digest webhooks.
+pub fn build_daily_summary(
+    miner_hex: &str,
+    tasks_completed: u64,
+    tasks_failed: u64,
+    earnings_wei: u128,
+    score: f64,
+) -> WebhookPayload {
+    WebhookPayload {
+        event_type: "daily_summary".to_string(),
+        miner: miner_hex.to_string(),
+        block_height: None,
+        task_type: None,
+        flops: None,
+        reward_wei: None,
+        spot_checked: None,
+        timestamp: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+        message: format!(
+            "Daily summary: {} tasks completed, {} failed, earned {}, score {:.2}",
+            tasks_completed,
+            tasks_failed,
+            format_wei(earnings_wei),
+            score,
+        ),
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `slashing_applied` webhook event on spot-check and challenge failures
- Add `score_changed` and `daily_summary` event types
- Add `build_daily_summary()` payload builder for periodic digest
- Validate webhook event types on registration (reject unknown events)
- Add `format_wei()` helper for human-readable QFC amounts

Closes qfc-network/qfc-design#33

## Test plan
- [ ] Register webhook with `events: ["slashing_applied"]` — should succeed
- [ ] Register webhook with `events: ["invalid_type"]` — should fail with error listing valid types
- [ ] Trigger spot-check failure — verify slashing webhook is delivered
- [ ] Verify `build_daily_summary()` produces correct JSON payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)