### PR TITLE
AI-V3 B-1: sharded model distribution (B0–B2)

### DIFF
--- a/crates/qfc-ai-coordinator/src/governance.rs
+++ b/crates/qfc-ai-coordinator/src/governance.rs
@@ -217,6 +217,7 @@ mod tests {
             approved: false,
             canonical_format: qfc_inference::CanonicalFormat::SafetensorsFp32,
             weights_hash: None,
+            shard_manifest: None,
         }
     }
 

--- a/crates/qfc-inference/build.rs
+++ b/crates/qfc-inference/build.rs
@@ -29,17 +29,14 @@ mod cuda {
 
             // Emit lib search paths — both lib/x64 (Windows) and lib64 (Linux)
             let lib_candidates = [
-                root.join("lib").join("x64"),   // Windows standard
-                root.join("lib64"),              // Linux standard
-                root.join("lib"),                // Fallback
+                root.join("lib").join("x64"), // Windows standard
+                root.join("lib64"),           // Linux standard
+                root.join("lib"),             // Fallback
             ];
 
             for lib_dir in &lib_candidates {
                 if lib_dir.is_dir() {
-                    println!(
-                        "cargo:rustc-link-search=native={}",
-                        lib_dir.display()
-                    );
+                    println!("cargo:rustc-link-search=native={}", lib_dir.display());
                 }
             }
 
@@ -48,10 +45,7 @@ mod cuda {
             {
                 let bin_dir = root.join("bin");
                 if bin_dir.is_dir() {
-                    println!(
-                        "cargo:rustc-link-search=native={}",
-                        bin_dir.display()
-                    );
+                    println!("cargo:rustc-link-search=native={}", bin_dir.display());
                 }
             }
         } else {
@@ -86,9 +80,11 @@ mod cuda {
         #[cfg(target_os = "windows")]
         {
             // Try versioned paths from newest to oldest
-            let program_files = std::env::var("ProgramFiles")
-                .unwrap_or_else(|_| r"C:\Program Files".to_string());
-            let cuda_base = Path::new(&program_files).join("NVIDIA GPU Computing Toolkit").join("CUDA");
+            let program_files =
+                std::env::var("ProgramFiles").unwrap_or_else(|_| r"C:\Program Files".to_string());
+            let cuda_base = Path::new(&program_files)
+                .join("NVIDIA GPU Computing Toolkit")
+                .join("CUDA");
 
             if cuda_base.is_dir() {
                 // Find the highest versioned directory

--- a/crates/qfc-inference/src/gpu_monitor.rs
+++ b/crates/qfc-inference/src/gpu_monitor.rs
@@ -273,11 +273,10 @@ fn get_windows_memory() -> (u64, u64) {
         .and_then(|o| {
             if o.status.success() {
                 let stdout = String::from_utf8_lossy(&o.stdout).to_string();
-                stdout.lines()
-                    .find_map(|line| {
-                        line.strip_prefix("TotalPhysicalMemory=")
-                            .and_then(|v| v.trim().parse::<u64>().ok())
-                    })
+                stdout.lines().find_map(|line| {
+                    line.strip_prefix("TotalPhysicalMemory=")
+                        .and_then(|v| v.trim().parse::<u64>().ok())
+                })
             } else {
                 None
             }
@@ -292,11 +291,10 @@ fn get_windows_memory() -> (u64, u64) {
         .and_then(|o| {
             if o.status.success() {
                 let stdout = String::from_utf8_lossy(&o.stdout).to_string();
-                stdout.lines()
-                    .find_map(|line| {
-                        line.strip_prefix("FreePhysicalMemory=")
-                            .and_then(|v| v.trim().parse::<u64>().ok())
-                    })
+                stdout.lines().find_map(|line| {
+                    line.strip_prefix("FreePhysicalMemory=")
+                        .and_then(|v| v.trim().parse::<u64>().ok())
+                })
             } else {
                 None
             }

--- a/crates/qfc-inference/src/lib.rs
+++ b/crates/qfc-inference/src/lib.rs
@@ -30,6 +30,7 @@ pub mod models;
 pub mod proof;
 pub mod runtime;
 pub mod scheduler;
+pub mod shard;
 pub mod task;
 
 pub use data_store::{DataRef, LocalDataStore, TaskData, MAX_INLINE_SIZE};
@@ -40,6 +41,7 @@ pub use runtime::{
     compute_benchmark_score, find_nvidia_smi, validate_gpu_claim, BackendType, BenchmarkResult,
     GpuTier, HardwareInfo,
 };
+pub use shard::{ShardDownloader, ShardEntry, ShardManifest};
 pub use task::{ComputeTaskType, InferenceTask, ModelId};
 
 use async_trait::async_trait;
@@ -71,6 +73,9 @@ pub enum InferenceError {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("Shard verification failed: {0}")]
+    ShardVerification(String),
 }
 
 /// Core inference engine trait — implemented by each backend

--- a/crates/qfc-inference/src/model.rs
+++ b/crates/qfc-inference/src/model.rs
@@ -61,7 +61,14 @@ pub struct ModelInfo {
     /// Blake3 hash of the model weight file (for integrity verification).
     /// If set, downloaded weights are verified against this hash.
     /// Prevents supply-chain attacks and ensures all miners use identical weights.
+    #[serde(default)]
     pub weights_hash: Option<qfc_types::Hash>,
+    /// Sharded distribution manifest (ADR-0001: sharded model distribution).
+    /// `None` means the existing single-artifact download path.
+    /// If both this and `weights_hash` are set, `shard_manifest.assembled_hash`
+    /// must equal `weights_hash` (checked at assembly time).
+    #[serde(default)]
+    pub shard_manifest: Option<crate::shard::ShardManifest>,
 }
 
 /// Local model cache with LRU eviction and auto-download
@@ -171,8 +178,23 @@ impl ModelCache {
 
             if let Some(id) = lru_id {
                 if let Some(entry) = self.cached.remove(&id) {
-                    // Best-effort delete from disk
-                    let _ = std::fs::remove_file(&entry.path);
+                    // Entry paths can be directories (sharded models register
+                    // the model dir; candle ensure_model registers a dir too)
+                    // or single files — delete accordingly, and surface
+                    // failures instead of silently leaking disk.
+                    let result = if entry.path.is_dir() {
+                        std::fs::remove_dir_all(&entry.path)
+                    } else {
+                        std::fs::remove_file(&entry.path)
+                    };
+                    if let Err(e) = result {
+                        tracing::warn!(
+                            "Failed to delete evicted model {} at {}: {}",
+                            id,
+                            entry.path.display(),
+                            e
+                        );
+                    }
                     tracing::info!(
                         "Evicted model {} ({} bytes) from cache",
                         id,
@@ -227,6 +249,53 @@ impl ModelCache {
 
         Ok(model_dir)
     }
+
+    /// Ensure a sharded model is cached, downloading and assembling its
+    /// shards if necessary (ADR-0001 / Roadmap AI-V3 B-1).
+    ///
+    /// Requires `info.shard_manifest` to be set. If `info.weights_hash` is
+    /// also set, it must equal the manifest's `assembled_hash`.
+    /// Returns the model directory containing the assembled `weights.bin`.
+    pub fn ensure_sharded_model(
+        &mut self,
+        info: &ModelInfo,
+        downloader: &crate::shard::ShardDownloader,
+    ) -> Result<PathBuf, crate::InferenceError> {
+        // Already cached — return path
+        if let Some(entry) = self.cached.get_mut(&info.id) {
+            entry.last_accessed = now_ms();
+            return Ok(entry.path.clone());
+        }
+
+        let manifest = info.shard_manifest.as_ref().ok_or_else(|| {
+            crate::InferenceError::ModelNotFound(format!(
+                "Model {} has no shard manifest (use the single-artifact path instead)",
+                info.id
+            ))
+        })?;
+
+        // ADR-0001 Decision 1: if both are set, they must agree.
+        if let Some(weights_hash) = info.weights_hash {
+            if weights_hash != manifest.assembled_hash {
+                return Err(crate::InferenceError::ShardVerification(format!(
+                    "Model {}: weights_hash {} does not match manifest assembled_hash {}",
+                    info.id, weights_hash, manifest.assembled_hash
+                )));
+            }
+        }
+
+        let model_dir = self
+            .cache_dir
+            .join(format!("{}-{}", info.id.name, info.id.version));
+        let dest = model_dir.join("weights.bin");
+
+        downloader.download_and_assemble(manifest, &dest)?;
+
+        self.register(info.id.clone(), model_dir.clone(), manifest.total_size_bytes);
+        self.evict_lru();
+
+        Ok(model_dir)
+    }
 }
 
 /// Approved model registry (controlled by on-chain governance)
@@ -259,6 +328,7 @@ impl ModelRegistry {
                 approved: true,
                 canonical_format: CanonicalFormat::SafetensorsFp32,
                 weights_hash: None,
+                shard_manifest: None,
             },
             ModelInfo {
                 id: ModelId::new("qfc-embed-medium", "v1.0"),
@@ -270,6 +340,7 @@ impl ModelRegistry {
                 approved: true,
                 canonical_format: CanonicalFormat::SafetensorsFp32,
                 weights_hash: None,
+                shard_manifest: None,
             },
             ModelInfo {
                 id: ModelId::new("qfc-classify-small", "v1.0"),
@@ -281,6 +352,7 @@ impl ModelRegistry {
                 approved: true,
                 canonical_format: CanonicalFormat::SafetensorsFp32,
                 weights_hash: None,
+                shard_manifest: None,
             },
             ModelInfo {
                 id: ModelId::new("qfc-llm-0.5b", "v1.0"),
@@ -293,6 +365,7 @@ impl ModelRegistry {
                 approved: true,
                 canonical_format: CanonicalFormat::SafetensorsFp32,
                 weights_hash: None,
+                shard_manifest: None,
             },
             ModelInfo {
                 id: ModelId::new("qfc-llm-3b", "v1.0"),
@@ -305,6 +378,7 @@ impl ModelRegistry {
                 approved: true,
                 canonical_format: CanonicalFormat::GgufQ4KM,
                 weights_hash: None,
+                shard_manifest: None,
             },
             ModelInfo {
                 id: ModelId::new("qfc-llm-7b", "v1.0"),
@@ -317,6 +391,7 @@ impl ModelRegistry {
                 approved: true,
                 canonical_format: CanonicalFormat::GgufQ4KM,
                 weights_hash: None,
+                shard_manifest: None,
             },
             ModelInfo {
                 id: ModelId::new("qfc-whisper-base", "v1.0"),
@@ -328,6 +403,7 @@ impl ModelRegistry {
                 approved: true,
                 canonical_format: CanonicalFormat::SafetensorsFp32,
                 weights_hash: None,
+                shard_manifest: None,
             },
             ModelInfo {
                 id: ModelId::new("qfc-whisper-large", "v1.0"),
@@ -339,6 +415,7 @@ impl ModelRegistry {
                 approved: true,
                 canonical_format: CanonicalFormat::SafetensorsFp32,
                 weights_hash: None,
+                shard_manifest: None,
             },
             ModelInfo {
                 id: ModelId::new("qfc-sd-1.5", "v1.0"),
@@ -351,6 +428,7 @@ impl ModelRegistry {
                 approved: true,
                 canonical_format: CanonicalFormat::SafetensorsFp32,
                 weights_hash: None,
+                shard_manifest: None,
             },
         ];
 
@@ -437,7 +515,7 @@ mod tests {
 
         // Add 3 models, each 1MB
         for i in 0..3 {
-            let id = ModelId::new(&format!("model-{}", i), "v1");
+            let id = ModelId::new(format!("model-{}", i), "v1");
             cache.register(
                 id,
                 PathBuf::from(format!("/tmp/models/m{}.bin", i)),
@@ -446,7 +524,7 @@ mod tests {
             // Stagger last_accessed so eviction order is deterministic
             if let Some(entry) = cache
                 .cached
-                .get_mut(&ModelId::new(&format!("model-{}", i), "v1"))
+                .get_mut(&ModelId::new(format!("model-{}", i), "v1"))
             {
                 entry.last_accessed = i as u64;
             }
@@ -461,6 +539,32 @@ mod tests {
         assert!(!cache.is_cached(&ModelId::new("model-0", "v1")));
         assert!(cache.is_cached(&ModelId::new("model-1", "v1")));
         assert!(cache.is_cached(&ModelId::new("model-2", "v1")));
+    }
+
+    #[test]
+    fn test_evict_lru_removes_directory_from_disk() {
+        let dir = std::env::temp_dir().join(format!("qfc_evict_dir_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // A real model directory containing a file (sharded models register
+        // the model dir as the cache entry path).
+        let model_dir = dir.join("test-sharded-v1.0");
+        std::fs::create_dir_all(&model_dir).unwrap();
+        std::fs::write(model_dir.join("weights.bin"), vec![0u8; 256]).unwrap();
+
+        let mut cache = ModelCache::with_max_size(dir.clone(), 100);
+        cache.register(ModelId::new("test-sharded", "v1.0"), model_dir.clone(), 256);
+        assert!(cache.total_size_bytes() > 100);
+
+        let evicted = cache.evict_lru();
+        assert_eq!(evicted, 1);
+        assert!(
+            !model_dir.exists(),
+            "evicted model directory must be deleted from disk"
+        );
+        assert!(!cache.is_cached(&ModelId::new("test-sharded", "v1.0")));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -484,6 +588,116 @@ mod tests {
         // Hot tier: all models (Warm + llm-7b)
         let hot_models = registry.models_for_tier(GpuTier::Hot);
         assert_eq!(hot_models.len(), 9);
+    }
+
+    fn sharded_test_model(manifest: crate::shard::ShardManifest) -> ModelInfo {
+        ModelInfo {
+            id: ModelId::new("test-sharded", "v1.0"),
+            description: "Sharded test model".to_string(),
+            min_memory_mb: 512,
+            min_tier: GpuTier::Cold,
+            size_mb: 1,
+            approved: true,
+            canonical_format: CanonicalFormat::SafetensorsFp32,
+            weights_hash: Some(manifest.assembled_hash),
+            shard_manifest: Some(manifest),
+        }
+    }
+
+    #[test]
+    fn test_ensure_sharded_model_pre_seeded() {
+        let dir = std::env::temp_dir().join(format!("qfc_sharded_model_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let downloader =
+            crate::shard::ShardDownloader::new("http://invalid.invalid:1", dir.join("shards"))
+                .unwrap();
+
+        // Pre-seed two shards in the store — no network needed.
+        let shard_a: Vec<u8> = vec![0x01; 800];
+        let shard_b: Vec<u8> = vec![0x02; 300];
+        downloader.store().put(&shard_a).unwrap();
+        downloader.store().put(&shard_b).unwrap();
+
+        let mut full = shard_a.clone();
+        full.extend_from_slice(&shard_b);
+        let manifest = crate::shard::ShardManifest {
+            shards: vec![
+                crate::shard::ShardEntry {
+                    cid: String::new(),
+                    hash: qfc_crypto::blake3_hash(&shard_a),
+                    size_bytes: shard_a.len() as u64,
+                    layer_range: None,
+                },
+                crate::shard::ShardEntry {
+                    cid: String::new(),
+                    hash: qfc_crypto::blake3_hash(&shard_b),
+                    size_bytes: shard_b.len() as u64,
+                    layer_range: None,
+                },
+            ],
+            total_size_bytes: full.len() as u64,
+            assembled_hash: qfc_crypto::blake3_hash(&full),
+        };
+        let info = sharded_test_model(manifest.clone());
+
+        let mut cache = ModelCache::new(dir.join("models"));
+        let model_dir = cache.ensure_sharded_model(&info, &downloader).unwrap();
+
+        // Assembled file exists, content hash-checks, model is registered.
+        let weights_path = model_dir.join("weights.bin");
+        assert!(weights_path.exists());
+        let assembled = std::fs::read(&weights_path).unwrap();
+        assert_eq!(qfc_crypto::blake3_hash(&assembled), manifest.assembled_hash);
+        assert!(cache.is_cached(&info.id));
+        assert_eq!(cache.total_size_bytes(), manifest.total_size_bytes);
+
+        // Second call hits the cache and returns the same path.
+        let again = cache.ensure_sharded_model(&info, &downloader).unwrap();
+        assert_eq!(again, model_dir);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_ensure_sharded_model_weights_hash_mismatch() {
+        let dir =
+            std::env::temp_dir().join(format!("qfc_sharded_mismatch_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let downloader =
+            crate::shard::ShardDownloader::new("http://invalid.invalid:1", dir.join("shards"))
+                .unwrap();
+
+        let shard: Vec<u8> = vec![0x05; 128];
+        downloader.store().put(&shard).unwrap();
+        let manifest = crate::shard::ShardManifest {
+            shards: vec![crate::shard::ShardEntry {
+                cid: String::new(),
+                hash: qfc_crypto::blake3_hash(&shard),
+                size_bytes: shard.len() as u64,
+                layer_range: None,
+            }],
+            total_size_bytes: shard.len() as u64,
+            assembled_hash: qfc_crypto::blake3_hash(&shard),
+        };
+
+        let mut info = sharded_test_model(manifest);
+        // Registry weights_hash disagrees with the manifest — must be rejected.
+        info.weights_hash = Some(qfc_types::Hash::new([0x99; 32]));
+
+        let mut cache = ModelCache::new(dir.join("models"));
+        let err = cache.ensure_sharded_model(&info, &downloader).unwrap_err();
+        assert!(err.to_string().contains("does not match"));
+        assert!(!cache.is_cached(&info.id));
+
+        // Missing manifest → ModelNotFound-style error.
+        info.weights_hash = None;
+        info.shard_manifest = None;
+        let err = cache.ensure_sharded_model(&info, &downloader).unwrap_err();
+        assert!(err.to_string().contains("no shard manifest"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/qfc-inference/src/model.rs
+++ b/crates/qfc-inference/src/model.rs
@@ -291,7 +291,11 @@ impl ModelCache {
 
         downloader.download_and_assemble(manifest, &dest)?;
 
-        self.register(info.id.clone(), model_dir.clone(), manifest.total_size_bytes);
+        self.register(
+            info.id.clone(),
+            model_dir.clone(),
+            manifest.total_size_bytes,
+        );
         self.evict_lru();
 
         Ok(model_dir)
@@ -661,8 +665,7 @@ mod tests {
 
     #[test]
     fn test_ensure_sharded_model_weights_hash_mismatch() {
-        let dir =
-            std::env::temp_dir().join(format!("qfc_sharded_mismatch_{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("qfc_sharded_mismatch_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
 
         let downloader =

--- a/crates/qfc-inference/src/runtime.rs
+++ b/crates/qfc-inference/src/runtime.rs
@@ -427,7 +427,11 @@ fn detect_cuda_hardware() -> (u64, u32, String) {
         _ => {
             // Fallback: report system memory / 4 as rough GPU estimate
             let mem = get_system_memory_mb();
-            (mem / 4, 0, "NVIDIA GPU (nvidia-smi unavailable)".to_string())
+            (
+                mem / 4,
+                0,
+                "NVIDIA GPU (nvidia-smi unavailable)".to_string(),
+            )
         }
     }
 }
@@ -437,16 +441,18 @@ pub fn find_nvidia_smi() -> String {
     #[cfg(target_os = "windows")]
     {
         // nvidia-smi is installed by the NVIDIA driver into System32
-        let sys32 = std::env::var("SystemRoot")
-            .unwrap_or_else(|_| r"C:\Windows".to_string());
-        let sys32_path =
-            std::path::Path::new(&sys32).join("System32").join("nvidia-smi.exe");
+        let sys32 = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
+        let sys32_path = std::path::Path::new(&sys32)
+            .join("System32")
+            .join("nvidia-smi.exe");
         if sys32_path.exists() {
             return sys32_path.to_string_lossy().to_string();
         }
         // Also check CUDA_PATH\bin
         if let Ok(cuda) = std::env::var("CUDA_PATH") {
-            let cuda_bin = std::path::Path::new(&cuda).join("bin").join("nvidia-smi.exe");
+            let cuda_bin = std::path::Path::new(&cuda)
+                .join("bin")
+                .join("nvidia-smi.exe");
             if cuda_bin.exists() {
                 return cuda_bin.to_string_lossy().to_string();
             }
@@ -535,8 +541,11 @@ fn get_windows_memory_mb() -> u64 {
 
     // Method 2: PowerShell (fallback)
     if let Ok(output) = std::process::Command::new("powershell")
-        .args(["-NoProfile", "-Command",
-               "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"])
+        .args([
+            "-NoProfile",
+            "-Command",
+            "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory",
+        ])
         .output()
     {
         if output.status.success() {

--- a/crates/qfc-inference/src/shard.rs
+++ b/crates/qfc-inference/src/shard.rs
@@ -25,9 +25,7 @@ use crate::data_store::LocalDataStore;
 use crate::InferenceError;
 
 /// One byte-range shard of a model weight file.
-#[derive(
-    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct ShardEntry {
     /// IPFS CID of the shard bytes (empty until published to IPFS)
     pub cid: String,
@@ -44,9 +42,7 @@ pub struct ShardEntry {
 ///
 /// Concatenating the shards in order yields the weight file; its Blake3
 /// hash must equal `assembled_hash` (and `ModelInfo::weights_hash` when set).
-#[derive(
-    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct ShardManifest {
     /// Shards in file order (concatenation order = byte order)
     pub shards: Vec<ShardEntry>,
@@ -106,7 +102,11 @@ impl ShardManifest {
         }
 
         // Layer ranges: all-or-none, each non-empty, contiguous and in order.
-        let with_range = self.shards.iter().filter(|s| s.layer_range.is_some()).count();
+        let with_range = self
+            .shards
+            .iter()
+            .filter(|s| s.layer_range.is_some())
+            .count();
         if with_range > 0 {
             if with_range != self.shards.len() {
                 return Err(InferenceError::ShardVerification(
@@ -716,7 +716,9 @@ mod tests {
 
     #[test]
     fn test_validate_rejects_invalid_cid() {
-        for bad_cid in ["../evil", "Qm/Foo", "cid?x=1", "cid#frag", "cid%2e", "cid foo"] {
+        for bad_cid in [
+            "../evil", "Qm/Foo", "cid?x=1", "cid#frag", "cid%2e", "cid foo",
+        ] {
             let mut entry = make_entry(b"abc");
             entry.cid = bad_cid.to_string();
             let manifest = ShardManifest {
@@ -734,7 +736,11 @@ mod tests {
         }
 
         // Valid CIDv0/CIDv1 shapes (and the pre-upload empty cid) pass.
-        for ok_cid in ["QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG", "bafybeigdyrzt5", ""] {
+        for ok_cid in [
+            "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+            "bafybeigdyrzt5",
+            "",
+        ] {
             let mut entry = make_entry(b"abc");
             entry.cid = ok_cid.to_string();
             let manifest = ShardManifest {
@@ -742,7 +748,11 @@ mod tests {
                 total_size_bytes: 3,
                 assembled_hash: Hash::ZERO,
             };
-            assert!(manifest.validate().is_ok(), "cid {:?} should be valid", ok_cid);
+            assert!(
+                manifest.validate().is_ok(),
+                "cid {:?} should be valid",
+                ok_cid
+            );
         }
     }
 
@@ -823,7 +833,8 @@ mod tests {
     fn test_tampered_shard_fails_integrity() {
         let dir = test_dir("tamper");
         let shard_dir = dir.join("shards");
-        let downloader = ShardDownloader::new("http://invalid.invalid:1", shard_dir.clone()).unwrap();
+        let downloader =
+            ShardDownloader::new("http://invalid.invalid:1", shard_dir.clone()).unwrap();
 
         let shard: Vec<u8> = vec![0x33; 512];
         let data_ref = downloader.store().put(&shard).unwrap();

--- a/crates/qfc-inference/src/shard.rs
+++ b/crates/qfc-inference/src/shard.rs
@@ -1,0 +1,855 @@
+//! Sharded model distribution (ADR-0001, Roadmap AI-V3 milestone B-1)
+//!
+//! Large model weight files are split into verifiable byte-range shards.
+//! Each shard is content-addressed by its Blake3 hash and fetched from an
+//! IPFS gateway by CID. Shards live in a [`LocalDataStore`] keyed by hash,
+//! which gives resumable downloads (already-present shards are skipped) and
+//! cross-version reuse (a fine-tune that only changed some layers re-uses
+//! the byte-identical shards already on disk).
+//!
+//! Flow (ADR-0001 Decision 4):
+//! 1. For each manifest entry: skip if cached, else fetch `<gateway>/ipfs/<cid>`
+//!    via curl and verify `blake3(bytes) == entry.hash` before storing.
+//! 2. Assemble: concatenate shards in manifest order into a temp file while
+//!    streaming a Blake3 hash; verify against `assembled_hash`; atomic rename.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use qfc_types::Hash;
+use serde::{Deserialize, Serialize};
+
+use crate::data_store::LocalDataStore;
+use crate::InferenceError;
+
+/// One byte-range shard of a model weight file.
+#[derive(
+    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct ShardEntry {
+    /// IPFS CID of the shard bytes (empty until published to IPFS)
+    pub cid: String,
+    /// Blake3 hash of the shard bytes (verification key)
+    pub hash: Hash,
+    /// Size of the shard in bytes
+    pub size_bytes: u64,
+    /// Optional `[start, end)` layer range covered by this shard.
+    /// Metadata only in B-1; B-2 pipeline execution will use it.
+    pub layer_range: Option<(u32, u32)>,
+}
+
+/// Ordered list of shards describing a complete model weight file.
+///
+/// Concatenating the shards in order yields the weight file; its Blake3
+/// hash must equal `assembled_hash` (and `ModelInfo::weights_hash` when set).
+#[derive(
+    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct ShardManifest {
+    /// Shards in file order (concatenation order = byte order)
+    pub shards: Vec<ShardEntry>,
+    /// Total size of the assembled file in bytes (must equal sum of shard sizes)
+    pub total_size_bytes: u64,
+    /// Blake3 hash of the assembled (concatenated) file
+    pub assembled_hash: Hash,
+}
+
+impl ShardManifest {
+    /// Validate structural invariants of the manifest.
+    ///
+    /// Checks: non-empty shard list, no zero-size shards, shard sizes sum to
+    /// `total_size_bytes`, CIDs are alphanumeric (or empty), and layer ranges
+    /// (if used) are present on every shard, non-empty, contiguous, and
+    /// non-overlapping in order.
+    pub fn validate(&self) -> Result<(), InferenceError> {
+        if self.shards.is_empty() {
+            return Err(InferenceError::ShardVerification(
+                "Invalid shard manifest: shard list is empty".to_string(),
+            ));
+        }
+
+        let mut sum: u64 = 0;
+        for (i, shard) in self.shards.iter().enumerate() {
+            if shard.size_bytes == 0 {
+                return Err(InferenceError::ShardVerification(format!(
+                    "Invalid shard manifest: shard {} has zero size",
+                    i
+                )));
+            }
+            // Non-empty CIDs must be purely alphanumeric ([A-Za-z0-9]+). This
+            // covers base58btc CIDv0 ("Qm...") and lowercase base32 CIDv1
+            // ("bafy...") while rejecting `/ . ? # %` and friends — which is
+            // what makes interpolating the cid into the gateway URL
+            // (`<gateway>/ipfs/<cid>`) safe from path traversal and query
+            // injection. An empty cid stays allowed: it is the publisher's
+            // pre-upload state (`split_file` emits empty cids); fetching such
+            // an entry is rejected separately in `ensure_shard`.
+            if !shard.cid.is_empty() && !shard.cid.bytes().all(|b| b.is_ascii_alphanumeric()) {
+                return Err(InferenceError::ShardVerification(format!(
+                    "Invalid shard manifest: shard {} cid {:?} contains characters outside [A-Za-z0-9]",
+                    i, shard.cid
+                )));
+            }
+            sum = sum.checked_add(shard.size_bytes).ok_or_else(|| {
+                InferenceError::ShardVerification(
+                    "Invalid shard manifest: shard sizes overflow u64".to_string(),
+                )
+            })?;
+        }
+        if sum != self.total_size_bytes {
+            return Err(InferenceError::ShardVerification(format!(
+                "Invalid shard manifest: shard sizes sum to {} but total_size_bytes is {}",
+                sum, self.total_size_bytes
+            )));
+        }
+
+        // Layer ranges: all-or-none, each non-empty, contiguous and in order.
+        let with_range = self.shards.iter().filter(|s| s.layer_range.is_some()).count();
+        if with_range > 0 {
+            if with_range != self.shards.len() {
+                return Err(InferenceError::ShardVerification(
+                    "Invalid shard manifest: layer_range must be set on all shards or none"
+                        .to_string(),
+                ));
+            }
+            let mut prev_end: Option<u32> = None;
+            for (i, shard) in self.shards.iter().enumerate() {
+                let (start, end) = shard.layer_range.expect("checked above");
+                if start >= end {
+                    return Err(InferenceError::ShardVerification(format!(
+                        "Invalid shard manifest: shard {} has empty layer range [{}, {})",
+                        i, start, end
+                    )));
+                }
+                if let Some(prev) = prev_end {
+                    if start != prev {
+                        return Err(InferenceError::ShardVerification(format!(
+                            "Invalid shard manifest: shard {} layer range starts at {} but previous shard ends at {} (ranges must be contiguous and non-overlapping)",
+                            i, start, prev
+                        )));
+                    }
+                }
+                prev_end = Some(end);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Split a weight file into `shard_size`-byte shards (governance/publishing
+    /// helper). Reads the file in chunks — never loads it whole into memory.
+    ///
+    /// The returned entries have empty `cid` (filled in by the publisher after
+    /// uploading each shard to IPFS) and no `layer_range`.
+    pub fn split_file(path: &Path, shard_size: u64) -> Result<ShardManifest, InferenceError> {
+        if shard_size == 0 {
+            return Err(InferenceError::ExecutionFailed(
+                "Cannot split file: shard_size must be > 0".to_string(),
+            ));
+        }
+
+        let mut file = std::fs::File::open(path)?;
+        let mut whole_hasher = blake3::Hasher::new();
+        let mut shards = Vec::new();
+        let mut total_size_bytes: u64 = 0;
+
+        loop {
+            let mut chunk = Vec::with_capacity(shard_size.min(64 * 1024 * 1024) as usize);
+            let n = (&mut file).take(shard_size).read_to_end(&mut chunk)?;
+            if n == 0 {
+                break;
+            }
+            whole_hasher.update(&chunk);
+            shards.push(ShardEntry {
+                cid: String::new(),
+                hash: qfc_crypto::blake3_hash(&chunk),
+                size_bytes: n as u64,
+                layer_range: None,
+            });
+            total_size_bytes += n as u64;
+        }
+
+        if shards.is_empty() {
+            return Err(InferenceError::ExecutionFailed(format!(
+                "Cannot split file {}: file is empty",
+                path.display()
+            )));
+        }
+
+        Ok(ShardManifest {
+            shards,
+            total_size_bytes,
+            assembled_hash: Hash::new(*whole_hasher.finalize().as_bytes()),
+        })
+    }
+}
+
+/// Downloads manifest shards from an IPFS gateway into a content-addressed
+/// shard store and assembles them into the final weight file (ADR-0001).
+pub struct ShardDownloader {
+    /// IPFS gateway base URL (e.g. `http://127.0.0.1:8080`)
+    gateway_url: String,
+    /// Content-addressed shard store (`<shard_dir>/<hash>`)
+    store: LocalDataStore,
+    /// Private shard store directory. Download temp files live here too —
+    /// not in the world-writable system temp dir, where a pre-planted
+    /// symlink or a colliding name could clobber/redirect the write.
+    shard_dir: PathBuf,
+}
+
+/// Monotonic counter making download temp-file names unique per attempt,
+/// even across threads in the same process.
+static TMP_ATTEMPT: AtomicU64 = AtomicU64::new(0);
+
+impl ShardDownloader {
+    /// Create a downloader fetching from `gateway_url` and caching shards in `shard_dir`.
+    pub fn new(gateway_url: impl Into<String>, shard_dir: PathBuf) -> Result<Self, InferenceError> {
+        Ok(Self {
+            gateway_url: gateway_url.into(),
+            store: LocalDataStore::new(shard_dir.clone())?,
+            shard_dir,
+        })
+    }
+
+    /// Access the underlying shard store (e.g. for pre-seeding or cleanup).
+    pub fn store(&self) -> &LocalDataStore {
+        &self.store
+    }
+
+    /// Ensure a shard is present in the local store, fetching it from the
+    /// gateway if missing. Already-cached shards are never re-downloaded —
+    /// this is what makes downloads resumable and shards reusable across
+    /// model versions (ADR-0001 Decision 3).
+    pub fn ensure_shard(&self, entry: &ShardEntry) -> Result<(), InferenceError> {
+        if self.store.contains(&entry.hash) {
+            tracing::debug!("Shard {} already cached, skipping fetch", entry.hash);
+            return Ok(());
+        }
+
+        // An empty cid is the publisher's pre-upload state — there is no
+        // valid gateway URL to construct, so refuse instead of fetching
+        // `<gateway>/ipfs/` (a garbage URL).
+        if entry.cid.is_empty() {
+            return Err(InferenceError::ExecutionFailed(format!(
+                "Cannot fetch shard {}: manifest entry has an empty cid (shard not yet published to IPFS)",
+                entry.hash
+            )));
+        }
+
+        let url = shard_url(&self.gateway_url, &entry.cid);
+        // Temp file inside the private shard store dir (not the shared system
+        // temp dir), named uniquely per attempt: pid distinguishes processes,
+        // the atomic counter distinguishes threads/retries within a process.
+        let attempt = TMP_ATTEMPT.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = self.shard_dir.join(format!(
+            ".qfc-shard-{}-{}-{}.part",
+            std::process::id(),
+            attempt,
+            entry.hash
+        ));
+
+        let fetch_result = fetch_url(&url, &tmp_path, entry.size_bytes);
+        if let Err(e) = fetch_result {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(e);
+        }
+
+        // Stat the downloaded file BEFORE reading it into memory: curl's
+        // --max-filesize is ignored for chunked transfer-encoding, so this
+        // check is the real bound on how much attacker-controlled data we
+        // are willing to load and hash.
+        let actual_size = match std::fs::metadata(&tmp_path) {
+            Ok(m) => m.len(),
+            Err(e) => {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(e.into());
+            }
+        };
+        if actual_size != entry.size_bytes {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(InferenceError::ShardVerification(format!(
+                "Shard size mismatch for cid {}: expected {} bytes, downloaded {}",
+                entry.cid, entry.size_bytes, actual_size
+            )));
+        }
+
+        let bytes = match std::fs::read(&tmp_path) {
+            Ok(b) => b,
+            Err(e) => {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(e.into());
+            }
+        };
+        let _ = std::fs::remove_file(&tmp_path);
+
+        let actual_hash = qfc_crypto::blake3_hash(&bytes);
+        if actual_hash != entry.hash {
+            return Err(InferenceError::ShardVerification(format!(
+                "Shard hash mismatch for cid {}: expected {}, got {}",
+                entry.cid, entry.hash, actual_hash
+            )));
+        }
+
+        self.store.put(&bytes)?;
+        Ok(())
+    }
+
+    /// Download all manifest shards (skipping cached ones) and assemble them
+    /// into `dest`, verifying the streamed Blake3 of the assembled file
+    /// against `manifest.assembled_hash`. Idempotent: if `dest` already
+    /// exists with the expected hash, returns immediately.
+    pub fn download_and_assemble(
+        &self,
+        manifest: &ShardManifest,
+        dest: &Path,
+    ) -> Result<(), InferenceError> {
+        manifest.validate()?;
+
+        // Idempotent early return: dest already assembled and intact.
+        if dest.exists() && file_blake3(dest)? == manifest.assembled_hash {
+            tracing::info!(
+                "Assembled model already present at {} with matching hash, skipping",
+                dest.display()
+            );
+            return Ok(());
+        }
+
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let total = manifest.shards.len();
+        for (i, entry) in manifest.shards.iter().enumerate() {
+            tracing::info!(
+                "Ensuring shard {}/{} ({} bytes, cid {})",
+                i + 1,
+                total,
+                entry.size_bytes,
+                entry.cid
+            );
+            self.ensure_shard(entry)?;
+        }
+
+        // Assemble: concatenate shards in order into a temp file while
+        // streaming the Blake3 hash, then atomic rename into place.
+        let tmp_path = dest.with_extension("tmp");
+        let mut hasher = blake3::Hasher::new();
+        {
+            let mut file = std::fs::File::create(&tmp_path)?;
+            for entry in &manifest.shards {
+                let bytes = match self.store.get(&entry.hash) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        let _ = std::fs::remove_file(&tmp_path);
+                        return Err(e);
+                    }
+                };
+                hasher.update(&bytes);
+                if let Err(e) = file.write_all(&bytes) {
+                    let _ = std::fs::remove_file(&tmp_path);
+                    return Err(e.into());
+                }
+            }
+            let assembled = Hash::new(*hasher.finalize().as_bytes());
+            if assembled != manifest.assembled_hash {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(InferenceError::ShardVerification(format!(
+                    "Assembled file hash mismatch: expected {}, got {}",
+                    manifest.assembled_hash, assembled
+                )));
+            }
+            if let Err(e) = file.sync_all() {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(e.into());
+            }
+        }
+        std::fs::rename(&tmp_path, dest)?;
+
+        tracing::info!(
+            "Assembled {} shards ({} bytes) into {}",
+            total,
+            manifest.total_size_bytes,
+            dest.display()
+        );
+        Ok(())
+    }
+}
+
+/// Build the gateway fetch URL for a shard CID: `<gateway>/ipfs/<cid>`.
+fn shard_url(gateway_url: &str, cid: &str) -> String {
+    format!("{}/ipfs/{}", gateway_url.trim_end_matches('/'), cid)
+}
+
+/// Fetch a URL to a destination file via `curl -sfL` (same convention as
+/// `download.rs` and `qfc-ai-coordinator/src/ipfs.rs`), bounded in size and
+/// time.
+///
+/// - `--max-filesize` caps the transfer at the manifest-declared shard size.
+///   curl ignores it for chunked transfer-encoding, so the caller MUST also
+///   stat the result against `max_size_bytes` — that check is the real
+///   guarantee; this flag just aborts obviously-oversized transfers early.
+/// - `--max-time 300` is a fixed wall-clock ceiling rather than one computed
+///   from size: shards are bounded artifacts (publishers split big weight
+///   files into many shards precisely so each download is small), and a
+///   fixed ceiling keeps behavior predictable while still preventing a
+///   stalled or throttled gateway from hanging a miner indefinitely.
+fn fetch_url(url: &str, dest: &Path, max_size_bytes: u64) -> Result<(), InferenceError> {
+    let output = std::process::Command::new("curl")
+        .args(["-sfL", "--max-time", "300", "--max-filesize"])
+        .arg(max_size_bytes.to_string())
+        .arg("-o")
+        .arg(dest)
+        .arg(url)
+        .output()
+        .map_err(|e| {
+            InferenceError::ExecutionFailed(format!("Failed to spawn curl for {}: {}", url, e))
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(InferenceError::ExecutionFailed(format!(
+            "Failed to fetch shard from {}: curl exited with {} ({})",
+            url,
+            output.status,
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Streaming Blake3 hash of a file on disk.
+fn file_blake3(path: &Path) -> Result<Hash, InferenceError> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    std::io::copy(&mut file, &mut hasher)?;
+    Ok(Hash::new(*hasher.finalize().as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("qfc_shard_{}_{}", name, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn make_entry(data: &[u8]) -> ShardEntry {
+        ShardEntry {
+            cid: String::new(),
+            hash: qfc_crypto::blake3_hash(data),
+            size_bytes: data.len() as u64,
+            layer_range: None,
+        }
+    }
+
+    #[test]
+    fn test_shard_url_join() {
+        assert_eq!(
+            shard_url("http://127.0.0.1:8080", "QmFoo"),
+            "http://127.0.0.1:8080/ipfs/QmFoo"
+        );
+        assert_eq!(
+            shard_url("http://127.0.0.1:8080/", "QmFoo"),
+            "http://127.0.0.1:8080/ipfs/QmFoo"
+        );
+    }
+
+    #[test]
+    fn test_split_file_round_trip() {
+        let dir = test_dir("split");
+        let file_path = dir.join("weights.bin");
+        // 2500 bytes with a non-trivial pattern → shards of 1000, 1000, 500
+        let data: Vec<u8> = (0..2500u32).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&file_path, &data).unwrap();
+
+        let manifest = ShardManifest::split_file(&file_path, 1000).unwrap();
+        manifest.validate().unwrap();
+
+        assert_eq!(manifest.shards.len(), 3);
+        assert_eq!(manifest.total_size_bytes, 2500);
+        assert_eq!(manifest.shards[0].size_bytes, 1000);
+        assert_eq!(manifest.shards[1].size_bytes, 1000);
+        assert_eq!(manifest.shards[2].size_bytes, 500); // last-shard remainder
+        assert_eq!(manifest.assembled_hash, qfc_crypto::blake3_hash(&data));
+        assert_eq!(
+            manifest.shards[0].hash,
+            qfc_crypto::blake3_hash(&data[..1000])
+        );
+        assert_eq!(
+            manifest.shards[2].hash,
+            qfc_crypto::blake3_hash(&data[2000..])
+        );
+        assert!(manifest.shards.iter().all(|s| s.cid.is_empty()));
+        assert!(manifest.shards.iter().all(|s| s.layer_range.is_none()));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_split_file_rejects_zero_shard_size_and_empty_file() {
+        let dir = test_dir("split_reject");
+        let file_path = dir.join("weights.bin");
+        std::fs::write(&file_path, b"data").unwrap();
+        assert!(ShardManifest::split_file(&file_path, 0).is_err());
+
+        let empty_path = dir.join("empty.bin");
+        std::fs::write(&empty_path, b"").unwrap();
+        assert!(ShardManifest::split_file(&empty_path, 100).is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_validate_rejections() {
+        // Empty
+        let empty = ShardManifest {
+            shards: vec![],
+            total_size_bytes: 0,
+            assembled_hash: Hash::ZERO,
+        };
+        assert!(empty.validate().is_err());
+
+        // Size mismatch
+        let mismatch = ShardManifest {
+            shards: vec![make_entry(b"abc")],
+            total_size_bytes: 99,
+            assembled_hash: Hash::ZERO,
+        };
+        assert!(mismatch.validate().is_err());
+
+        // Zero-size shard
+        let zero = ShardManifest {
+            shards: vec![ShardEntry {
+                cid: String::new(),
+                hash: Hash::ZERO,
+                size_bytes: 0,
+                layer_range: None,
+            }],
+            total_size_bytes: 0,
+            assembled_hash: Hash::ZERO,
+        };
+        assert!(zero.validate().is_err());
+
+        // layer_range on some shards but not all
+        let mut e1 = make_entry(b"aaa");
+        e1.layer_range = Some((0, 4));
+        let e2 = make_entry(b"bbb");
+        let partial = ShardManifest {
+            shards: vec![e1.clone(), e2.clone()],
+            total_size_bytes: 6,
+            assembled_hash: Hash::ZERO,
+        };
+        assert!(partial.validate().is_err());
+
+        // Overlapping layer ranges
+        let mut e2_overlap = e2.clone();
+        e2_overlap.layer_range = Some((2, 8)); // overlaps [0,4)
+        let overlapping = ShardManifest {
+            shards: vec![e1.clone(), e2_overlap],
+            total_size_bytes: 6,
+            assembled_hash: Hash::ZERO,
+        };
+        assert!(overlapping.validate().is_err());
+
+        // Non-contiguous layer ranges (gap)
+        let mut e2_gap = e2.clone();
+        e2_gap.layer_range = Some((6, 8)); // gap after [0,4)
+        let gapped = ShardManifest {
+            shards: vec![e1.clone(), e2_gap],
+            total_size_bytes: 6,
+            assembled_hash: Hash::ZERO,
+        };
+        assert!(gapped.validate().is_err());
+
+        // Valid contiguous layer ranges pass
+        let mut e2_ok = e2;
+        e2_ok.layer_range = Some((4, 8));
+        let valid = ShardManifest {
+            shards: vec![e1, e2_ok],
+            total_size_bytes: 6,
+            assembled_hash: Hash::ZERO,
+        };
+        assert!(valid.validate().is_ok());
+    }
+
+    #[test]
+    fn test_ensure_shard_cache_hit_no_network() {
+        let dir = test_dir("cache_hit");
+        let downloader =
+            ShardDownloader::new("http://invalid.invalid:1", dir.join("shards")).unwrap();
+
+        let data = b"pre-seeded shard bytes";
+        downloader.store().put(data).unwrap();
+
+        let mut entry = make_entry(data);
+        entry.cid = "this-cid-does-not-exist".to_string();
+
+        // Must succeed without any network access (shard already in store).
+        downloader.ensure_shard(&entry).unwrap();
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_download_and_assemble_via_file_gateway() {
+        let dir = test_dir("file_gw");
+        let gw_dir = dir.join("fake-gw").join("ipfs");
+        std::fs::create_dir_all(&gw_dir).unwrap();
+
+        // Two shards served as files under <gateway>/ipfs/<cid>
+        let shard_a: Vec<u8> = vec![0xAA; 1500];
+        let shard_b: Vec<u8> = vec![0xBB; 700];
+        std::fs::write(gw_dir.join("cida"), &shard_a).unwrap();
+        std::fs::write(gw_dir.join("cidb"), &shard_b).unwrap();
+
+        let mut full = shard_a.clone();
+        full.extend_from_slice(&shard_b);
+
+        let mut entry_a = make_entry(&shard_a);
+        entry_a.cid = "cida".to_string();
+        let mut entry_b = make_entry(&shard_b);
+        entry_b.cid = "cidb".to_string();
+        let manifest = ShardManifest {
+            shards: vec![entry_a, entry_b],
+            total_size_bytes: full.len() as u64,
+            assembled_hash: qfc_crypto::blake3_hash(&full),
+        };
+
+        let gateway = format!("file://{}", dir.join("fake-gw").display());
+        let downloader = ShardDownloader::new(gateway, dir.join("shards")).unwrap();
+
+        let dest = dir.join("models").join("assembled.bin");
+        downloader.download_and_assemble(&manifest, &dest).unwrap();
+
+        let assembled = std::fs::read(&dest).unwrap();
+        assert_eq!(assembled, full);
+
+        // Idempotent early return: remove all shards from the store, dest is
+        // already intact → must still succeed without fetching anything.
+        for entry in &manifest.shards {
+            downloader.store().delete(&entry.hash).unwrap();
+        }
+        downloader.download_and_assemble(&manifest, &dest).unwrap();
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_gateway_serves_wrong_bytes_rejected() {
+        let dir = test_dir("wrong_bytes");
+        let gw_dir = dir.join("fake-gw").join("ipfs");
+        std::fs::create_dir_all(&gw_dir).unwrap();
+
+        // Gateway serves bytes of the RIGHT size but the WRONG content.
+        let good: Vec<u8> = vec![0xAA; 1024];
+        let bad: Vec<u8> = vec![0xBB; 1024];
+        std::fs::write(gw_dir.join("cidbad"), &bad).unwrap();
+
+        let gateway = format!("file://{}", dir.join("fake-gw").display());
+        let downloader = ShardDownloader::new(gateway, dir.join("shards")).unwrap();
+
+        let mut entry = make_entry(&good);
+        entry.cid = "cidbad".to_string();
+
+        let err = downloader.ensure_shard(&entry).unwrap_err();
+        assert!(
+            matches!(err, InferenceError::ShardVerification(_)),
+            "expected ShardVerification, got: {:?}",
+            err
+        );
+        assert!(
+            err.to_string().contains("cidbad"),
+            "error should mention the cid, got: {}",
+            err
+        );
+        // Neither the expected hash nor the bad bytes' hash may be stored.
+        assert!(!downloader.store().contains(&entry.hash));
+        assert!(!downloader.store().contains(&qfc_crypto::blake3_hash(&bad)));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_gateway_serves_wrong_size_rejected() {
+        let dir = test_dir("wrong_size");
+        let gw_dir = dir.join("fake-gw").join("ipfs");
+        std::fs::create_dir_all(&gw_dir).unwrap();
+
+        // Gateway serves fewer bytes than the manifest declares (truncated).
+        let good: Vec<u8> = vec![0xCC; 2048];
+        std::fs::write(gw_dir.join("cidshort"), &good[..512]).unwrap();
+
+        let gateway = format!("file://{}", dir.join("fake-gw").display());
+        let shard_dir = dir.join("shards");
+        let downloader = ShardDownloader::new(gateway, shard_dir.clone()).unwrap();
+
+        let mut entry = make_entry(&good);
+        entry.cid = "cidshort".to_string();
+
+        let err = downloader.ensure_shard(&entry).unwrap_err();
+        assert!(
+            matches!(err, InferenceError::ShardVerification(_)),
+            "expected ShardVerification, got: {:?}",
+            err
+        );
+        assert!(
+            err.to_string().contains("size mismatch"),
+            "expected size mismatch error, got: {}",
+            err
+        );
+        assert!(!downloader.store().contains(&entry.hash));
+        // Temp download files must not be left behind in the shard dir.
+        let leftover: Vec<_> = std::fs::read_dir(&shard_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".part"))
+            .collect();
+        assert!(leftover.is_empty(), "leftover temp files: {:?}", leftover);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_validate_rejects_invalid_cid() {
+        for bad_cid in ["../evil", "Qm/Foo", "cid?x=1", "cid#frag", "cid%2e", "cid foo"] {
+            let mut entry = make_entry(b"abc");
+            entry.cid = bad_cid.to_string();
+            let manifest = ShardManifest {
+                shards: vec![entry],
+                total_size_bytes: 3,
+                assembled_hash: Hash::ZERO,
+            };
+            let err = manifest.validate().unwrap_err();
+            assert!(
+                matches!(err, InferenceError::ShardVerification(_)),
+                "cid {:?}: expected ShardVerification, got: {:?}",
+                bad_cid,
+                err
+            );
+        }
+
+        // Valid CIDv0/CIDv1 shapes (and the pre-upload empty cid) pass.
+        for ok_cid in ["QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG", "bafybeigdyrzt5", ""] {
+            let mut entry = make_entry(b"abc");
+            entry.cid = ok_cid.to_string();
+            let manifest = ShardManifest {
+                shards: vec![entry],
+                total_size_bytes: 3,
+                assembled_hash: Hash::ZERO,
+            };
+            assert!(manifest.validate().is_ok(), "cid {:?} should be valid", ok_cid);
+        }
+    }
+
+    #[test]
+    fn test_ensure_shard_empty_cid_errors_cleanly() {
+        let dir = test_dir("empty_cid");
+        // Invalid gateway: the empty-cid error must fire before any fetch.
+        let downloader =
+            ShardDownloader::new("http://invalid.invalid:1", dir.join("shards")).unwrap();
+
+        let entry = make_entry(b"never published"); // cid stays empty
+        let err = downloader.ensure_shard(&entry).unwrap_err();
+        assert!(
+            err.to_string().contains("empty cid"),
+            "expected empty-cid error, got: {}",
+            err
+        );
+        assert!(!downloader.store().contains(&entry.hash));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_download_and_assemble_pre_seeded() {
+        let dir = test_dir("preseed");
+        let downloader =
+            ShardDownloader::new("http://invalid.invalid:1", dir.join("shards")).unwrap();
+
+        let shard_a: Vec<u8> = (0..1024u32).map(|i| (i % 7) as u8).collect();
+        let shard_b: Vec<u8> = (0..333u32).map(|i| (i % 13) as u8).collect();
+        downloader.store().put(&shard_a).unwrap();
+        downloader.store().put(&shard_b).unwrap();
+
+        let mut full = shard_a.clone();
+        full.extend_from_slice(&shard_b);
+        let manifest = ShardManifest {
+            shards: vec![make_entry(&shard_a), make_entry(&shard_b)],
+            total_size_bytes: full.len() as u64,
+            assembled_hash: qfc_crypto::blake3_hash(&full),
+        };
+
+        let dest = dir.join("assembled.bin");
+        downloader.download_and_assemble(&manifest, &dest).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), full);
+        // tmp file cleaned up by rename
+        assert!(!dest.with_extension("tmp").exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_assembled_hash_mismatch_rejected() {
+        let dir = test_dir("asm_mismatch");
+        let downloader =
+            ShardDownloader::new("http://invalid.invalid:1", dir.join("shards")).unwrap();
+
+        let shard: Vec<u8> = vec![0x11; 256];
+        downloader.store().put(&shard).unwrap();
+
+        let manifest = ShardManifest {
+            shards: vec![make_entry(&shard)],
+            total_size_bytes: shard.len() as u64,
+            assembled_hash: Hash::new([0x42; 32]), // wrong on purpose
+        };
+
+        let dest = dir.join("assembled.bin");
+        let err = downloader
+            .download_and_assemble(&manifest, &dest)
+            .unwrap_err();
+        assert!(err.to_string().contains("hash mismatch"));
+        assert!(!dest.exists());
+        assert!(!dest.with_extension("tmp").exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_tampered_shard_fails_integrity() {
+        let dir = test_dir("tamper");
+        let shard_dir = dir.join("shards");
+        let downloader = ShardDownloader::new("http://invalid.invalid:1", shard_dir.clone()).unwrap();
+
+        let shard: Vec<u8> = vec![0x33; 512];
+        let data_ref = downloader.store().put(&shard).unwrap();
+
+        // Corrupt the shard file on disk (filename = Hash Display = 0x-hex).
+        let shard_path = shard_dir.join(format!("{}", data_ref.hash));
+        assert!(shard_path.exists());
+        std::fs::write(&shard_path, vec![0x44; 512]).unwrap();
+
+        let manifest = ShardManifest {
+            shards: vec![make_entry(&shard)],
+            total_size_bytes: shard.len() as u64,
+            assembled_hash: qfc_crypto::blake3_hash(&shard),
+        };
+
+        let dest = dir.join("assembled.bin");
+        let err = downloader
+            .download_and_assemble(&manifest, &dest)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("integrity"),
+            "expected integrity error, got: {}",
+            err
+        );
+        assert!(!dest.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/qfc-rpc/src/qfc.rs
+++ b/crates/qfc-rpc/src/qfc.rs
@@ -670,6 +670,13 @@ pub struct RpcProposeModelRequest {
     pub min_memory_mb: u64,
     pub min_tier: String,
     pub size_mb: u64,
+    /// Blake3 hash of the model weight file (0x-hex, optional)
+    #[serde(default)]
+    pub weights_hash: Option<String>,
+    /// Sharded distribution manifest (ADR-0001, optional). Reuses the
+    /// canonical `ShardManifest` serde shape: hashes are 0x-hex strings.
+    #[serde(default)]
+    pub shard_manifest: Option<qfc_inference::ShardManifest>,
 }
 
 /// Request to vote on a model proposal

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -2434,6 +2434,30 @@ impl QfcApiServer for RpcServer {
             _ => qfc_inference::GpuTier::Cold,
         };
 
+        let weights_hash = request
+            .weights_hash
+            .as_deref()
+            .map(Self::parse_hash)
+            .transpose()?;
+
+        // ADR-0001: validate the manifest before it can enter governance, and
+        // reject entries where weights_hash and assembled_hash disagree (a
+        // registry entry with both set must have them equal).
+        if let Some(manifest) = &request.shard_manifest {
+            manifest.validate().map_err(|e| {
+                RpcError::InvalidParams(format!("invalid shard manifest: {}", e))
+            })?;
+            if let Some(wh) = weights_hash {
+                if wh != manifest.assembled_hash {
+                    return Err(RpcError::InvalidParams(format!(
+                        "weightsHash {} does not match shard manifest assembledHash {}",
+                        wh, manifest.assembled_hash
+                    ))
+                    .into());
+                }
+            }
+        }
+
         let model_info = qfc_inference::model::ModelInfo {
             id: qfc_inference::task::ModelId::new(&request.model_name, &request.model_version),
             description: request.description,
@@ -2442,7 +2466,8 @@ impl QfcApiServer for RpcServer {
             size_mb: request.size_mb,
             approved: false,
             canonical_format: qfc_inference::CanonicalFormat::SafetensorsFp32,
-            weights_hash: None,
+            weights_hash,
+            shard_manifest: request.shard_manifest,
         };
 
         let now = std::time::SystemTime::now()
@@ -5026,5 +5051,85 @@ mod tests_agent_write_rpcs {
         assert!(
             qfc_crypto::verify_hash_signature(&keypair.public_key(), &hash_without, &sig).is_err()
         );
+    }
+}
+
+#[cfg(test)]
+mod tests_model_governance_rpcs {
+    use crate::qfc::RpcProposeModelRequest;
+
+    /// Old-style requests without the new optional fields must still parse
+    /// (serde defaults — backward compatible).
+    #[test]
+    fn test_propose_model_request_without_optional_fields() {
+        let json = r#"{
+            "proposer": "0x1234567890abcdef1234567890abcdef12345678",
+            "modelName": "qfc-llm-test",
+            "modelVersion": "v1.0",
+            "description": "test model",
+            "minMemoryMb": 1024,
+            "minTier": "Cold",
+            "sizeMb": 100
+        }"#;
+        let parsed: RpcProposeModelRequest = serde_json::from_str(json).unwrap();
+        assert!(parsed.weights_hash.is_none());
+        assert!(parsed.shard_manifest.is_none());
+    }
+
+    /// Manifest round-trips through the RPC request with 0x-hex hashes.
+    #[test]
+    fn test_propose_model_request_with_manifest_round_trip() {
+        let data = vec![0x42u8; 64];
+        let manifest = qfc_inference::ShardManifest {
+            shards: vec![qfc_inference::ShardEntry {
+                cid: "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG".to_string(),
+                hash: qfc_crypto::blake3_hash(&data),
+                size_bytes: data.len() as u64,
+                layer_range: None,
+            }],
+            total_size_bytes: data.len() as u64,
+            assembled_hash: qfc_crypto::blake3_hash(&data),
+        };
+        manifest.validate().unwrap();
+
+        let req = RpcProposeModelRequest {
+            proposer: "0x1234567890abcdef1234567890abcdef12345678".into(),
+            model_name: "qfc-llm-test".into(),
+            model_version: "v1.0".into(),
+            description: "sharded test model".into(),
+            min_memory_mb: 1024,
+            min_tier: "Cold".into(),
+            size_mb: 100,
+            weights_hash: Some(format!("{}", manifest.assembled_hash)),
+            shard_manifest: Some(manifest.clone()),
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        // Hashes serialize as 0x-hex strings (qfc_types::Hash serde).
+        assert!(json.contains(&format!("{}", manifest.assembled_hash)));
+        let parsed: RpcProposeModelRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.shard_manifest.as_ref().unwrap(), &manifest);
+        assert_eq!(
+            parsed.weights_hash.as_deref().unwrap(),
+            format!("{}", manifest.assembled_hash)
+        );
+    }
+
+    /// An invalid manifest (bad cid) is rejected by the same validate() the
+    /// propose_model handler runs before building ModelInfo.
+    #[test]
+    fn test_propose_model_manifest_with_invalid_cid_rejected() {
+        let data = vec![0x42u8; 64];
+        let manifest = qfc_inference::ShardManifest {
+            shards: vec![qfc_inference::ShardEntry {
+                cid: "../evil".to_string(),
+                hash: qfc_crypto::blake3_hash(&data),
+                size_bytes: data.len() as u64,
+                layer_range: None,
+            }],
+            total_size_bytes: data.len() as u64,
+            assembled_hash: qfc_crypto::blake3_hash(&data),
+        };
+        assert!(manifest.validate().is_err());
     }
 }

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -2444,9 +2444,9 @@ impl QfcApiServer for RpcServer {
         // reject entries where weights_hash and assembled_hash disagree (a
         // registry entry with both set must have them equal).
         if let Some(manifest) = &request.shard_manifest {
-            manifest.validate().map_err(|e| {
-                RpcError::InvalidParams(format!("invalid shard manifest: {}", e))
-            })?;
+            manifest
+                .validate()
+                .map_err(|e| RpcError::InvalidParams(format!("invalid shard manifest: {}", e)))?;
             if let Some(wh) = weights_hash {
                 if wh != manifest.assembled_hash {
                     return Err(RpcError::InvalidParams(format!(

--- a/docs/adr/0001-sharded-model-distribution.md
+++ b/docs/adr/0001-sharded-model-distribution.md
@@ -1,0 +1,97 @@
+# ADR-0001: Sharded model distribution (Roadmap AI-V3, B0)
+
+**Status:** accepted
+**Date:** 2026-06-10
+**Context:** [ROADMAP-AI-V3.md](../ROADMAP-AI-V3.md) Feature B, stage B-1.
+
+## Problem
+
+A registry model today is one artifact with one optional whole-file Blake3 hash
+(`ModelInfo.weights_hash`). A model that exceeds a single download — or that no
+single miner wants to re-download after a fine-tune that changed 3 of 30 layers —
+has no representation. B-1 introduces *sharded distribution with single-miner
+execution*: split the weight file into verifiable shards, download shard-by-shard,
+reuse unchanged shards across model versions.
+
+## Decision 1 — Manifest shape
+
+A `ShardManifest` describes the weight file as an ordered list of byte-range shards:
+
+```rust
+ShardEntry {
+    cid: String,                     // IPFS CID of the shard bytes
+    hash: Hash,                      // Blake3 of the shard bytes (verification key)
+    size_bytes: u64,
+    layer_range: Option<(u32, u32)>, // [start, end) — metadata only in B-1; B-2 uses it
+}
+ShardManifest {
+    shards: Vec<ShardEntry>,         // concatenation order = file order
+    total_size_bytes: u64,
+    assembled_hash: Hash,            // Blake3 of the concatenated file
+}
+```
+
+- **Byte-range, not tensor-aware, in B-1.** Assembly is plain concatenation; no
+  format knowledge needed. `layer_range` is carried as optional metadata so a
+  governance proposal *may* align shard boundaries to layer boundaries — which is
+  what makes cross-version reuse effective (fine-tunes that freeze layers produce
+  byte-identical shards) and is what B-2 pipeline execution will require.
+- **`assembled_hash` duplicates `weights_hash` deliberately.** The manifest is
+  self-contained (verifiable without consulting the registry entry), and a
+  registry entry with both set must have them equal — checked at assembly time.
+- Borsh + serde derives, same as every on-chain-adjacent type.
+
+## Decision 2 — Where the manifest lives
+
+`ModelInfo` gains `shard_manifest: Option<ShardManifest>`. `None` means the
+existing single-artifact path (HuggingFace download + whole-file hash check) —
+**fully backward compatible; no existing registry entry changes shape semantics.**
+Governance approves the manifest as part of the model entry, same as
+`weights_hash` today.
+
+Rejected alternative: a separate manifest registry keyed by `ModelId`. More
+moving parts, and the manifest has the same lifecycle/trust model as the rest of
+`ModelInfo`.
+
+## Decision 3 — Shard cache is content-addressed, shared across models
+
+Shards are stored by Blake3 hash via the existing `LocalDataStore` pattern
+(`<cache>/shards/<hash>`). Consequences, all free:
+
+- **Resumable:** a shard already present and hash-valid is never re-downloaded;
+  re-running an interrupted download fetches only missing shards.
+- **Cross-version reuse:** v1.1 of a model lists mostly the same shard hashes as
+  v1.0 → those shards hit the cache regardless of which model brought them in.
+- **Tamper-evident:** `LocalDataStore::get` re-verifies hash on read.
+
+Eviction: shard files are owned by the shard store, not `ModelCache`'s LRU.
+B-1 ships with manual/size-cap cleanup deferred — assembled models dominate disk
+anyway and shards can be deleted after assembly (kept by default for re-share).
+
+## Decision 4 — Download & verification flow
+
+```
+for entry in manifest.shards:           (sequential in B-1; parallelism later)
+    if store.contains(entry.hash): skip
+    fetch <gateway>/ipfs/<entry.cid>    (curl subprocess, same as ipfs.rs)
+    verify blake3(bytes) == entry.hash  → store, else fail that shard
+assemble: concat shards in order → temp file, streaming Blake3
+verify assembled == manifest.assembled_hash (and == weights_hash if set)
+atomic rename into place
+```
+
+Per-shard hash check is the generalization of today's `verify_weights_hash`;
+the assembled-hash check keeps the end-to-end guarantee identical to v2.x.
+
+## Decision 5 — Assignment unchanged in B-1
+
+Execution is still single-miner: `assignment.rs` continues to match on
+`min_memory_mb`/`size_mb`/tier against the *total* model. Shard-group assignment
+is B-2 (`B3` milestone) and explicitly out of scope here.
+
+## Non-goals (B-1)
+
+- Multi-miner pipeline execution (B-2, gated on WAN latency data).
+- Tensor-format-aware splitting; governance tooling may align boundaries but the
+  protocol doesn't require it.
+- P2P shard exchange between miners (IPFS gateway is the transport, as today).


### PR DESCRIPTION
Implements **stage B-1** of [ROADMAP-AI-V3](docs/ROADMAP-AI-V3.md) — sharded *distribution*, single-miner *execution*. B-2 (pipeline execution) remains gated on WAN latency data.

## What's in here

- **B0 — ADR**: [`docs/adr/0001-sharded-model-distribution.md`](docs/adr/0001-sharded-model-distribution.md). Byte-range shards (layer-aligned optional, B-2 hook), manifest lives on `ModelInfo`, content-addressed shard store, assignment untouched.
- **B1 — manifest + verified download**: new `qfc-inference::shard` module — `ShardManifest`/`ShardEntry` (Borsh+serde), `ShardManifest::split_file` publisher helper, `ShardDownloader` fetching `<gateway>/ipfs/<cid>` with per-shard Blake3 verification. Governance RPC `propose_model` now accepts optional `weights_hash` + `shard_manifest` (validated; rejected if `weights_hash != assembled_hash`).
- **B2 — assembly + cache reuse**: shards stored content-addressed via the existing `LocalDataStore` → resumable downloads and byte-identical shard reuse across model versions fall out for free. Assembly = streaming Blake3 + fsync + atomic rename; `ModelCache::ensure_sharded_model` registers the assembled model and `evict_lru` now reclaims directory entries.

## Hardening (from adversarial review pass)

- Download bounded by `--max-filesize`/`--max-time` + pre-read size stat (untrusted gateway can't OOM/fill disk)
- Tmp files in the private shard dir with unique names (no predictable `/tmp` paths)
- CID alphabet validation (`[A-Za-z0-9]+`) before URL interpolation
- `#[serde(default)]` on new `ModelInfo` fields for forward compat

## Tests

`qfc-inference` 56 ✓, `qfc-rpc` 33 ✓, `qfc-ai-coordinator` 88 ✓, workspace builds clean (incl. `--features candle`). Negative cases covered: wrong-bytes gateway, wrong-size gateway, tampered shard on disk, path-traversal CIDs, assembled-hash mismatch, idempotent re-assembly.

## Known follow-ups (deliberately out of scope)

- Miner runtime routing: no production call site constructs `ShardDownloader` yet (miner loads via `scheduler.ensure_model_loaded`, not `ModelCache`) — wiring lands with the first sharded registry entry.
- Pre-existing: governance `proposal_id = blake3(proposer ‖ counter)` doesn't commit to `model_info` content, so a vote doesn't cryptographically bind the manifest. Worth its own issue before any mainnet sharded model.
- Shard-store eviction policy (ADR Decision 3 defers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)