### PR TITLE
T3.2: crash-atomic block commit + durability ADR

### DIFF
--- a/crates/qfc-chain/src/chain.rs
+++ b/crates/qfc-chain/src/chain.rs
@@ -147,20 +147,23 @@ impl Chain {
         // Compute genesis hash
         let hash = genesis_hash(&genesis);
 
-        // Store genesis
-        self.store_block(&genesis)?;
-
-        // Update metadata
-        self.db.put(
+        // Store genesis block, chain metadata, and head metadata in a single
+        // atomic batch so a crash during init can never leave a partially
+        // initialized chain (e.g. a stored genesis block without GENESIS_HASH).
+        let mut batch = WriteBatch::new();
+        Self::append_block_to_batch(&mut batch, &genesis);
+        Self::append_receipts_and_head_to_batch(&mut batch, &genesis, &[], &state_root);
+        batch.put(
             cf::METADATA,
-            qfc_storage::meta::GENESIS_HASH,
-            hash.as_bytes(),
-        )?;
-        self.db.put(
+            qfc_storage::meta::GENESIS_HASH.to_vec(),
+            hash.as_bytes().to_vec(),
+        );
+        batch.put(
             cf::METADATA,
-            qfc_storage::meta::CHAIN_ID,
-            &self.config.chain_id.to_le_bytes(),
-        )?;
+            qfc_storage::meta::CHAIN_ID.to_vec(),
+            self.config.chain_id.to_le_bytes().to_vec(),
+        );
+        self.db.write_batch_sync(batch)?;
 
         *self.genesis_hash.write() = Some(hash);
         *self.head.write() = Some(SealedBlock::new(hash, genesis));
@@ -347,6 +350,13 @@ impl Chain {
 
     /// Store Ethereum transaction hash mapping (keccak256 -> blake3)
     /// This allows looking up transactions/receipts by the hash returned to Ethereum wallets
+    ///
+    /// Note: this is intentionally *not* part of the atomic block-commit batch
+    /// ([`Self::commit_block`]). Its only caller is the RPC server's
+    /// `eth_sendRawTransaction` path, which records the mapping at submission
+    /// time — before the transaction is in any block — so there is no block
+    /// commit to be atomic with. Losing this mapping in a crash only degrades
+    /// hash translation for a not-yet-mined tx; it cannot orphan block data.
     pub fn store_eth_tx_hash_mapping(&self, eth_hash: &Hash, internal_hash: &Hash) -> Result<()> {
         self.db.put(
             cf::ETH_TX_INDEX,
@@ -471,32 +481,11 @@ impl Chain {
                 .update_inference_score(&proof.validator, proof.flops_estimated, 1);
         }
 
-        // Store block
-        self.store_block(&block)?;
+        // Commit block, receipts, and head metadata in a single atomic batch
+        self.commit_block(&block, &receipts, &state_root)?;
 
-        // Store receipts
-        for receipt in &receipts {
-            self.db.put(
-                cf::RECEIPTS,
-                receipt.tx_hash.as_bytes(),
-                &borsh::to_vec(&receipt).unwrap(),
-            )?;
-        }
-
-        // Update head
+        // Update in-memory head (only after the durable commit succeeded)
         *self.head.write() = Some(SealedBlock::new(block_hash, block.clone()));
-
-        // Update metadata
-        self.db.put(
-            cf::METADATA,
-            qfc_storage::meta::LATEST_BLOCK_NUMBER,
-            &block.number().to_le_bytes(),
-        )?;
-        self.db.put(
-            cf::METADATA,
-            qfc_storage::meta::LATEST_STATE_ROOT,
-            state_root.as_bytes(),
-        )?;
 
         // Record block production in consensus engine for PoC scoring
         self.consensus.record_block_produced(&producer);
@@ -526,12 +515,11 @@ impl Chain {
         Vec::new()
     }
 
-    /// Store a block in the database
-    fn store_block(&self, block: &Block) -> Result<()> {
+    /// Append all storage writes for a block (header, body, hash index,
+    /// transactions, tx locations) to a batch. Returns the block hash.
+    fn append_block_to_batch(batch: &mut WriteBatch, block: &Block) -> Hash {
         let key = encode_block_number(block.number());
         let block_hash = blake3_hash(&block.header_bytes());
-
-        let mut batch = WriteBatch::new();
 
         // Store header
         batch.put(
@@ -571,9 +559,52 @@ impl Chain {
             );
         }
 
-        self.db.write_batch(batch)?;
+        block_hash
+    }
 
-        Ok(())
+    /// Append the block's receipts and the canonical-head metadata
+    /// (`latest_block_number` / `latest_state_root`) to a batch.
+    fn append_receipts_and_head_to_batch(
+        batch: &mut WriteBatch,
+        block: &Block,
+        receipts: &[Receipt],
+        state_root: &Hash,
+    ) {
+        for receipt in receipts {
+            batch.put(
+                cf::RECEIPTS,
+                receipt.tx_hash.as_bytes().to_vec(),
+                borsh::to_vec(receipt).unwrap(),
+            );
+        }
+
+        batch.put(
+            cf::METADATA,
+            qfc_storage::meta::LATEST_BLOCK_NUMBER.to_vec(),
+            block.number().to_le_bytes().to_vec(),
+        );
+        batch.put(
+            cf::METADATA,
+            qfc_storage::meta::LATEST_STATE_ROOT.to_vec(),
+            state_root.as_bytes().to_vec(),
+        );
+    }
+
+    /// Atomically commit a canonical block.
+    ///
+    /// Header, body, hash index, transactions, tx locations, receipts, and
+    /// head metadata (`latest_block_number` / `latest_state_root`) all land in
+    /// a single WriteBatch, so a crash can never leave a stored block without
+    /// its receipts or a head pointer ahead of the stored data.
+    ///
+    /// The batch is written with `WriteOptions::set_sync(true)`; see
+    /// `docs/adr/0001-block-commit-durability.md` for the durability policy.
+    fn commit_block(&self, block: &Block, receipts: &[Receipt], state_root: &Hash) -> Result<Hash> {
+        let mut batch = WriteBatch::new();
+        let block_hash = Self::append_block_to_batch(&mut batch, block);
+        Self::append_receipts_and_head_to_batch(&mut batch, block, receipts, state_root);
+        self.db.write_batch_sync(batch)?;
+        Ok(block_hash)
     }
 
     /// Get state at a specific block
@@ -642,34 +673,11 @@ impl Chain {
 
     /// Store a block that we produced (skip validation since we created it)
     pub fn store_produced_block(&self, block: &Block, receipts: &[Receipt]) -> Result<()> {
-        let block_hash = blake3_hash(&block.header_bytes());
+        // Commit block, receipts, and head metadata in a single atomic batch
+        let block_hash = self.commit_block(block, receipts, &block.state_root())?;
 
-        // Store block
-        self.store_block(block)?;
-
-        // Store receipts
-        for receipt in receipts {
-            self.db.put(
-                cf::RECEIPTS,
-                receipt.tx_hash.as_bytes(),
-                &borsh::to_vec(receipt).unwrap(),
-            )?;
-        }
-
-        // Update head
+        // Update in-memory head (only after the durable commit succeeded)
         *self.head.write() = Some(SealedBlock::new(block_hash, block.clone()));
-
-        // Update metadata
-        self.db.put(
-            cf::METADATA,
-            qfc_storage::meta::LATEST_BLOCK_NUMBER,
-            &block.number().to_le_bytes(),
-        )?;
-        self.db.put(
-            cf::METADATA,
-            qfc_storage::meta::LATEST_STATE_ROOT,
-            block.state_root().as_bytes(),
-        )?;
 
         debug!(
             "Stored produced block {} at height {}",
@@ -785,5 +793,116 @@ mod tests {
         let balance = chain.get_balance(&addr).unwrap();
 
         assert!(balance > U256::ZERO);
+    }
+
+    /// The whole block commit (header, body, hash index, tx, tx location,
+    /// receipts, head metadata) must be assembled into a single WriteBatch —
+    /// that batch is what RocksDB applies atomically.
+    #[test]
+    fn test_block_commit_assembles_single_atomic_batch() {
+        let mut block = Block::default();
+        block.header.number = 1;
+        block.transactions = vec![Transaction::default()];
+
+        let tx_hash = blake3_hash(&block.transactions[0].to_bytes_without_signature());
+        let receipts = vec![Receipt {
+            tx_hash,
+            ..Default::default()
+        }];
+
+        let mut batch = WriteBatch::new();
+        Chain::append_block_to_batch(&mut batch, &block);
+        Chain::append_receipts_and_head_to_batch(&mut batch, &block, &receipts, &Hash::ZERO);
+
+        // header + body + hash index + 1 tx + 1 tx location + 1 receipt
+        // + latest_block_number + latest_state_root = 8 ops, one batch
+        assert_eq!(batch.len(), 8);
+
+        let cfs: std::collections::HashSet<&str> = batch
+            .ops()
+            .iter()
+            .map(|op| match op {
+                qfc_storage::BatchOp::Put { cf, .. } => cf.as_str(),
+                qfc_storage::BatchOp::Delete { cf, .. } => cf.as_str(),
+            })
+            .collect();
+        for expected in [
+            cf::BLOCK_HEADERS,
+            cf::BLOCK_BODIES,
+            cf::BLOCK_HASH_INDEX,
+            cf::TRANSACTIONS,
+            cf::TX_INDEX,
+            cf::RECEIPTS,
+            cf::METADATA,
+        ] {
+            assert!(cfs.contains(expected), "batch missing CF {expected}");
+        }
+    }
+
+    /// After a block commit, receipts and head metadata must be present for
+    /// the stored block — a stored block can never be observed without them.
+    #[test]
+    fn test_commit_leaves_no_partial_block() {
+        let chain = create_test_chain();
+        let genesis = chain.get_block_by_number(0).unwrap().unwrap();
+
+        let mut block = Block::default();
+        block.header.number = 1;
+        block.header.parent_hash = blake3_hash(&genesis.header_bytes());
+        block.header.state_root = chain.state_root();
+        block.transactions = vec![Transaction::default()];
+
+        let tx_hash = blake3_hash(&block.transactions[0].to_bytes_without_signature());
+        let receipts = vec![Receipt {
+            tx_hash,
+            ..Default::default()
+        }];
+
+        chain.store_produced_block(&block, &receipts).unwrap();
+
+        // Block, transaction, location, and receipt are all readable
+        assert!(chain.get_block_by_number(1).unwrap().is_some());
+        assert!(chain.get_transaction(&tx_hash).unwrap().is_some());
+        assert_eq!(
+            chain.get_transaction_location(&tx_hash).unwrap(),
+            Some((1, 0))
+        );
+        assert!(chain.get_receipt(&tx_hash).unwrap().is_some());
+
+        // Head metadata committed in the same batch
+        let latest = chain
+            .db()
+            .get(cf::METADATA, qfc_storage::meta::LATEST_BLOCK_NUMBER)
+            .unwrap()
+            .expect("latest_block_number must be set");
+        assert_eq!(u64::from_le_bytes(latest.try_into().unwrap()), 1);
+
+        let root = chain
+            .db()
+            .get(cf::METADATA, qfc_storage::meta::LATEST_STATE_ROOT)
+            .unwrap()
+            .expect("latest_state_root must be set");
+        assert_eq!(root, block.state_root().as_bytes().to_vec());
+
+        assert_eq!(chain.block_number(), 1);
+    }
+
+    /// Genesis init must also commit head metadata atomically with the block.
+    #[test]
+    fn test_genesis_commits_head_metadata() {
+        let chain = create_test_chain();
+
+        let latest = chain
+            .db()
+            .get(cf::METADATA, qfc_storage::meta::LATEST_BLOCK_NUMBER)
+            .unwrap()
+            .expect("genesis must set latest_block_number");
+        assert_eq!(u64::from_le_bytes(latest.try_into().unwrap()), 0);
+
+        assert!(chain
+            .db()
+            .get(cf::METADATA, qfc_storage::meta::LATEST_STATE_ROOT)
+            .unwrap()
+            .is_some());
     }
 }

--- a/crates/qfc-storage/src/db.rs
+++ b/crates/qfc-storage/src/db.rs
@@ -298,6 +298,39 @@ impl Database {
         Ok(self.db.write(rocks_batch)?)
     }
 
+    /// Write a batch of operations atomically with `WriteOptions::set_sync(true)`.
+    ///
+    /// The RocksDB WAL is fsynced before this returns, making the batch — and,
+    /// because the WAL is sequential, every previously written batch — durable
+    /// against power loss and kernel panic, not just process crash.
+    ///
+    /// Intended for canonical block commits; see
+    /// `docs/adr/0001-block-commit-durability.md` for the durability policy.
+    pub fn write_batch_sync(&self, batch: WriteBatch) -> Result<()> {
+        let mut rocks_batch = RocksWriteBatch::default();
+
+        // Same per-batch CF handle caching as `write_batch`.
+        let mut handles: HashMap<&str, Arc<BoundColumnFamily<'_>>> = HashMap::new();
+
+        for op in batch.ops() {
+            let cf_name = match op {
+                BatchOp::Put { cf, .. } | BatchOp::Delete { cf, .. } => cf.as_str(),
+            };
+            if !handles.contains_key(cf_name) {
+                handles.insert(cf_name, self.get_cf(cf_name)?);
+            }
+            let handle = &handles[cf_name];
+            match op {
+                BatchOp::Put { key, value, .. } => rocks_batch.put_cf(handle, key, value),
+                BatchOp::Delete { key, .. } => rocks_batch.delete_cf(handle, key),
+            }
+        }
+
+        let mut write_opts = rocksdb::WriteOptions::default();
+        write_opts.set_sync(true);
+        Ok(self.db.write_opt(rocks_batch, &write_opts)?)
+    }
+
     /// Get an iterator over a column family.
     ///
     /// NOTE: panics if RocksDB reports an error mid-iteration (e.g. a corrupt

--- a/docs/adr/0001-block-commit-durability.md
+++ b/docs/adr/0001-block-commit-durability.md
@@ -1,0 +1,105 @@
+# ADR 0001: Crash-atomic block commit and durability policy
+
+- Status: Accepted
+- Date: 2026-06-10
+- Related: `docs/ROADMAP-SRE.md` T3.2 (items 3–4)
+
+## Context
+
+Before this change, committing a canonical block touched the database in
+**four separate writes**:
+
+1. `store_block()` — one `WriteBatch` covering `block_headers`,
+   `block_bodies`, `block_hash_index`, `transactions`, `tx_index`;
+2. a loop of individual `db.put` calls for `receipts`;
+3. `db.put` for `metadata/latest_block_number`;
+4. `db.put` for `metadata/latest_state_root`.
+
+A crash between (1) and (2)–(4) could leave a stored block **without its
+receipts** or with a **stale head pointer**, and a crash between (3) and (4)
+could leave the head number pointing at a block whose state root metadata
+belongs to its parent. The same sequence existed in both the import path
+(`Chain::import_block`) and the producer path (`Chain::store_produced_block`),
+and genesis init wrote `genesis_hash` / `chain_id` separately from the genesis
+block itself.
+
+In addition, all writes used RocksDB's default `WriteOptions`
+(`sync = false`): the write-ahead log (WAL) is appended but **not fsynced**,
+so a power loss or kernel panic can lose writes that were already
+acknowledged to consensus and possibly broadcast to peers.
+
+## Decision
+
+### 1. Single atomic WriteBatch per block commit
+
+`Chain::commit_block()` assembles headers, bodies, hash index, transactions,
+tx locations, **receipts**, and **head metadata**
+(`latest_block_number`, `latest_state_root`) into one `WriteBatch` and writes
+it in a single RocksDB write. RocksDB applies a batch atomically across
+column families (one WAL record), so after a crash the database either
+contains the whole block commit or none of it. Both `import_block` and
+`store_produced_block` use this path; genesis init likewise commits the
+genesis block together with `genesis_hash`, `chain_id`, and head metadata in
+one batch.
+
+The in-memory head (`Chain::head`) is updated only **after** the durable
+commit succeeds, so the node never advertises a head it could lose.
+
+### 2. `WriteOptions::set_sync(true)` for canonical block commits
+
+The block-commit batch is written via `Database::write_batch_sync()`, which
+sets `WriteOptions::set_sync(true)`: RocksDB fsyncs the WAL before returning.
+
+Why sync rather than the WAL default:
+
+- **Cost is bounded by block rate, not tx rate.** One fsync per block
+  (block interval is on the order of seconds) is negligible write
+  amplification; this is not a per-transaction fsync. All other writes
+  (state trie, mempool, indexes, checkpoints) keep the default non-sync
+  WAL write, so steady-state write throughput is unaffected.
+- **The WAL is sequential, so one fsync covers everything before it.**
+  `StateDB::commit()` (trie nodes) runs earlier in the same import and uses a
+  non-sync batch; the fsync on the block-commit batch also persists those
+  earlier WAL entries. The block's *entire* effect — state, block data,
+  receipts, head — is durable once `commit_block` returns.
+- **A validator must not un-know a block it acted on.** After commit the node
+  votes on / broadcasts the block. Losing it to a power failure and restarting
+  on an older head risks double-signing-adjacent behavior and triggers an
+  avoidable peer re-sync.
+
+### 3. Exemptions
+
+- `eth_tx_index` (`store_eth_tx_hash_mapping`) stays a separate non-sync
+  `put`: its only caller is the RPC `eth_sendRawTransaction` path, which
+  records the keccak256→blake3 mapping at **submission time**, before the tx
+  is in any block — there is no block commit to be atomic with, and losing it
+  only degrades hash translation for a not-yet-mined tx.
+- All non-canonical writes (state trie commits, pruning, snap sync,
+  consensus checkpoints, double-sign evidence) keep default `WriteOptions`.
+
+## Consequences / RPO
+
+- **Process crash (panic, OOM-kill):** RPO = 0 blocks regardless of the sync
+  flag — the WAL survives the process.
+- **Power loss / kernel panic:** RPO = 0 *committed* blocks. At most the
+  block currently being imported (its non-synced state-trie writes included)
+  is lost, and it is re-fetched from peers on restart. Without `sync=true`
+  the loss window would have been "everything since the last OS page-cache
+  flush" (potentially several blocks plus their state).
+- **Latency:** block commit gains one fsync (typically well under 10 ms on
+  SSD/NVMe). Acceptable at ≥1 s block intervals.
+- **Follow-up (not in scope here):** `latest_state_root` durability now
+  matches the head pointer, but state-trie writes between block commits are
+  only as durable as the last block fsync — which is exactly the guarantee we
+  want (state is recomputed/re-synced for any lost in-flight block).
+
+## Alternatives considered
+
+- **Default WAL (`sync = false`) everywhere** — cheaper, but the RPO on power
+  loss is unbounded in block terms and depends on OS flush timing; rejected
+  because validators act on committed blocks immediately.
+- **`fsync` on an interval / every N blocks** — complexity without benefit at
+  current block rates; revisit only if profiling (T1) shows WAL-sync latency
+  in the block-commit critical path.
+- **Disable WAL + rely on flush** — unacceptable RPO and recovery semantics
+  for chain data.


### PR DESCRIPTION
Implements roadmap item T3.2 (`docs/ROADMAP-SRE.md`, T3 items 3–4): crash-atomic block commit and an explicit, documented durability policy.

## Write path: before → after

**Before** — committing a block touched the DB in 4 separate writes:
1. `store_block()`: one batch (headers, bodies, hash index, transactions, tx locations)
2. per-receipt `db.put` loop (`receipts` CF)
3. `db.put` `metadata/latest_block_number`
4. `db.put` `metadata/latest_state_root`

A crash between (1) and (2)–(4) left a block without receipts or a stale/torn head pointer. The same sequence existed in **both** `import_block` (sync path) and `store_produced_block` (producer path), and genesis init wrote `genesis_hash`/`chain_id` separately from the genesis block.

**After** — one `Chain::commit_block()` assembles everything (block data + receipts + head metadata) into a **single WriteBatch** applied atomically by RocksDB; in-memory head is updated only after the durable commit succeeds. Genesis init likewise commits the genesis block + `genesis_hash` + `chain_id` + head metadata in one batch (genesis now also sets `latest_block_number`/`latest_state_root`, so on-disk head matches the in-memory head from first boot).

## Durability decision (ADR 0001)

Canonical block commits use the new `Database::write_batch_sync()` → `WriteOptions::set_sync(true)` (WAL fsync). Rationale and RPO in `docs/adr/0001-block-commit-durability.md`:
- Cost is **one fsync per block** (block-rate, not tx-rate) — negligible write amplification at ≥1 s block intervals; all other writes keep the non-sync default.
- The WAL is sequential, so the block-commit fsync also persists the block's earlier non-sync state-trie writes — the block's entire effect is durable once `commit_block` returns.
- **RPO = 0 committed blocks** on power loss / kernel panic (at most the in-flight block is lost and re-synced from peers). Process crash was already RPO 0 via the WAL.

## Exemption

`store_eth_tx_hash_mapping` (`eth_tx_index`) stays a separate non-sync put: its only caller is the RPC `eth_sendRawTransaction` path, recording the keccak256→blake3 mapping at submission time — before the tx is in any block — so there is no block commit to be atomic with. Documented inline.

## Reorg/rollback audit

Searched for reorg/rollback/unwind/set-head DB write paths mirroring this sequence: **none exist yet** (no chain-reorg implementation in qfc-chain/qfc-node; only in-memory state snapshots/reverts). When a reorg path is added it must reuse `commit_block()` / batch-append helpers — noting as follow-up for the future reorg work.

## Tests

- `test_block_commit_assembles_single_atomic_batch` — unit test: all 7 CFs (headers, bodies, hash index, transactions, tx_index, receipts, metadata) land in one batch with the expected op count.
- `test_commit_leaves_no_partial_block` — end-to-end: after `store_produced_block`, block, tx, tx location, receipt, and both head metadata keys are all present and consistent.
- `test_genesis_commits_head_metadata` — genesis sets head metadata atomically.
- `cargo test -p qfc-chain` 9/9 pass, `cargo test -p qfc-storage` 8/8 pass, `cargo build -p qfc-node` clean (no new warnings; clippy findings are pre-existing).

## Merge-conflict heads-up

This adds one self-contained method `write_batch_sync()` to `crates/qfc-storage/src/db.rs` (no existing lines modified). A parallel branch is working on db.rs/batch.rs CF options — conflict risk is low (pure insertion) but flag for whoever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)