### PR TITLE
feat: add hardware profile to miner registration

### DIFF
--- a/crates/qfc-miner/src/submit.rs
+++ b/crates/qfc-miner/src/submit.rs
@@ -217,6 +217,12 @@ struct RegisterMinerReq {
     benchmark_score: u32,
     backend: String,
     signature: String,
+    os: String,
+    arch: String,
+    cpu_model: String,
+    cpu_cores: u32,
+    total_memory_mb: u64,
+    version: String,
 }
 
 /// Register miner result
@@ -250,6 +256,14 @@ pub async fn register_miner(
         benchmark_score,
         backend: format!("{}", backend),
         signature: hex::encode(signature.as_bytes()),
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        cpu_model: get_cpu_model(),
+        cpu_cores: std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(1),
+        total_memory_mb: get_total_memory_mb(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
     };
 
     info!("Registering miner at {}", rpc_url);
@@ -327,6 +341,69 @@ pub async fn fetch_epoch(rpc_url: &str) -> Result<u64, SubmitError> {
     let hex_str = result.number.strip_prefix("0x").unwrap_or(&result.number);
     u64::from_str_radix(hex_str, 16)
         .map_err(|e| SubmitError::SerializationError(format!("Invalid epoch hex: {}", e)))
+}
+
+/// Get CPU model name from the system
+fn get_cpu_model() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("sysctl")
+            .args(["-n", "machdep.cpu.brand_string"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/cpuinfo")
+            .ok()
+            .and_then(|s| {
+                s.lines()
+                    .find(|l| l.starts_with("model name"))
+                    .and_then(|l| l.split(':').nth(1))
+                    .map(|s| s.trim().to_string())
+            })
+            .unwrap_or_default()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        String::new()
+    }
+}
+
+/// Get total system memory in MB
+fn get_total_memory_mb() -> u64 {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("sysctl")
+            .args(["-n", "hw.memsize"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .map(|bytes| bytes / (1024 * 1024))
+            .unwrap_or(0)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/meminfo")
+            .ok()
+            .and_then(|s| {
+                s.lines().find(|l| l.starts_with("MemTotal")).and_then(|l| {
+                    l.split_whitespace()
+                        .nth(1)
+                        .and_then(|v| v.parse::<u64>().ok())
+                })
+            })
+            .map(|kb| kb / 1024)
+            .unwrap_or(0)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        0
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/qfc-rpc/src/qfc.rs
+++ b/crates/qfc-rpc/src/qfc.rs
@@ -714,6 +714,18 @@ pub struct RpcRegisteredMiner {
     pub vram_mb: u64,
     pub backend: String,
     pub registered_at: String,
+    /// Operating system: "linux", "macos", "windows"
+    pub os: String,
+    /// CPU architecture: "x86_64", "aarch64"
+    pub arch: String,
+    /// CPU model name (e.g. "Apple M2 Pro", "AMD Ryzen 9 7950X")
+    pub cpu_model: String,
+    /// Number of CPU cores
+    pub cpu_cores: u32,
+    /// Total system memory in MB
+    pub total_memory_mb: u64,
+    /// Miner software version (e.g. "2.2.1")
+    pub version: String,
 }
 
 // ============ v2.0 P2: Miner Registration & Status Report Types ============
@@ -736,6 +748,24 @@ pub struct RpcRegisterMinerRequest {
     pub backend: String,
     /// Ed25519 signature over (miner_address || gpu_model || benchmark_score)
     pub signature: String,
+    /// Operating system: "linux", "macos", "windows"
+    #[serde(default)]
+    pub os: String,
+    /// CPU architecture: "x86_64", "aarch64"
+    #[serde(default)]
+    pub arch: String,
+    /// CPU model name (e.g. "Apple M2 Pro")
+    #[serde(default)]
+    pub cpu_model: String,
+    /// Number of CPU cores
+    #[serde(default)]
+    pub cpu_cores: u32,
+    /// Total system memory in MB
+    #[serde(default)]
+    pub total_memory_mb: u64,
+    /// Miner software version
+    #[serde(default)]
+    pub version: String,
 }
 
 /// Result of miner registration

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -68,6 +68,12 @@ struct MinerProfile {
     vram_mb: u64,
     backend: String,
     registered_at: u64, // unix timestamp
+    os: String,
+    arch: String,
+    cpu_model: String,
+    cpu_cores: u32,
+    total_memory_mb: u64,
+    version: String,
 }
 
 /// RPC server
@@ -1419,6 +1425,12 @@ impl QfcApiServer for RpcServer {
                 vram_mb: req.vram_mb,
                 backend: req.backend.clone(),
                 registered_at: now,
+                os: req.os.clone(),
+                arch: req.arch.clone(),
+                cpu_model: req.cpu_model.clone(),
+                cpu_cores: req.cpu_cores,
+                total_memory_mb: req.total_memory_mb,
+                version: req.version.clone(),
             },
         );
 
@@ -1458,6 +1470,12 @@ impl QfcApiServer for RpcServer {
                 vram_mb: profile.vram_mb,
                 backend: profile.backend.clone(),
                 registered_at: profile.registered_at.to_string(),
+                os: profile.os.clone(),
+                arch: profile.arch.clone(),
+                cpu_model: profile.cpu_model.clone(),
+                cpu_cores: profile.cpu_cores,
+                total_memory_mb: profile.total_memory_mb,
+                version: profile.version.clone(),
             })
             .collect();
         // Sort by tier desc, then benchmark_score desc


### PR DESCRIPTION
## Summary
- Collect OS, arch, CPU model, CPU cores, total RAM, and miner version during `qfc_registerMiner`
- Store hardware profile in `MinerProfile` struct alongside existing fields
- Return hardware fields in `qfc_getRegisteredMiners` RPC response
- Platform-specific system info helpers (macOS: `sysctl`, Linux: `/proc/cpuinfo` + `/proc/meminfo`)
- `#[serde(default)]` on all new request fields for backward compatibility with older miners

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --all` passes
- [x] `cargo fmt` clean
- [ ] Deploy to testnet, verify miner registration includes hardware fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)