### PR TITLE
fix: redirect logs to file when TUI dashboard is active

### DIFF
--- a/crates/qfc-miner/src/main.rs
+++ b/crates/qfc-miner/src/main.rs
@@ -25,9 +25,19 @@ use tracing::info;
 async fn main() -> anyhow::Result<()> {
     let cli = MinerCli::parse();
 
-    // Setup logging
+    // Setup logging — redirect to file when TUI dashboard is active
     let filter = if cli.verbose { "debug" } else { "info" };
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+    if cli.dashboard {
+        let log_file = std::fs::File::create("qfc-miner.log")
+            .expect("Failed to create log file");
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(log_file)
+            .with_ansi(false)
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    }
 
     info!("QFC AI Inference Miner v{}", env!("CARGO_PKG_VERSION"));
 


### PR DESCRIPTION
## Summary
- `tracing_subscriber` writes to stdout, which conflicts with ratatui's AlternateScreen
- When `--dashboard` is used, logs are now redirected to `qfc-miner.log`
- Without `--dashboard`, logging behavior is unchanged

## Test plan
- [x] `cargo check --bin qfc-miner --features tui` passes
- [x] Manual test: TUI renders correctly with `--dashboard`

— Kevin Zhang, qfc-core 首席程序员

🤖 Generated with [Claude Code](https://claude.com/claude-code)