### PR TITLE
T2.2/T2.3: chain+mempool+RPC metrics, Grafana dashboard, SLO alert rules

### DIFF
--- a/crates/qfc-inference/build.rs
+++ b/crates/qfc-inference/build.rs
@@ -29,17 +29,14 @@ mod cuda {
 
             // Emit lib search paths — both lib/x64 (Windows) and lib64 (Linux)
             let lib_candidates = [
-                root.join("lib").join("x64"),   // Windows standard
-                root.join("lib64"),              // Linux standard
-                root.join("lib"),                // Fallback
+                root.join("lib").join("x64"), // Windows standard
+                root.join("lib64"),           // Linux standard
+                root.join("lib"),             // Fallback
             ];
 
             for lib_dir in &lib_candidates {
                 if lib_dir.is_dir() {
-                    println!(
-                        "cargo:rustc-link-search=native={}",
-                        lib_dir.display()
-                    );
+                    println!("cargo:rustc-link-search=native={}", lib_dir.display());
                 }
             }
 
@@ -48,10 +45,7 @@ mod cuda {
             {
                 let bin_dir = root.join("bin");
                 if bin_dir.is_dir() {
-                    println!(
-                        "cargo:rustc-link-search=native={}",
-                        bin_dir.display()
-                    );
+                    println!("cargo:rustc-link-search=native={}", bin_dir.display());
                 }
             }
         } else {
@@ -86,9 +80,11 @@ mod cuda {
         #[cfg(target_os = "windows")]
         {
             // Try versioned paths from newest to oldest
-            let program_files = std::env::var("ProgramFiles")
-                .unwrap_or_else(|_| r"C:\Program Files".to_string());
-            let cuda_base = Path::new(&program_files).join("NVIDIA GPU Computing Toolkit").join("CUDA");
+            let program_files =
+                std::env::var("ProgramFiles").unwrap_or_else(|_| r"C:\Program Files".to_string());
+            let cuda_base = Path::new(&program_files)
+                .join("NVIDIA GPU Computing Toolkit")
+                .join("CUDA");
 
             if cuda_base.is_dir() {
                 // Find the highest versioned directory

--- a/crates/qfc-inference/src/gpu_monitor.rs
+++ b/crates/qfc-inference/src/gpu_monitor.rs
@@ -273,11 +273,10 @@ fn get_windows_memory() -> (u64, u64) {
         .and_then(|o| {
             if o.status.success() {
                 let stdout = String::from_utf8_lossy(&o.stdout).to_string();
-                stdout.lines()
-                    .find_map(|line| {
-                        line.strip_prefix("TotalPhysicalMemory=")
-                            .and_then(|v| v.trim().parse::<u64>().ok())
-                    })
+                stdout.lines().find_map(|line| {
+                    line.strip_prefix("TotalPhysicalMemory=")
+                        .and_then(|v| v.trim().parse::<u64>().ok())
+                })
             } else {
                 None
             }
@@ -292,11 +291,10 @@ fn get_windows_memory() -> (u64, u64) {
         .and_then(|o| {
             if o.status.success() {
                 let stdout = String::from_utf8_lossy(&o.stdout).to_string();
-                stdout.lines()
-                    .find_map(|line| {
-                        line.strip_prefix("FreePhysicalMemory=")
-                            .and_then(|v| v.trim().parse::<u64>().ok())
-                    })
+                stdout.lines().find_map(|line| {
+                    line.strip_prefix("FreePhysicalMemory=")
+                        .and_then(|v| v.trim().parse::<u64>().ok())
+                })
             } else {
                 None
             }

--- a/crates/qfc-inference/src/runtime.rs
+++ b/crates/qfc-inference/src/runtime.rs
@@ -427,7 +427,11 @@ fn detect_cuda_hardware() -> (u64, u32, String) {
         _ => {
             // Fallback: report system memory / 4 as rough GPU estimate
             let mem = get_system_memory_mb();
-            (mem / 4, 0, "NVIDIA GPU (nvidia-smi unavailable)".to_string())
+            (
+                mem / 4,
+                0,
+                "NVIDIA GPU (nvidia-smi unavailable)".to_string(),
+            )
         }
     }
 }
@@ -437,16 +441,18 @@ pub fn find_nvidia_smi() -> String {
     #[cfg(target_os = "windows")]
     {
         // nvidia-smi is installed by the NVIDIA driver into System32
-        let sys32 = std::env::var("SystemRoot")
-            .unwrap_or_else(|_| r"C:\Windows".to_string());
-        let sys32_path =
-            std::path::Path::new(&sys32).join("System32").join("nvidia-smi.exe");
+        let sys32 = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
+        let sys32_path = std::path::Path::new(&sys32)
+            .join("System32")
+            .join("nvidia-smi.exe");
         if sys32_path.exists() {
             return sys32_path.to_string_lossy().to_string();
         }
         // Also check CUDA_PATH\bin
         if let Ok(cuda) = std::env::var("CUDA_PATH") {
-            let cuda_bin = std::path::Path::new(&cuda).join("bin").join("nvidia-smi.exe");
+            let cuda_bin = std::path::Path::new(&cuda)
+                .join("bin")
+                .join("nvidia-smi.exe");
             if cuda_bin.exists() {
                 return cuda_bin.to_string_lossy().to_string();
             }
@@ -535,8 +541,11 @@ fn get_windows_memory_mb() -> u64 {
 
     // Method 2: PowerShell (fallback)
     if let Ok(output) = std::process::Command::new("powershell")
-        .args(["-NoProfile", "-Command",
-               "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"])
+        .args([
+            "-NoProfile",
+            "-Command",
+            "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory",
+        ])
         .output()
     {
         if output.status.success() {

--- a/crates/qfc-mempool/src/pool.rs
+++ b/crates/qfc-mempool/src/pool.rs
@@ -343,6 +343,12 @@ impl Mempool {
         *self.size.read()
     }
 
+    /// Age of the oldest transaction currently in the pool (T2.2 observability).
+    /// Returns `None` when the pool is empty.
+    pub fn oldest_tx_age(&self) -> Option<Duration> {
+        self.by_hash.iter().map(|r| r.added_at.elapsed()).max()
+    }
+
     /// Check if pool is empty
     pub fn is_empty(&self) -> bool {
         self.size() == 0
@@ -456,6 +462,20 @@ mod tests {
 
         pool.remove(&hash);
         assert!(!pool.contains(&hash));
+    }
+
+    #[test]
+    fn test_oldest_tx_age() {
+        let pool = Mempool::default_pool();
+        assert!(pool.oldest_tx_age().is_none());
+
+        let sender = Address::new([0x11; 20]);
+        pool.add(create_test_tx(0, 2_000_000_000), sender).unwrap();
+        std::thread::sleep(Duration::from_millis(10));
+        pool.add(create_test_tx(1, 2_000_000_000), sender).unwrap();
+
+        let age = pool.oldest_tx_age().unwrap();
+        assert!(age >= Duration::from_millis(10));
     }
 
     #[test]

--- a/crates/qfc-node/Cargo.toml
+++ b/crates/qfc-node/Cargo.toml
@@ -38,3 +38,4 @@ qfc-ai-coordinator.workspace = true
 tiny_http.workspace = true
 
 [dev-dependencies]
+tempfile.workspace = true

--- a/crates/qfc-node/src/main.rs
+++ b/crates/qfc-node/src/main.rs
@@ -326,6 +326,10 @@ async fn main() -> Result<()> {
         None => (None, None),
     };
 
+    // T2.2: RPC metrics registry, shared between the RPC middleware (writer)
+    // and the Prometheus exporter (reader)
+    let rpc_metrics = Arc::new(qfc_rpc::metrics::RpcMetrics::new());
+
     // Start RPC server (with network for transaction broadcasting)
     let _rpc_handle = if args.rpc {
         let rpc_config = RpcConfig {
@@ -343,6 +347,7 @@ async fn main() -> Result<()> {
         // Attach CPU inference engine for spot-check verification
         let rpc_engine = qfc_inference::create_engine_for_backend(qfc_inference::BackendType::Cpu)?;
         rpc_server = rpc_server
+            .with_metrics(rpc_metrics.clone())
             .with_inference_engine(rpc_engine)
             .with_proof_pool(proof_pool.clone())
             .with_task_pool(task_pool.clone())
@@ -457,7 +462,7 @@ async fn main() -> Result<()> {
     };
 
     // Start Prometheus metrics server
-    let metrics_server = metrics::MetricsServer::new(
+    let mut metrics_server = metrics::MetricsServer::new(
         args.metrics_addr,
         chain.clone(),
         consensus.clone(),
@@ -465,7 +470,12 @@ async fn main() -> Result<()> {
         _network_service.clone(),
         proof_pool.clone(),
         args.chain_id,
-    );
+    )
+    .with_rpc_metrics(rpc_metrics.clone());
+    if let Some(ref sync) = _sync_manager {
+        metrics_server =
+            metrics_server.with_sync_status(sync.clone() as Arc<dyn qfc_rpc::SyncStatusProvider>);
+    }
     metrics_server.start();
 
     // Print startup info

--- a/crates/qfc-node/src/metrics.rs
+++ b/crates/qfc-node/src/metrics.rs
@@ -3,12 +3,16 @@
 //! Lightweight `/metrics` endpoint using `tiny_http` on a background `std::thread`.
 //! Each scrape queries live state from shared `Arc` handles.
 
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use qfc_ai_coordinator::ProofPool;
 use qfc_chain::Chain;
 use qfc_consensus::ConsensusEngine;
+use qfc_crypto::blake3_hash;
 use qfc_mempool::Mempool;
 use qfc_network::NetworkService;
+use qfc_rpc::metrics::RpcMetrics;
+use qfc_rpc::SyncStatusProvider;
+use qfc_types::Hash;
 use std::fmt::Write as _;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -27,6 +31,14 @@ pub struct MetricsServer {
     tx_total: AtomicU64,
     /// Last block height we counted transactions up to
     tx_counted_to: AtomicU64,
+    /// T2.2: sync status (lag vs peers, syncing flag, pending queue depth)
+    sync_status: Option<Arc<dyn SyncStatusProvider>>,
+    /// T2.2: RPC metrics registry, shared with the jsonrpsee middleware
+    rpc_metrics: Option<Arc<RpcMetrics>>,
+    /// T2.2: head observed at the previous scrape, for reorg detection
+    last_head: Mutex<Option<(u64, Hash)>>,
+    /// T2.2: reorgs detected at scrape granularity (see `update_reorg_detection`)
+    reorgs_detected: AtomicU64,
 }
 
 impl MetricsServer {
@@ -49,7 +61,23 @@ impl MetricsServer {
             chain_id,
             tx_total: AtomicU64::new(0),
             tx_counted_to: AtomicU64::new(0),
+            sync_status: None,
+            rpc_metrics: None,
+            last_head: Mutex::new(None),
+            reorgs_detected: AtomicU64::new(0),
         }
+    }
+
+    /// Attach a sync status provider (T2.2: sync lag / syncing / pending blocks).
+    pub fn with_sync_status(mut self, sync_status: Arc<dyn SyncStatusProvider>) -> Self {
+        self.sync_status = Some(sync_status);
+        self
+    }
+
+    /// Attach the RPC metrics registry shared with the RPC middleware (T2.2).
+    pub fn with_rpc_metrics(mut self, rpc_metrics: Arc<RpcMetrics>) -> Self {
+        self.rpc_metrics = Some(rpc_metrics);
+        self
     }
 
     /// Spawn a background thread running the metrics HTTP server.
@@ -140,6 +168,30 @@ impl MetricsServer {
         let _ = writeln!(out, "# TYPE qfc_block_time_seconds gauge");
         let _ = writeln!(out, "qfc_block_time_seconds {block_time:.3}");
 
+        // T2.2: wall-clock seconds since the head block's timestamp — the
+        // primary block-production-stall signal (alerting SLI).
+        let time_since_last_block = self.compute_time_since_last_block();
+        let _ = writeln!(
+            out,
+            "# HELP qfc_time_since_last_block_seconds Seconds since the head block timestamp."
+        );
+        let _ = writeln!(out, "# TYPE qfc_time_since_last_block_seconds gauge");
+        let _ = writeln!(
+            out,
+            "qfc_time_since_last_block_seconds {time_since_last_block:.3}"
+        );
+
+        // T2.2: reorg detection at scrape granularity (no chain-internal hook
+        // yet — a precise import-time counter is part of the T2.1/T3 follow-up
+        // since it touches qfc-chain/src/chain.rs).
+        let reorgs = self.update_reorg_detection(block_height);
+        let _ = writeln!(
+            out,
+            "# HELP qfc_reorgs_detected_total Reorgs detected by the exporter (scrape-granularity: counted when a previously-seen block hash changes)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_reorgs_detected_total counter");
+        let _ = writeln!(out, "qfc_reorgs_detected_total {reorgs}");
+
         // --- consensus ---
         let validators = self.consensus.get_validators();
         let active_validators = validators.len();
@@ -219,13 +271,65 @@ impl MetricsServer {
         let _ = writeln!(out, "qfc_peer_count {peer_count}");
 
         // --- mempool ---
-        let mempool_size = self.mempool.read().size();
+        let (mempool_size, oldest_tx_age) = {
+            let pool = self.mempool.read();
+            (pool.size(), pool.oldest_tx_age())
+        };
         let _ = writeln!(
             out,
             "# HELP qfc_mempool_size Number of pending transactions."
         );
         let _ = writeln!(out, "# TYPE qfc_mempool_size gauge");
         let _ = writeln!(out, "qfc_mempool_size {mempool_size}");
+
+        // T2.2: age of the oldest pending transaction (0 when the pool is
+        // empty) — rising age with stable depth means stuck inclusion.
+        let oldest_age_secs = oldest_tx_age.map(|d| d.as_secs_f64()).unwrap_or(0.0);
+        let _ = writeln!(
+            out,
+            "# HELP qfc_mempool_oldest_tx_age_seconds Age of the oldest pending transaction (0 if empty)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_mempool_oldest_tx_age_seconds gauge");
+        let _ = writeln!(
+            out,
+            "qfc_mempool_oldest_tx_age_seconds {oldest_age_secs:.3}"
+        );
+
+        // --- sync (T2.2) ---
+        if let Some(sync) = &self.sync_status {
+            let syncing: u8 = if sync.is_syncing() { 1 } else { 0 };
+            let highest_peer = sync.highest_peer_block();
+            let pending = sync.pending_count();
+            let lag = highest_peer.saturating_sub(block_height);
+
+            let _ = writeln!(
+                out,
+                "# HELP qfc_sync_syncing Whether the node is actively syncing (0/1)."
+            );
+            let _ = writeln!(out, "# TYPE qfc_sync_syncing gauge");
+            let _ = writeln!(out, "qfc_sync_syncing {syncing}");
+
+            let _ = writeln!(
+                out,
+                "# HELP qfc_sync_highest_peer_block Highest block number known from peers."
+            );
+            let _ = writeln!(out, "# TYPE qfc_sync_highest_peer_block gauge");
+            let _ = writeln!(out, "qfc_sync_highest_peer_block {highest_peer}");
+
+            let _ = writeln!(
+                out,
+                "# HELP qfc_sync_lag_blocks Blocks behind the highest known peer (0 when ahead or in sync)."
+            );
+            let _ = writeln!(out, "# TYPE qfc_sync_lag_blocks gauge");
+            let _ = writeln!(out, "qfc_sync_lag_blocks {lag}");
+
+            let _ = writeln!(
+                out,
+                "# HELP qfc_sync_pending_blocks Blocks queued waiting for missing parents."
+            );
+            let _ = writeln!(out, "# TYPE qfc_sync_pending_blocks gauge");
+            let _ = writeln!(out, "qfc_sync_pending_blocks {pending}");
+        }
 
         // --- chain id ---
         let _ = writeln!(out, "# HELP qfc_chain_id Chain ID of this node.");
@@ -266,7 +370,64 @@ impl MetricsServer {
         let _ = writeln!(out, "# TYPE qfc_node_info gauge");
         let _ = writeln!(out, "qfc_node_info{{version=\"{version}\"}} 1");
 
+        // --- rpc (T2.2, recorded by qfc-rpc middleware) ---
+        if let Some(rpc) = &self.rpc_metrics {
+            rpc.render_prometheus(&mut out);
+        }
+
+        // --- storage (T2.1, deferred) ---
+        // TODO(T2.1): RocksDB statistics export — compaction-stall counters,
+        // pending-compaction bytes, block-cache hit/miss, memtable size,
+        // per-CF read/write volume, WAL sync latency. Blocked on the
+        // qfc-storage statistics hook landing on a parallel branch (touches
+        // crates/qfc-storage/src/db.rs, owned by the T3 work). When it lands,
+        // render it here:
+        //   self.render_storage_metrics(&mut out);
+
         out
+    }
+
+    /// Wall-clock seconds since the head block's timestamp (block timestamps
+    /// are unix milliseconds). Returns 0 when the chain is empty or clocks
+    /// disagree.
+    fn compute_time_since_last_block(&self) -> f64 {
+        let head_ts_ms = match self.chain.head() {
+            Some(sealed) => sealed.block.header.timestamp,
+            None => return 0.0,
+        };
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        now_ms.saturating_sub(head_ts_ms) as f64 / 1000.0
+    }
+
+    /// Detect reorgs at scrape granularity: remember the head (height, hash)
+    /// from the previous scrape; if the block now stored at that height has a
+    /// different hash, the canonical chain was rewritten below the old head.
+    /// Misses reorgs that fully revert between scrapes — a precise counter
+    /// needs an import-time hook in qfc-chain (T2.1/T3 follow-up).
+    fn update_reorg_detection(&self, current_height: u64) -> u64 {
+        let hash_at = |n: u64| -> Option<Hash> {
+            self.chain
+                .get_block_by_number(n)
+                .ok()
+                .flatten()
+                .map(|b| blake3_hash(&b.header_bytes()))
+        };
+
+        let mut last = self.last_head.lock();
+        if let Some((prev_height, prev_hash)) = *last {
+            if let Some(now_hash) = hash_at(prev_height) {
+                if now_hash != prev_hash {
+                    self.reorgs_detected.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        if let Some(cur_hash) = hash_at(current_height) {
+            *last = Some((current_height, cur_hash));
+        }
+        self.reorgs_detected.load(Ordering::Relaxed)
     }
 
     fn compute_block_time(&self, height: u64) -> f64 {
@@ -283,6 +444,102 @@ impl MetricsServer {
         match (ts(height), ts(height - 1)) {
             (Some(cur), Some(prev)) if cur > prev => (cur - prev) as f64 / 1000.0,
             _ => 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qfc_chain::{ChainConfig, GenesisConfig};
+    use qfc_consensus::ConsensusConfig;
+    use qfc_mempool::MempoolConfig;
+    use qfc_storage::{Database, StorageConfig};
+
+    struct FakeSync;
+
+    impl SyncStatusProvider for FakeSync {
+        fn is_syncing(&self) -> bool {
+            false
+        }
+        fn highest_peer_block(&self) -> u64 {
+            42
+        }
+        fn pending_count(&self) -> usize {
+            0
+        }
+    }
+
+    /// T2.2: the exporter output must contain every metric name referenced by
+    /// docs/observability/ (dashboard + alert rules).
+    #[test]
+    fn render_metrics_includes_expected_metric_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(StorageConfig {
+            path: tmp.path().join("db"),
+            create_if_missing: true,
+            ..Default::default()
+        })
+        .unwrap();
+        let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
+        let chain = Arc::new(
+            Chain::new(
+                db,
+                ChainConfig {
+                    chain_id: 9000,
+                    genesis: GenesisConfig::dev(),
+                },
+                consensus.clone(),
+            )
+            .unwrap(),
+        );
+        let mempool = Arc::new(RwLock::new(Mempool::new(MempoolConfig::default())));
+        let proof_pool = Arc::new(RwLock::new(ProofPool::new()));
+
+        let rpc_metrics = Arc::new(RpcMetrics::new());
+        rpc_metrics.request_started();
+        rpc_metrics.request_finished("eth_blockNumber", std::time::Duration::from_millis(5), None);
+
+        let server = MetricsServer::new(
+            "127.0.0.1:0".parse().unwrap(),
+            chain,
+            consensus,
+            mempool,
+            None,
+            proof_pool,
+            9000,
+        )
+        .with_sync_status(Arc::new(FakeSync))
+        .with_rpc_metrics(rpc_metrics);
+
+        let out = server.render_metrics();
+
+        for name in [
+            // chain
+            "qfc_block_height",
+            "qfc_block_time_seconds",
+            "qfc_time_since_last_block_seconds",
+            "qfc_reorgs_detected_total",
+            "qfc_transactions_total",
+            // mempool
+            "qfc_mempool_size",
+            "qfc_mempool_oldest_tx_age_seconds",
+            // network / sync
+            "qfc_peer_count",
+            "qfc_sync_syncing",
+            "qfc_sync_highest_peer_block",
+            "qfc_sync_lag_blocks",
+            "qfc_sync_pending_blocks",
+            // rpc (rendered from the shared registry)
+            "qfc_rpc_requests_in_flight",
+            "qfc_rpc_requests_total",
+            "qfc_rpc_request_duration_seconds_bucket",
+            "qfc_rpc_errors_total",
+        ] {
+            assert!(
+                out.contains(name),
+                "missing metric `{name}` in exporter output:\n{out}"
+            );
         }
     }
 }

--- a/crates/qfc-rpc/src/lib.rs
+++ b/crates/qfc-rpc/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod error;
 mod eth;
+pub mod metrics;
 mod qfc;
 mod server;
 mod txpool;

--- a/crates/qfc-rpc/src/metrics.rs
+++ b/crates/qfc-rpc/src/metrics.rs
@@ -1,0 +1,304 @@
+//! RPC observability metrics (T2.2).
+//!
+//! Lock-light Prometheus-style metrics for the JSON-RPC server:
+//! - per-method latency histograms (buckets chosen for p50/p99/p999 queries),
+//! - an in-flight request gauge,
+//! - error counters labelled by method and JSON-RPC error code.
+//!
+//! The metrics are recorded by [`MetricsMiddleware`], a jsonrpsee RPC
+//! middleware, and rendered into the node's Prometheus exporter via
+//! [`RpcMetrics::render_prometheus`]. No `prometheus` crate dependency — the
+//! node exporter (qfc-node/src/metrics.rs) hand-renders the text format, and
+//! this module follows the same convention.
+
+use futures::future::BoxFuture;
+use jsonrpsee::core::server::MethodResponse;
+use jsonrpsee::server::middleware::rpc::RpcServiceT;
+use jsonrpsee::types::Request;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Histogram bucket upper bounds in seconds.
+///
+/// Spans 500µs (cache-hit reads) to 10s (worst-case range scans) with enough
+/// resolution around 1–500ms for meaningful p50/p99/p999 estimates via
+/// `histogram_quantile()`.
+pub const LATENCY_BUCKETS_SECONDS: [f64; 14] = [
+    0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+/// Per-method counters and latency histogram.
+#[derive(Default)]
+struct MethodStats {
+    /// Total completed requests.
+    count: AtomicU64,
+    /// Sum of observed durations in nanoseconds (rendered as seconds in `_sum`).
+    sum_nanos: AtomicU64,
+    /// Cumulative-style bucket counts are computed at render time; these are
+    /// per-bucket (non-cumulative) increments to keep recording a single
+    /// fetch_add.
+    buckets: [AtomicU64; LATENCY_BUCKETS_SECONDS.len()],
+    /// Observations larger than the last bucket bound (counted in `+Inf` only).
+    overflow: AtomicU64,
+    /// Error counts by JSON-RPC error code.
+    errors_by_code: RwLock<HashMap<i32, u64>>,
+}
+
+impl MethodStats {
+    fn record(&self, elapsed: Duration, error_code: Option<i32>) {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.sum_nanos
+            .fetch_add(elapsed.as_nanos() as u64, Ordering::Relaxed);
+
+        let secs = elapsed.as_secs_f64();
+        match LATENCY_BUCKETS_SECONDS.iter().position(|&le| secs <= le) {
+            Some(idx) => {
+                self.buckets[idx].fetch_add(1, Ordering::Relaxed);
+            }
+            None => {
+                self.overflow.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        if let Some(code) = error_code {
+            *self.errors_by_code.write().entry(code).or_insert(0) += 1;
+        }
+    }
+}
+
+/// Shared RPC metrics registry.
+///
+/// One instance per node, shared between the RPC middleware (writer) and the
+/// Prometheus exporter (reader).
+#[derive(Default)]
+pub struct RpcMetrics {
+    /// Requests currently being processed.
+    in_flight: AtomicU64,
+    /// Per-method stats, keyed by JSON-RPC method name.
+    methods: RwLock<HashMap<String, Arc<MethodStats>>>,
+}
+
+impl RpcMetrics {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn method_stats(&self, method: &str) -> Arc<MethodStats> {
+        if let Some(stats) = self.methods.read().get(method) {
+            return stats.clone();
+        }
+        self.methods
+            .write()
+            .entry(method.to_owned())
+            .or_default()
+            .clone()
+    }
+
+    /// Increment the in-flight gauge (request started).
+    pub fn request_started(&self) {
+        self.in_flight.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Decrement the in-flight gauge (request finished) and record the
+    /// observation.
+    pub fn request_finished(&self, method: &str, elapsed: Duration, error_code: Option<i32>) {
+        self.in_flight.fetch_sub(1, Ordering::Relaxed);
+        self.method_stats(method).record(elapsed, error_code);
+    }
+
+    /// Current number of in-flight requests.
+    pub fn in_flight(&self) -> u64 {
+        self.in_flight.load(Ordering::Relaxed)
+    }
+
+    /// Append all RPC metrics to `out` in Prometheus text exposition format.
+    pub fn render_prometheus(&self, out: &mut String) {
+        let _ = writeln!(
+            out,
+            "# HELP qfc_rpc_requests_in_flight JSON-RPC requests currently being processed."
+        );
+        let _ = writeln!(out, "# TYPE qfc_rpc_requests_in_flight gauge");
+        let _ = writeln!(out, "qfc_rpc_requests_in_flight {}", self.in_flight());
+
+        // Snapshot method map (Arc clones; cheap) so we don't hold the lock
+        // while formatting.
+        let methods: Vec<(String, Arc<MethodStats>)> = {
+            let guard = self.methods.read();
+            let mut v: Vec<_> = guard.iter().map(|(k, s)| (k.clone(), s.clone())).collect();
+            v.sort_by(|a, b| a.0.cmp(&b.0));
+            v
+        };
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_rpc_requests_total Total JSON-RPC requests completed, by method."
+        );
+        let _ = writeln!(out, "# TYPE qfc_rpc_requests_total counter");
+        for (method, stats) in &methods {
+            let _ = writeln!(
+                out,
+                "qfc_rpc_requests_total{{method=\"{method}\"}} {}",
+                stats.count.load(Ordering::Relaxed)
+            );
+        }
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_rpc_request_duration_seconds JSON-RPC request latency, by method."
+        );
+        let _ = writeln!(out, "# TYPE qfc_rpc_request_duration_seconds histogram");
+        for (method, stats) in &methods {
+            let mut cumulative = 0u64;
+            for (idx, le) in LATENCY_BUCKETS_SECONDS.iter().enumerate() {
+                cumulative += stats.buckets[idx].load(Ordering::Relaxed);
+                let _ = writeln!(
+                    out,
+                    "qfc_rpc_request_duration_seconds_bucket{{method=\"{method}\",le=\"{le}\"}} {cumulative}"
+                );
+            }
+            let total = cumulative + stats.overflow.load(Ordering::Relaxed);
+            let _ = writeln!(
+                out,
+                "qfc_rpc_request_duration_seconds_bucket{{method=\"{method}\",le=\"+Inf\"}} {total}"
+            );
+            let sum_secs = stats.sum_nanos.load(Ordering::Relaxed) as f64 / 1e9;
+            let _ = writeln!(
+                out,
+                "qfc_rpc_request_duration_seconds_sum{{method=\"{method}\"}} {sum_secs:.9}"
+            );
+            let _ = writeln!(
+                out,
+                "qfc_rpc_request_duration_seconds_count{{method=\"{method}\"}} {}",
+                stats.count.load(Ordering::Relaxed)
+            );
+        }
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_rpc_errors_total JSON-RPC error responses, by method and error code."
+        );
+        let _ = writeln!(out, "# TYPE qfc_rpc_errors_total counter");
+        for (method, stats) in &methods {
+            let errors = stats.errors_by_code.read();
+            let mut codes: Vec<_> = errors.iter().collect();
+            codes.sort_by_key(|(code, _)| **code);
+            for (code, count) in codes {
+                let _ = writeln!(
+                    out,
+                    "qfc_rpc_errors_total{{method=\"{method}\",code=\"{code}\"}} {count}"
+                );
+            }
+        }
+    }
+}
+
+/// RPC service wrapper that times each call and classifies the response.
+///
+/// Install via `RpcServiceBuilder::new().layer_fn(move |s| MetricsMiddleware::new(s, metrics.clone()))`
+/// and `ServerBuilder::set_rpc_middleware`.
+#[derive(Clone)]
+pub struct MetricsMiddleware<S> {
+    inner: S,
+    metrics: Arc<RpcMetrics>,
+}
+
+impl<S> MetricsMiddleware<S> {
+    /// Wrap an RPC service, recording into the given registry.
+    pub fn new(inner: S, metrics: Arc<RpcMetrics>) -> Self {
+        Self { inner, metrics }
+    }
+}
+
+impl<'a, S> RpcServiceT<'a> for MetricsMiddleware<S>
+where
+    S: RpcServiceT<'a> + Send + Sync + 'a,
+{
+    type Future = BoxFuture<'a, MethodResponse>;
+
+    fn call(&self, request: Request<'a>) -> Self::Future {
+        let metrics = self.metrics.clone();
+        let method = request.method_name().to_owned();
+        metrics.request_started();
+        let fut = self.inner.call(request);
+
+        Box::pin(async move {
+            let start = Instant::now();
+            let response = fut.await;
+            metrics.request_finished(&method, start.elapsed(), response.as_error_code());
+            response
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_and_renders_basic_metrics() {
+        let metrics = RpcMetrics::new();
+
+        metrics.request_started();
+        metrics.request_finished("eth_blockNumber", Duration::from_micros(800), None);
+        metrics.request_started();
+        metrics.request_finished("eth_blockNumber", Duration::from_millis(30), None);
+        metrics.request_started();
+        metrics.request_finished("eth_call", Duration::from_millis(120), Some(-32000));
+
+        let mut out = String::new();
+        metrics.render_prometheus(&mut out);
+
+        // Metric families present
+        assert!(out.contains("qfc_rpc_requests_in_flight 0"));
+        assert!(out.contains("qfc_rpc_requests_total{method=\"eth_blockNumber\"} 2"));
+        assert!(out.contains("qfc_rpc_requests_total{method=\"eth_call\"} 1"));
+        assert!(out.contains("qfc_rpc_errors_total{method=\"eth_call\",code=\"-32000\"} 1"));
+        assert!(
+            out.contains("qfc_rpc_request_duration_seconds_count{method=\"eth_blockNumber\"} 2")
+        );
+        assert!(out.contains("qfc_rpc_request_duration_seconds_sum{method=\"eth_blockNumber\"}"));
+    }
+
+    #[test]
+    fn histogram_buckets_are_cumulative() {
+        let metrics = RpcMetrics::new();
+        metrics.request_started();
+        metrics.request_finished("eth_call", Duration::from_micros(400), None); // <= 0.0005
+        metrics.request_started();
+        metrics.request_finished("eth_call", Duration::from_millis(2), None); // <= 0.0025
+        metrics.request_started();
+        metrics.request_finished("eth_call", Duration::from_secs(60), None); // > 10s -> +Inf only
+
+        let mut out = String::new();
+        metrics.render_prometheus(&mut out);
+
+        assert!(out.contains(
+            "qfc_rpc_request_duration_seconds_bucket{method=\"eth_call\",le=\"0.0005\"} 1"
+        ));
+        assert!(out.contains(
+            "qfc_rpc_request_duration_seconds_bucket{method=\"eth_call\",le=\"0.0025\"} 2"
+        ));
+        // Largest finite bucket sees both fast observations, not the 60s one
+        assert!(out
+            .contains("qfc_rpc_request_duration_seconds_bucket{method=\"eth_call\",le=\"10\"} 2"));
+        assert!(out.contains(
+            "qfc_rpc_request_duration_seconds_bucket{method=\"eth_call\",le=\"+Inf\"} 3"
+        ));
+        assert!(out.contains("qfc_rpc_request_duration_seconds_count{method=\"eth_call\"} 3"));
+    }
+
+    #[test]
+    fn in_flight_gauge_tracks_outstanding_requests() {
+        let metrics = RpcMetrics::new();
+        metrics.request_started();
+        metrics.request_started();
+        assert_eq!(metrics.in_flight(), 2);
+        metrics.request_finished("eth_call", Duration::from_millis(1), None);
+        assert_eq!(metrics.in_flight(), 1);
+    }
+}

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -141,6 +141,8 @@ pub struct RpcServer {
     session_key_store: Arc<RwLock<qfc_qvm::stdlib::session_keys::SessionKeyStore>>,
     /// v3.0: Agent discovery index
     agent_index: Arc<RwLock<qfc_qvm::stdlib::agent_index::AgentIndex>>,
+    /// T2.2: RPC observability metrics (latency histograms, in-flight, errors)
+    metrics: Option<Arc<crate::metrics::RpcMetrics>>,
 }
 
 impl Clone for RpcServer {
@@ -174,6 +176,7 @@ impl Clone for RpcServer {
             capability_store: self.capability_store.clone(),
             session_key_store: self.session_key_store.clone(),
             agent_index: self.agent_index.clone(),
+            metrics: self.metrics.clone(),
         }
     }
 }
@@ -230,7 +233,16 @@ impl RpcServer {
                 qfc_qvm::stdlib::session_keys::SessionKeyStore::new(),
             )),
             agent_index: Arc::new(RwLock::new(qfc_qvm::stdlib::agent_index::AgentIndex::new())),
+            metrics: None,
         }
+    }
+
+    /// Set the RPC metrics registry (T2.2). When set, every JSON-RPC call is
+    /// timed and counted via middleware; the registry is rendered by the
+    /// node's Prometheus exporter.
+    pub fn with_metrics(mut self, metrics: Arc<crate::metrics::RpcMetrics>) -> Self {
+        self.metrics = Some(metrics);
+        self
     }
 
     /// Set the challenge generator (P2)
@@ -310,7 +322,22 @@ impl RpcServer {
 
         info!("Starting RPC server on {}", config.http_addr);
 
-        let server = ServerBuilder::default().build(config.http_addr).await?;
+        // T2.2: per-method latency/error/in-flight metrics middleware.
+        // If no registry was attached via `with_metrics`, record into a
+        // private throwaway registry so the server type stays uniform.
+        let metrics = self
+            .metrics
+            .clone()
+            .unwrap_or_else(|| Arc::new(crate::metrics::RpcMetrics::new()));
+        let rpc_middleware =
+            jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(move |service| {
+                crate::metrics::MetricsMiddleware::new(service, metrics.clone())
+            });
+
+        let server = ServerBuilder::default()
+            .set_rpc_middleware(rpc_middleware)
+            .build(config.http_addr)
+            .await?;
 
         // Merge all RPC modules
         let mut eth_module = EthApiServer::into_rpc(self.clone());

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,116 @@
+# QFC Node Observability (T2)
+
+Dashboard and alert rules for the qfc-node Prometheus exporter
+(`crates/qfc-node/src/metrics.rs`) and the RPC metrics middleware
+(`crates/qfc-rpc/src/metrics.rs`).
+
+## Exporter
+
+Every node serves Prometheus text-format metrics on
+`http://<node>:6060/metrics` (configurable via `--metrics-addr` /
+`QFC_METRICS_ADDR`). No extra flags needed — chain, sync, mempool, and RPC
+metrics are always on.
+
+Scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: qfc-node          # alert rules expect job="qfc-node"
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["node-a:6060", "node-b:6060"]
+```
+
+## Loading the alert rules
+
+1. Copy `alert-rules.yaml` to your Prometheus config directory.
+2. Reference it in `prometheus.yml`:
+
+   ```yaml
+   rule_files:
+     - alert-rules.yaml
+   ```
+
+3. Reload Prometheus (`kill -HUP` or `POST /-/reload`).
+
+The rules include recording rules (`qfc:*`) used by both the burn-rate alerts
+and the dashboard SLO panels — load the whole file, not just the alert groups.
+
+SLOs encoded in the rules (multi-window multi-burn-rate, per the Google SRE
+Workbook):
+
+| SLO | Target | SLI |
+|---|---|---|
+| Block production | 99.9% | head block younger than 30s |
+| RPC availability | 99.9% | non-client-error responses / total requests |
+| RPC latency | 99% | requests completing in < 250ms |
+
+Commented placeholders at the bottom of the file are intentionally disabled
+until their metrics exist:
+
+- **Backup freshness** — enable after T4 exports `qfc_backup_last_success_timestamp_seconds`.
+- **RocksDB write stall / compaction backlog** — enable after T2.1 lands the
+  qfc-storage statistics hook.
+
+## Loading the Grafana dashboard
+
+UI: *Dashboards → New → Import → Upload JSON file* →
+`grafana-dashboard.json` → select your Prometheus datasource when prompted.
+
+Provisioning: drop the JSON into your dashboards provider directory, e.g.
+
+```yaml
+# /etc/grafana/provisioning/dashboards/qfc.yaml
+apiVersion: 1
+providers:
+  - name: qfc
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards/qfc
+```
+
+and place `grafana-dashboard.json` in that path. The dashboard has an
+`$instance` variable populated from `qfc_block_height`.
+
+## Metric inventory (T2.2)
+
+| Metric | Type | Labels | Source |
+|---|---|---|---|
+| `qfc_block_height` | gauge | — | chain head |
+| `qfc_blocks_produced_total` | counter | — | chain head |
+| `qfc_transactions_total` | counter | — | blocks (accumulated) |
+| `qfc_block_time_seconds` | gauge | — | last two block timestamps |
+| `qfc_time_since_last_block_seconds` | gauge | — | head timestamp vs wall clock |
+| `qfc_reorgs_detected_total` | counter | — | exporter (scrape-granularity hash check) |
+| `qfc_sync_syncing` | gauge (0/1) | — | SyncManager |
+| `qfc_sync_highest_peer_block` | gauge | — | SyncManager |
+| `qfc_sync_lag_blocks` | gauge | — | SyncManager vs head |
+| `qfc_sync_pending_blocks` | gauge | — | SyncManager |
+| `qfc_mempool_size` | gauge | — | mempool |
+| `qfc_mempool_oldest_tx_age_seconds` | gauge | — | mempool |
+| `qfc_peer_count` | gauge | — | libp2p network service |
+| `qfc_active_validators` | gauge | — | consensus |
+| `qfc_is_validator` | gauge (0/1) | — | consensus |
+| `qfc_epoch_number` | gauge | — | consensus |
+| `qfc_contribution_score` | gauge | `validator` | consensus |
+| `qfc_inference_flops_total` | counter | `validator` | consensus |
+| `qfc_inference_score` | gauge | `validator` | consensus |
+| `qfc_inference_tasks_completed` | gauge | — | proof pool |
+| `qfc_inference_pass_rate` | gauge | — | proof pool |
+| `qfc_chain_id` | gauge | — | config |
+| `qfc_node_info` | gauge | `version` | build info |
+| `qfc_rpc_requests_in_flight` | gauge | — | RPC middleware |
+| `qfc_rpc_requests_total` | counter | `method` | RPC middleware |
+| `qfc_rpc_request_duration_seconds` | histogram | `method`, `le` | RPC middleware |
+| `qfc_rpc_errors_total` | counter | `method`, `code` | RPC middleware |
+
+Notes:
+
+- `qfc_reorgs_detected_total` counts canonical-chain rewrites observed between
+  scrapes (the block hash previously seen at a height changed). Reorgs that
+  fully revert between two scrapes are missed; a precise import-time counter
+  ships with the T2.1/T3 follow-up (needs a hook in `qfc-chain`).
+- RPC histogram buckets span 500µs–10s (14 buckets), tuned so
+  `histogram_quantile()` gives usable p50/p99/p999.
+- RocksDB metrics (`qfc_rocksdb_*`) are **not exported yet** — T2.1 is
+  deferred to a follow-up PR; the exporter has a marked seam for it.

--- a/docs/observability/alert-rules.yaml
+++ b/docs/observability/alert-rules.yaml
@@ -1,0 +1,304 @@
+# QFC node Prometheus alerting rules (T2.3)
+#
+# Metric names match the exporter in crates/qfc-node/src/metrics.rs and the
+# RPC middleware in crates/qfc-rpc/src/metrics.rs.
+#
+# SLOs:
+#   - Block production: 99.9% of time, head block is < 30s old
+#     (block interval is 3-5s, so 30s ~= 6+ consecutive missed blocks).
+#   - RPC availability: 99.9% of requests succeed (client errors excluded).
+#   - RPC latency: 99% of requests complete within 250ms.
+#
+# Burn-rate alerting follows the multi-window multi-burn-rate pattern from the
+# Google SRE Workbook ch.5: page on 14.4x/1h(+5m) and 6x/6h(+30m); ticket on
+# 1x/3d(+6h). Budget for a 99.9% SLO is 0.001; for 99% it is 0.01.
+
+groups:
+  # ---------------------------------------------------------------- recording
+  - name: qfc-slo-recording
+    interval: 15s
+    rules:
+      # 1 when block production is stalled (head older than 30s), else 0.
+      - record: qfc:block_production_stalled:bool
+        expr: (qfc_time_since_last_block_seconds > bool 30)
+
+      # RPC error ratio, excluding caller-side JSON-RPC errors
+      # (-32700 parse, -32600 invalid request, -32601 method not found,
+      #  -32602 invalid params).
+      - record: qfc:rpc_error_ratio:rate5m
+        expr: |
+          sum(rate(qfc_rpc_errors_total{code!~"-32700|-32600|-32601|-32602"}[5m]))
+          /
+          clamp_min(sum(rate(qfc_rpc_requests_total[5m])), 1e-10)
+      - record: qfc:rpc_error_ratio:rate30m
+        expr: |
+          sum(rate(qfc_rpc_errors_total{code!~"-32700|-32600|-32601|-32602"}[30m]))
+          /
+          clamp_min(sum(rate(qfc_rpc_requests_total[30m])), 1e-10)
+      - record: qfc:rpc_error_ratio:rate1h
+        expr: |
+          sum(rate(qfc_rpc_errors_total{code!~"-32700|-32600|-32601|-32602"}[1h]))
+          /
+          clamp_min(sum(rate(qfc_rpc_requests_total[1h])), 1e-10)
+      - record: qfc:rpc_error_ratio:rate6h
+        expr: |
+          sum(rate(qfc_rpc_errors_total{code!~"-32700|-32600|-32601|-32602"}[6h]))
+          /
+          clamp_min(sum(rate(qfc_rpc_requests_total[6h])), 1e-10)
+      - record: qfc:rpc_error_ratio:rate3d
+        expr: |
+          sum(rate(qfc_rpc_errors_total{code!~"-32700|-32600|-32601|-32602"}[3d]))
+          /
+          clamp_min(sum(rate(qfc_rpc_requests_total[3d])), 1e-10)
+
+      # RPC slow-request ratio: fraction of requests slower than 250ms.
+      - record: qfc:rpc_slow_ratio:rate5m
+        expr: |
+          1 - (
+            sum(rate(qfc_rpc_request_duration_seconds_bucket{le="0.25"}[5m]))
+            /
+            clamp_min(sum(rate(qfc_rpc_request_duration_seconds_count[5m])), 1e-10)
+          )
+      - record: qfc:rpc_slow_ratio:rate30m
+        expr: |
+          1 - (
+            sum(rate(qfc_rpc_request_duration_seconds_bucket{le="0.25"}[30m]))
+            /
+            clamp_min(sum(rate(qfc_rpc_request_duration_seconds_count[30m])), 1e-10)
+          )
+      - record: qfc:rpc_slow_ratio:rate1h
+        expr: |
+          1 - (
+            sum(rate(qfc_rpc_request_duration_seconds_bucket{le="0.25"}[1h]))
+            /
+            clamp_min(sum(rate(qfc_rpc_request_duration_seconds_count[1h])), 1e-10)
+          )
+      - record: qfc:rpc_slow_ratio:rate6h
+        expr: |
+          1 - (
+            sum(rate(qfc_rpc_request_duration_seconds_bucket{le="0.25"}[6h]))
+            /
+            clamp_min(sum(rate(qfc_rpc_request_duration_seconds_count[6h])), 1e-10)
+          )
+
+  # ----------------------------------------------- block production SLO 99.9%
+  - name: qfc-block-production-slo
+    rules:
+      # Fast burn: 14.4x budget over 1h, confirmed by 5m window. At this rate
+      # the 30-day budget is gone in ~2 days.
+      - alert: QfcBlockProductionBurnRateFast
+        expr: |
+          avg_over_time(qfc:block_production_stalled:bool[1h]) > (14.4 * 0.001)
+          and
+          avg_over_time(qfc:block_production_stalled:bool[5m]) > (14.4 * 0.001)
+        for: 2m
+        labels:
+          severity: page
+          slo: block-production
+        annotations:
+          summary: "Block production SLO fast burn (14.4x) on {{ $labels.instance }}"
+          description: >-
+            Block production has been stalled (head older than 30s) for more
+            than 1.44% of the last hour. Current head age:
+            {{ with query "qfc_time_since_last_block_seconds" }}{{ . | first | value | printf "%.0f" }}s{{ end }}.
+
+      # Slow burn: 6x budget over 6h, confirmed by 30m window.
+      - alert: QfcBlockProductionBurnRateSlow
+        expr: |
+          avg_over_time(qfc:block_production_stalled:bool[6h]) > (6 * 0.001)
+          and
+          avg_over_time(qfc:block_production_stalled:bool[30m]) > (6 * 0.001)
+        for: 15m
+        labels:
+          severity: ticket
+          slo: block-production
+        annotations:
+          summary: "Block production SLO slow burn (6x) on {{ $labels.instance }}"
+          description: >-
+            Block production stalls are consuming error budget 6x faster than
+            sustainable over the last 6h.
+
+      # Hard stall: head hasn't advanced for 2 minutes — page regardless of
+      # budget math (this is a dead node / dead producer).
+      - alert: QfcBlockProductionStalled
+        expr: qfc_time_since_last_block_seconds > 120
+        for: 1m
+        labels:
+          severity: page
+          slo: block-production
+        annotations:
+          summary: "No block produced for >2m on {{ $labels.instance }}"
+          description: >-
+            Head block is {{ $value | printf "%.0f" }}s old. Check the block
+            producer, validator status (qfc_is_validator), and peers.
+
+  # ------------------------------------------------- RPC availability SLO 99.9%
+  - name: qfc-rpc-availability-slo
+    rules:
+      - alert: QfcRpcErrorBurnRateFast
+        expr: |
+          qfc:rpc_error_ratio:rate1h > (14.4 * 0.001)
+          and
+          qfc:rpc_error_ratio:rate5m > (14.4 * 0.001)
+        for: 2m
+        labels:
+          severity: page
+          slo: rpc-availability
+        annotations:
+          summary: "RPC availability SLO fast burn (14.4x)"
+          description: >-
+            Server-side RPC error ratio over the last hour is
+            {{ $value | humanizePercentage }} (budget burn 14.4x for a 99.9% SLO).
+
+      - alert: QfcRpcErrorBurnRateSlow
+        expr: |
+          qfc:rpc_error_ratio:rate6h > (6 * 0.001)
+          and
+          qfc:rpc_error_ratio:rate30m > (6 * 0.001)
+        for: 15m
+        labels:
+          severity: ticket
+          slo: rpc-availability
+        annotations:
+          summary: "RPC availability SLO slow burn (6x)"
+          description: "Sustained elevated RPC error ratio over 6h."
+
+      - alert: QfcRpcErrorBudgetSlowLeak
+        expr: |
+          qfc:rpc_error_ratio:rate3d > 0.001
+          and
+          qfc:rpc_error_ratio:rate6h > 0.001
+        for: 1h
+        labels:
+          severity: ticket
+          slo: rpc-availability
+        annotations:
+          summary: "RPC availability error budget leaking (1x over 3d)"
+          description: "Error ratio above SLO target for 3 days; budget will be exhausted by month end."
+
+  # ---------------------------------------------------- RPC latency SLO 99%
+  - name: qfc-rpc-latency-slo
+    rules:
+      - alert: QfcRpcLatencyBurnRateFast
+        expr: |
+          qfc:rpc_slow_ratio:rate1h > (14.4 * 0.01)
+          and
+          qfc:rpc_slow_ratio:rate5m > (14.4 * 0.01)
+        for: 2m
+        labels:
+          severity: page
+          slo: rpc-latency
+        annotations:
+          summary: "RPC latency SLO fast burn (14.4x)"
+          description: >-
+            More than 14.4% of RPC requests in the last hour took longer than
+            250ms (99% <250ms SLO).
+
+      - alert: QfcRpcLatencyBurnRateSlow
+        expr: |
+          qfc:rpc_slow_ratio:rate6h > (6 * 0.01)
+          and
+          qfc:rpc_slow_ratio:rate30m > (6 * 0.01)
+        for: 15m
+        labels:
+          severity: ticket
+          slo: rpc-latency
+        annotations:
+          summary: "RPC latency SLO slow burn (6x)"
+          description: "Sustained slow RPC requests over the last 6h."
+
+  # -------------------------------------------------------- operational alerts
+  - name: qfc-node-operational
+    rules:
+      - alert: QfcNodeDown
+        expr: up{job="qfc-node"} == 0
+        for: 2m
+        labels:
+          severity: page
+        annotations:
+          summary: "qfc-node exporter down on {{ $labels.instance }}"
+          description: "Prometheus cannot scrape the node's /metrics endpoint."
+
+      - alert: QfcNoPeers
+        expr: qfc_peer_count == 0
+        for: 10m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Node has no peers ({{ $labels.instance }})"
+          description: "qfc_peer_count has been 0 for 10m; node is isolated from the network."
+
+      - alert: QfcSyncLagHigh
+        expr: qfc_sync_lag_blocks > 50
+        for: 10m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Node {{ $labels.instance }} is {{ $value }} blocks behind peers"
+          description: >-
+            qfc_sync_lag_blocks has exceeded 50 for 10m. Check qfc_sync_syncing
+            and qfc_sync_pending_blocks for a stuck sync pipeline.
+
+      - alert: QfcMempoolStuckTransactions
+        expr: qfc_mempool_oldest_tx_age_seconds > 900 and qfc_mempool_size > 0
+        for: 5m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Oldest mempool tx is {{ $value | printf \"%.0f\" }}s old on {{ $labels.instance }}"
+          description: >-
+            Transactions are not being included in blocks (mempool TTL is 1h,
+            so >15m age means inclusion has stalled while txs still pend).
+
+      - alert: QfcReorgDetected
+        expr: increase(qfc_reorgs_detected_total[1h]) > 0
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Chain reorg detected on {{ $labels.instance }}"
+          description: >-
+            The exporter observed a canonical-chain rewrite (scrape-granularity
+            detection). Investigate consensus health and peer divergence.
+
+  # ------------------------------------------------------------- placeholders
+  #
+  # T4 (DR automation) — backup freshness. Enable once the backup task exports
+  # qfc_backup_last_success_timestamp_seconds. Alert on AGE, not job success.
+  #
+  # - name: qfc-backup-freshness
+  #   rules:
+  #     - alert: QfcBackupStale
+  #       expr: time() - qfc_backup_last_success_timestamp_seconds > 2 * 3600
+  #       for: 15m
+  #       labels:
+  #         severity: ticket
+  #       annotations:
+  #         summary: "Last successful backup is older than 2h ({{ $labels.instance }})"
+  #         description: "RPO at risk: snapshot shipping to object storage has not succeeded recently."
+  #     - alert: QfcBackupVeryStale
+  #       expr: time() - qfc_backup_last_success_timestamp_seconds > 12 * 3600
+  #       labels:
+  #         severity: page
+  #       annotations:
+  #         summary: "No successful backup for >12h ({{ $labels.instance }})"
+  #
+  # T2.1 (RocksDB statistics export) — write-stall and compaction pressure.
+  # Enable once qfc-storage exports rocksdb statistics (parallel branch).
+  #
+  # - name: qfc-rocksdb
+  #   rules:
+  #     - alert: QfcRocksdbWriteStall
+  #       expr: rate(qfc_rocksdb_stall_micros_total[5m]) > 0
+  #       for: 5m
+  #       labels:
+  #         severity: ticket
+  #       annotations:
+  #         summary: "RocksDB write stalls on {{ $labels.instance }}"
+  #         description: "Compaction/flush cannot keep up with the write rate."
+  #     - alert: QfcRocksdbCompactionBacklog
+  #       expr: qfc_rocksdb_pending_compaction_bytes > 64 * 1024 * 1024 * 1024
+  #       for: 30m
+  #       labels:
+  #         severity: ticket
+  #       annotations:
+  #         summary: "RocksDB pending compaction backlog >64GiB ({{ $labels.instance }})"

--- a/docs/observability/grafana-dashboard.json
+++ b/docs/observability/grafana-dashboard.json
@@ -1,0 +1,425 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "title": "QFC Node Observability (T2)",
+  "uid": "qfc-node-observability",
+  "tags": ["qfc", "blockchain", "sre"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "type": "query",
+        "label": "Instance",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(qfc_block_height, instance)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": false,
+        "current": { "selected": false, "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Block production",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Block height",
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "max(qfc_block_height{instance=~\"$instance\"})", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 }, "overrides": [] }
+    },
+    {
+      "type": "stat",
+      "title": "Reorgs detected (24h)",
+      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "sum(increase(qfc_reorgs_detected_total{instance=~\"$instance\"}[24h]))", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Time since last block (block-production SLI, alert at 30s)",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "qfc_time_since_last_block_seconds{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 30 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Block production rate (blocks/min) & block time",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "rate(qfc_blocks_produced_total{instance=~\"$instance\"}[5m]) * 60",
+          "legendFormat": "blocks/min {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "qfc_block_time_seconds{instance=~\"$instance\"}",
+          "legendFormat": "block time (s) {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 5 } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Transactions processed (rate)",
+      "gridPos": { "h": 3, "w": 8, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "rate(qfc_transactions_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "tx/s {{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
+    },
+    {
+      "type": "row",
+      "title": "Sync & network",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Sync lag vs peers (blocks)",
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "qfc_sync_lag_blocks{instance=~\"$instance\"}",
+          "legendFormat": "lag {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "qfc_sync_pending_blocks{instance=~\"$instance\"}",
+          "legendFormat": "pending parents {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Local height vs highest peer",
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "qfc_block_height{instance=~\"$instance\"}",
+          "legendFormat": "local {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "qfc_sync_highest_peer_block{instance=~\"$instance\"}",
+          "legendFormat": "highest peer {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line" } }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "Peers / validators / syncing",
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "qfc_peer_count{instance=~\"$instance\"}",
+          "legendFormat": "peers {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "qfc_active_validators{instance=~\"$instance\"}",
+          "legendFormat": "active validators {{instance}}",
+          "refId": "B"
+        },
+        {
+          "expr": "qfc_sync_syncing{instance=~\"$instance\"}",
+          "legendFormat": "syncing (0/1) {{instance}}",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line" } }, "overrides": [] }
+    },
+    {
+      "type": "row",
+      "title": "Mempool",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Mempool depth",
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "qfc_mempool_size{instance=~\"$instance\"}",
+          "legendFormat": "pending txs {{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 20 } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Oldest pending tx age (alert at 15m)",
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "qfc_mempool_oldest_tx_age_seconds{instance=~\"$instance\"}",
+          "legendFormat": "oldest tx age {{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 900 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "title": "RPC — latency & error SLOs",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "RPC latency p50 / p99 / p999 (all methods)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(qfc_rpc_request_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(qfc_rpc_request_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.999, sum by (le) (rate(qfc_rpc_request_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "p999",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 5 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.25 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "RPC p99 latency by method (top consumers)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, method) (rate(qfc_rpc_request_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "drawStyle": "line" } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "RPC request rate by method",
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 34 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (method) (rate(qfc_rpc_requests_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "stacking": { "mode": "normal" }, "fillOpacity": 30 } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "RPC error ratio (availability SLO 99.9% — budget line 0.1%)",
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 34 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate(qfc_rpc_errors_total{instance=~\"$instance\",code!~\"-32700|-32600|-32601|-32602\"}[5m])) / clamp_min(sum(rate(qfc_rpc_requests_total{instance=~\"$instance\"}[5m])), 1e-10)",
+          "legendFormat": "server error ratio (5m)",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (method, code) (rate(qfc_rpc_errors_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{method}} {{code}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.001 }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byFrameRefID", "options": "B" },
+            "properties": [{ "id": "unit", "value": "ops" }]
+          }
+        ]
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "RPC slow-request ratio (>250ms; latency SLO 99% — budget line 1%) & in-flight",
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 34 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "1 - (sum(rate(qfc_rpc_request_duration_seconds_bucket{instance=~\"$instance\",le=\"0.25\"}[5m])) / clamp_min(sum(rate(qfc_rpc_request_duration_seconds_count{instance=~\"$instance\"}[5m])), 1e-10))",
+          "legendFormat": "slow ratio (5m)",
+          "refId": "A"
+        },
+        {
+          "expr": "qfc_rpc_requests_in_flight{instance=~\"$instance\"}",
+          "legendFormat": "in-flight {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byFrameRefID", "options": "B" },
+            "properties": [{ "id": "unit", "value": "none" }]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Implements ROADMAP-SRE T2.2 (chain/mempool/RPC metrics) and T2.3 (dashboard + alert rules). **T2.1 (RocksDB statistics export) is deferred to a follow-up PR** — the qfc-storage statistics hook is being added on a parallel branch (`crates/qfc-storage/src/db.rs` / `crates/qfc-chain/src/chain.rs` are owned by that work and untouched here). The exporter has a clearly marked seam (`render_storage_metrics`) for it.

## New metrics

| Metric | Type | Labels | Source |
|---|---|---|---|
| `qfc_time_since_last_block_seconds` | gauge | — | head timestamp vs wall clock (block-stall SLI) |
| `qfc_reorgs_detected_total` | counter | — | exporter: hash-at-previous-height check between scrapes |
| `qfc_mempool_oldest_tx_age_seconds` | gauge | — | new `Mempool::oldest_tx_age()` |
| `qfc_sync_syncing` | gauge (0/1) | — | `SyncManager` via existing `SyncStatusProvider` trait |
| `qfc_sync_highest_peer_block` | gauge | — | `SyncManager` |
| `qfc_sync_lag_blocks` | gauge | — | highest peer − local head (clamped at 0) |
| `qfc_sync_pending_blocks` | gauge | — | `SyncManager` pending-parent queue |
| `qfc_rpc_requests_in_flight` | gauge | — | jsonrpsee RPC middleware |
| `qfc_rpc_requests_total` | counter | `method` | RPC middleware |
| `qfc_rpc_request_duration_seconds` | histogram | `method`, `le` (14 buckets, 500µs–10s) | RPC middleware |
| `qfc_rpc_errors_total` | counter | `method`, `code` | RPC middleware |

Pre-existing metrics (`qfc_block_height`, `qfc_mempool_size`, `qfc_peer_count`, validator/consensus/inference gauges) are unchanged. Everything is served on the existing `tiny_http` exporter (`--metrics-addr`, default `:6060`) — no new endpoint.

## Architecture

- `qfc_rpc::metrics::RpcMetrics` is a lock-light registry (atomics + parking_lot) shared between the jsonrpsee middleware (writer, installed via `ServerBuilder::set_rpc_middleware` + `layer_fn`) and the node exporter (reader, `render_prometheus`). No `prometheus` crate dependency — follows the existing hand-rendered text-format convention in `metrics.rs`.
- `MetricsServer` gains `with_sync_status(Arc<dyn SyncStatusProvider>)` and `with_rpc_metrics(Arc<RpcMetrics>)` builders; wired in `main.rs`.

## docs/observability/

- **grafana-dashboard.json** — block production (height, time-since-last-block w/ 30s threshold, blocks/min, reorgs), sync (lag, local vs peer height, pending), mempool (depth, oldest-tx age), RPC (p50/p99/p999, per-method p99, request rate, error-ratio and slow-ratio SLO panels with budget threshold lines).
- **alert-rules.yaml** — recording rules + multi-window multi-burn-rate alerts (SRE Workbook pattern: page on 14.4×/1h+5m, ticket on 6×/6h+30m, slow-leak 1×/3d) for:
  - block-production SLO (99.9% of time head < 30s old), plus a hard-stall page at 2min;
  - RPC availability SLO (99.9%, client-error codes −32700/−32600/−32601/−32602 excluded);
  - RPC latency SLO (99% < 250ms);
  - operational alerts: node down, no peers, sync lag > 50, stuck mempool tx, reorg detected;
  - **commented placeholders** for backup freshness (enable with T4) and RocksDB write-stall/compaction backlog (enable with T2.1).
- **README.md** — scrape config, loading instructions, full metric inventory.

Metric names in the dashboard/alerts are asserted against the exporter output by the new render test.

## Deferred to T2.1 follow-up

- RocksDB statistics (compaction stalls, pending-compaction bytes, block-cache hit/miss, memtable size, per-CF volume, WAL sync latency) — blocked on the qfc-storage stats hook.
- Precise import-time reorg counter — needs a hook in `qfc-chain/src/chain.rs` (forbidden here). Current `qfc_reorgs_detected_total` is scrape-granularity detection (documented in HELP text and README).
- Per-validator block-lag vs specific peers — only the aggregate `highest_peer_block` is tracked by `SyncManager` today.

## Tests

- `cargo build -p qfc-node -p qfc-rpc` ✅
- `cargo test -p qfc-node -p qfc-rpc -p qfc-mempool` ✅ — 10+6 qfc-node (incl. live-node integration tests through the new middleware), 33 qfc-rpc, 7 qfc-mempool
- New tests: exporter render contains all dashboard/alert metric names; histogram bucket cumulativity + +Inf; error labelling; in-flight gauge; `oldest_tx_age`.
- `cargo fmt --check` clean; clippy introduces no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)