### PR TITLE
T2.1: RocksDB statistics + property metrics in exporter, dashboard + stall alerts

### DIFF
--- a/crates/qfc-node/src/main.rs
+++ b/crates/qfc-node/src/main.rs
@@ -97,6 +97,12 @@ struct Args {
     #[arg(long, default_value = "0.0.0.0:6060", env = "QFC_METRICS_ADDR")]
     metrics_addr: SocketAddr,
 
+    /// Enable RocksDB statistics collection (tickers + histograms; costs a few
+    /// percent of storage throughput). Exposes qfc_rocksdb_* counter metrics
+    /// on /metrics; property-based gauges are exported regardless.
+    #[arg(long, env = "QFC_DB_STATISTICS")]
+    db_statistics: bool,
+
     /// IPFS Kubo API URL for large inference result storage (optional)
     #[arg(long, env = "QFC_IPFS_API_URL")]
     ipfs_api_url: Option<String>,
@@ -157,10 +163,14 @@ async fn main() -> Result<()> {
     let storage_config = StorageConfig {
         path: args.datadir.join("db"),
         create_if_missing: true,
+        enable_statistics: args.db_statistics,
         ..Default::default()
     };
     let db = Database::open(storage_config)?;
-    info!("Database opened");
+    info!(
+        "Database opened (statistics: {})",
+        if args.db_statistics { "on" } else { "off" }
+    );
 
     // Create genesis config
     let genesis = if args.dev {
@@ -471,7 +481,8 @@ async fn main() -> Result<()> {
         proof_pool.clone(),
         args.chain_id,
     )
-    .with_rpc_metrics(rpc_metrics.clone());
+    .with_rpc_metrics(rpc_metrics.clone())
+    .with_storage(db.clone());
     if let Some(ref sync) = _sync_manager {
         metrics_server =
             metrics_server.with_sync_status(sync.clone() as Arc<dyn qfc_rpc::SyncStatusProvider>);

--- a/crates/qfc-node/src/metrics.rs
+++ b/crates/qfc-node/src/metrics.rs
@@ -12,6 +12,7 @@ use qfc_mempool::Mempool;
 use qfc_network::NetworkService;
 use qfc_rpc::metrics::RpcMetrics;
 use qfc_rpc::SyncStatusProvider;
+use qfc_storage::{cf, props, Database, Histogram, Ticker};
 use qfc_types::Hash;
 use std::fmt::Write as _;
 use std::net::SocketAddr;
@@ -39,6 +40,8 @@ pub struct MetricsServer {
     last_head: Mutex<Option<(u64, Hash)>>,
     /// T2.2: reorgs detected at scrape granularity (see `update_reorg_detection`)
     reorgs_detected: AtomicU64,
+    /// T2.1: handle to the live RocksDB for statistics/property export
+    storage: Option<Database>,
 }
 
 impl MetricsServer {
@@ -65,6 +68,7 @@ impl MetricsServer {
             rpc_metrics: None,
             last_head: Mutex::new(None),
             reorgs_detected: AtomicU64::new(0),
+            storage: None,
         }
     }
 
@@ -77,6 +81,13 @@ impl MetricsServer {
     /// Attach the RPC metrics registry shared with the RPC middleware (T2.2).
     pub fn with_rpc_metrics(mut self, rpc_metrics: Arc<RpcMetrics>) -> Self {
         self.rpc_metrics = Some(rpc_metrics);
+        self
+    }
+
+    /// Attach the live database for RocksDB statistics/property export (T2.1).
+    /// `Database` is a cheap `Arc` clone of the node's open DB.
+    pub fn with_storage(mut self, storage: Database) -> Self {
+        self.storage = Some(storage);
         self
     }
 
@@ -375,16 +386,207 @@ impl MetricsServer {
             rpc.render_prometheus(&mut out);
         }
 
-        // --- storage (T2.1, deferred) ---
-        // TODO(T2.1): RocksDB statistics export — compaction-stall counters,
-        // pending-compaction bytes, block-cache hit/miss, memtable size,
-        // per-CF read/write volume, WAL sync latency. Blocked on the
-        // qfc-storage statistics hook landing on a parallel branch (touches
-        // crates/qfc-storage/src/db.rs, owned by the T3 work). When it lands,
-        // render it here:
-        //   self.render_storage_metrics(&mut out);
+        // --- storage (T2.1) ---
+        if let Some(db) = &self.storage {
+            Self::render_storage_metrics(db, &mut out);
+        }
 
         out
+    }
+
+    /// T2.1: RocksDB metrics, two layers:
+    ///
+    /// 1. **Properties** (always exported): computed on demand from live
+    ///    engine state, no statistics overhead. Per-CF memtable size,
+    ///    pending-compaction bytes, immutable memtables, and L0 file count
+    ///    across all 18 CFs, plus DB-wide block-cache usage and the two
+    ///    write-stall condition gauges.
+    /// 2. **Statistics tickers/histograms** (only when the DB was opened with
+    ///    `enable_statistics`, i.e. `--db-statistics`): a deliberately small,
+    ///    alertable set — stall time, block-cache and bloom effectiveness,
+    ///    user/compaction/flush byte volume, and WAL sync count/bytes/latency.
+    ///    `qfc_storage_statistics_enabled` says which mode the node is in.
+    fn render_storage_metrics(db: &Database, out: &mut String) {
+        // --- properties: per-CF gauges (work without statistics) ---
+        let cf_props: &[(&str, &str, &str)] = &[
+            (
+                props::CUR_SIZE_ALL_MEM_TABLES,
+                "qfc_rocksdb_memtable_bytes",
+                "Approximate size of active and unflushed immutable memtables (bytes).",
+            ),
+            (
+                props::ESTIMATE_PENDING_COMPACTION_BYTES,
+                "qfc_rocksdb_pending_compaction_bytes",
+                "Estimated bytes compaction must rewrite to catch up (compaction debt).",
+            ),
+            (
+                props::NUM_IMMUTABLE_MEM_TABLE,
+                "qfc_rocksdb_immutable_memtables",
+                "Immutable memtables not yet flushed.",
+            ),
+            (
+                props::NUM_FILES_AT_LEVEL0,
+                "qfc_rocksdb_l0_files",
+                "SST files at level 0 (write stalls trigger when this grows).",
+            ),
+        ];
+        for (prop, name, help) in cf_props {
+            let _ = writeln!(out, "# HELP {name} {help}");
+            let _ = writeln!(out, "# TYPE {name} gauge");
+            for cf_name in cf::ALL {
+                if let Ok(Some(v)) = db.property_int_cf(cf_name, prop) {
+                    let _ = writeln!(out, "{name}{{cf=\"{cf_name}\"}} {v}");
+                }
+            }
+        }
+
+        // --- properties: DB-wide gauges ---
+        let db_props: &[(&str, &str, &str)] = &[
+            (
+                props::BLOCK_CACHE_USAGE,
+                "qfc_rocksdb_block_cache_usage_bytes",
+                "Memory used by the shared block cache (bytes).",
+            ),
+            (
+                props::IS_WRITE_STOPPED,
+                "qfc_rocksdb_write_stopped",
+                "1 if RocksDB has completely stopped writes (hard stall), else 0.",
+            ),
+            (
+                props::ACTUAL_DELAYED_WRITE_RATE,
+                "qfc_rocksdb_actual_delayed_write_rate",
+                "Current delayed-write rate in bytes/s (0 = writes not delayed).",
+            ),
+        ];
+        for (prop, name, help) in db_props {
+            if let Ok(Some(v)) = db.property_int(prop) {
+                let _ = writeln!(out, "# HELP {name} {help}");
+                let _ = writeln!(out, "# TYPE {name} gauge");
+                let _ = writeln!(out, "{name} {v}");
+            }
+        }
+
+        // --- statistics (tickers + histograms, gated on --db-statistics) ---
+        let enabled: u8 = if db.statistics_enabled() { 1 } else { 0 };
+        let _ = writeln!(
+            out,
+            "# HELP qfc_storage_statistics_enabled Whether RocksDB statistics collection is on (--db-statistics). Ticker metrics below are absent when 0."
+        );
+        let _ = writeln!(out, "# TYPE qfc_storage_statistics_enabled gauge");
+        let _ = writeln!(out, "qfc_storage_statistics_enabled {enabled}");
+
+        if !db.statistics_enabled() {
+            return;
+        }
+
+        let tickers: &[(Ticker, &str, &str)] = &[
+            (
+                Ticker::StallMicros,
+                "qfc_rocksdb_stall_micros_total",
+                "Cumulative microseconds writer threads spent stalled by compaction/flush backpressure.",
+            ),
+            (
+                Ticker::BlockCacheHit,
+                "qfc_rocksdb_block_cache_hits_total",
+                "Block cache hits (data + index + filter blocks).",
+            ),
+            (
+                Ticker::BlockCacheMiss,
+                "qfc_rocksdb_block_cache_misses_total",
+                "Block cache misses (data + index + filter blocks).",
+            ),
+            (
+                Ticker::BloomFilterUseful,
+                "qfc_rocksdb_bloom_filter_useful_total",
+                "Point lookups where a bloom filter avoided a data-block read.",
+            ),
+            (
+                Ticker::BytesWritten,
+                "qfc_rocksdb_bytes_written_total",
+                "Bytes written by user writes (WriteBatch payload).",
+            ),
+            (
+                Ticker::BytesRead,
+                "qfc_rocksdb_bytes_read_total",
+                "Bytes of values returned to user reads (Get).",
+            ),
+            (
+                Ticker::CompactReadBytes,
+                "qfc_rocksdb_compaction_read_bytes_total",
+                "Bytes read by compaction.",
+            ),
+            (
+                Ticker::CompactWriteBytes,
+                "qfc_rocksdb_compaction_write_bytes_total",
+                "Bytes written by compaction.",
+            ),
+            (
+                Ticker::FlushWriteBytes,
+                "qfc_rocksdb_flush_write_bytes_total",
+                "Bytes written by memtable flushes.",
+            ),
+            (
+                Ticker::WalFileSynced,
+                "qfc_rocksdb_wal_syncs_total",
+                "Number of WAL fsyncs.",
+            ),
+            (
+                Ticker::WalFileBytes,
+                "qfc_rocksdb_wal_bytes_total",
+                "Bytes written to the WAL.",
+            ),
+        ];
+        for (ticker, name, help) in tickers {
+            if let Some(v) = db.statistics_ticker(*ticker) {
+                let _ = writeln!(out, "# HELP {name} {help}");
+                let _ = writeln!(out, "# TYPE {name} counter");
+                let _ = writeln!(out, "{name} {v}");
+            }
+        }
+
+        // WAL sync latency: cumulative sum/count (rate(sum)/rate(count) gives
+        // the windowed mean) plus the engine-side p99 since DB open.
+        if let Some(h) = db.statistics_histogram(Histogram::WalFileSyncMicros) {
+            let sum_secs = h.sum as f64 / 1e6;
+            let p99_secs = h.p99 / 1e6;
+            let _ = writeln!(
+                out,
+                "# HELP qfc_rocksdb_wal_sync_duration_seconds_sum Cumulative time spent in WAL fsync."
+            );
+            let _ = writeln!(
+                out,
+                "# TYPE qfc_rocksdb_wal_sync_duration_seconds_sum counter"
+            );
+            let _ = writeln!(
+                out,
+                "qfc_rocksdb_wal_sync_duration_seconds_sum {sum_secs:.6}"
+            );
+            let _ = writeln!(
+                out,
+                "# HELP qfc_rocksdb_wal_sync_duration_seconds_count Number of WAL fsyncs measured."
+            );
+            let _ = writeln!(
+                out,
+                "# TYPE qfc_rocksdb_wal_sync_duration_seconds_count counter"
+            );
+            let _ = writeln!(
+                out,
+                "qfc_rocksdb_wal_sync_duration_seconds_count {}",
+                h.count
+            );
+            let _ = writeln!(
+                out,
+                "# HELP qfc_rocksdb_wal_sync_duration_seconds_p99 p99 WAL fsync latency since DB open (engine-side histogram)."
+            );
+            let _ = writeln!(
+                out,
+                "# TYPE qfc_rocksdb_wal_sync_duration_seconds_p99 gauge"
+            );
+            let _ = writeln!(
+                out,
+                "qfc_rocksdb_wal_sync_duration_seconds_p99 {p99_secs:.6}"
+            );
+        }
     }
 
     /// Wall-clock seconds since the head block's timestamp (block timestamps
@@ -470,21 +672,22 @@ mod tests {
         }
     }
 
-    /// T2.2: the exporter output must contain every metric name referenced by
-    /// docs/observability/ (dashboard + alert rules).
-    #[test]
-    fn render_metrics_includes_expected_metric_names() {
+    /// Build a `MetricsServer` over a temp DB (optionally with RocksDB
+    /// statistics) wired the same way `main.rs` does it. The returned
+    /// `TempDir` must stay alive as long as the server.
+    fn test_server(enable_statistics: bool) -> (MetricsServer, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();
         let db = Database::open(StorageConfig {
             path: tmp.path().join("db"),
             create_if_missing: true,
+            enable_statistics,
             ..Default::default()
         })
         .unwrap();
         let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
         let chain = Arc::new(
             Chain::new(
-                db,
+                db.clone(),
                 ChainConfig {
                     chain_id: 9000,
                     genesis: GenesisConfig::dev(),
@@ -510,8 +713,16 @@ mod tests {
             9000,
         )
         .with_sync_status(Arc::new(FakeSync))
-        .with_rpc_metrics(rpc_metrics);
+        .with_rpc_metrics(rpc_metrics)
+        .with_storage(db);
+        (server, tmp)
+    }
 
+    /// T2.2/T2.1: the exporter output must contain every metric name
+    /// referenced by docs/observability/ (dashboard + alert rules).
+    #[test]
+    fn render_metrics_includes_expected_metric_names() {
+        let (server, _tmp) = test_server(true);
         let out = server.render_metrics();
 
         for name in [
@@ -535,10 +746,81 @@ mod tests {
             "qfc_rpc_requests_total",
             "qfc_rpc_request_duration_seconds_bucket",
             "qfc_rpc_errors_total",
+            // storage (T2.1) — properties, exported unconditionally
+            "qfc_rocksdb_memtable_bytes",
+            "qfc_rocksdb_pending_compaction_bytes",
+            "qfc_rocksdb_immutable_memtables",
+            "qfc_rocksdb_l0_files",
+            "qfc_rocksdb_block_cache_usage_bytes",
+            "qfc_rocksdb_write_stopped",
+            "qfc_rocksdb_actual_delayed_write_rate",
+            "qfc_storage_statistics_enabled",
+            // storage (T2.1) — statistics tickers (--db-statistics on)
+            "qfc_rocksdb_stall_micros_total",
+            "qfc_rocksdb_block_cache_hits_total",
+            "qfc_rocksdb_block_cache_misses_total",
+            "qfc_rocksdb_bloom_filter_useful_total",
+            "qfc_rocksdb_bytes_written_total",
+            "qfc_rocksdb_bytes_read_total",
+            "qfc_rocksdb_compaction_read_bytes_total",
+            "qfc_rocksdb_compaction_write_bytes_total",
+            "qfc_rocksdb_flush_write_bytes_total",
+            "qfc_rocksdb_wal_syncs_total",
+            "qfc_rocksdb_wal_bytes_total",
+            "qfc_rocksdb_wal_sync_duration_seconds_sum",
+            "qfc_rocksdb_wal_sync_duration_seconds_count",
+            "qfc_rocksdb_wal_sync_duration_seconds_p99",
         ] {
             assert!(
                 out.contains(name),
                 "missing metric `{name}` in exporter output:\n{out}"
+            );
+        }
+
+        assert!(out.contains("qfc_storage_statistics_enabled 1"));
+        // Per-CF metrics carry a {cf="..."} label for every CF in cf::ALL.
+        for cf_name in cf::ALL {
+            assert!(
+                out.contains(&format!("qfc_rocksdb_memtable_bytes{{cf=\"{cf_name}\"}}")),
+                "missing per-CF memtable metric for `{cf_name}`"
+            );
+        }
+    }
+
+    /// T2.1: with statistics off (the default), property metrics are still
+    /// exported but ticker/histogram metrics degrade to a single
+    /// `qfc_storage_statistics_enabled 0` gauge.
+    #[test]
+    fn render_metrics_degrades_without_statistics() {
+        let (server, _tmp) = test_server(false);
+        let out = server.render_metrics();
+
+        assert!(out.contains("qfc_storage_statistics_enabled 0"));
+
+        // Property-based metrics do not need statistics.
+        for name in [
+            "qfc_rocksdb_memtable_bytes",
+            "qfc_rocksdb_pending_compaction_bytes",
+            "qfc_rocksdb_immutable_memtables",
+            "qfc_rocksdb_l0_files",
+            "qfc_rocksdb_block_cache_usage_bytes",
+            "qfc_rocksdb_write_stopped",
+        ] {
+            assert!(
+                out.contains(name),
+                "property metric `{name}` should not be gated"
+            );
+        }
+
+        // Ticker/histogram metrics must be absent.
+        for name in [
+            "qfc_rocksdb_stall_micros_total",
+            "qfc_rocksdb_block_cache_hits_total",
+            "qfc_rocksdb_wal_sync_duration_seconds_sum",
+        ] {
+            assert!(
+                !out.contains(name),
+                "ticker metric `{name}` must not render without statistics"
             );
         }
     }

--- a/crates/qfc-storage/src/db.rs
+++ b/crates/qfc-storage/src/db.rs
@@ -14,8 +14,47 @@ use std::sync::Arc;
 use tracing::{debug, info};
 
 // Re-exported so consumers (e.g. an observability exporter) can query tickers
-// without taking a direct `rocksdb` dependency.
-pub use rocksdb::statistics::Ticker;
+// and histograms without taking a direct `rocksdb` dependency.
+pub use rocksdb::statistics::{Histogram, Ticker};
+
+/// Integer-valued RocksDB property names accepted by
+/// [`Database::property_int`] / [`Database::property_int_cf`].
+///
+/// Unlike statistics tickers, properties are computed on demand from live
+/// engine state and are available even when
+/// [`StorageConfig::enable_statistics`] is off.
+pub mod props {
+    /// Approximate size of active + unflushed immutable memtables (bytes).
+    pub const CUR_SIZE_ALL_MEM_TABLES: &str = "rocksdb.cur-size-all-mem-tables";
+    /// Estimated bytes compaction needs to rewrite to bring the LSM tree back
+    /// in shape (the compaction-debt / backlog signal).
+    pub const ESTIMATE_PENDING_COMPACTION_BYTES: &str = "rocksdb.estimate-pending-compaction-bytes";
+    /// Number of immutable memtables not yet flushed.
+    pub const NUM_IMMUTABLE_MEM_TABLE: &str = "rocksdb.num-immutable-mem-table";
+    /// Number of SST files at level 0 (write-stall trigger when high).
+    pub const NUM_FILES_AT_LEVEL0: &str = "rocksdb.num-files-at-level0";
+    /// Memory used by the (shared) block cache, in bytes.
+    pub const BLOCK_CACHE_USAGE: &str = "rocksdb.block-cache-usage";
+    /// 1 if writes are completely stopped (hard write stall), else 0.
+    pub const IS_WRITE_STOPPED: &str = "rocksdb.is-write-stopped";
+    /// Current delayed-write rate in bytes/s; 0 means writes are not delayed.
+    pub const ACTUAL_DELAYED_WRITE_RATE: &str = "rocksdb.actual-delayed-write-rate";
+}
+
+/// Plain-value snapshot of a RocksDB statistics histogram, returned by
+/// [`Database::statistics_histogram`]. Values are in the histogram's native
+/// unit (microseconds for `*Micros` histograms); `sum`/`count` are cumulative
+/// since DB open, so an exporter can publish them as monotonic counters.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct HistogramStats {
+    pub median: f64,
+    pub average: f64,
+    pub p95: f64,
+    pub p99: f64,
+    pub max: f64,
+    pub sum: u64,
+    pub count: u64,
+}
 
 type RocksDB = DBWithThreadMode<MultiThreaded>;
 
@@ -431,6 +470,45 @@ impl Database {
         Some(self.db_opts.get_ticker_count(ticker))
     }
 
+    /// Snapshot of a statistics histogram (e.g.
+    /// [`Histogram::WalFileSyncMicros`]) as plain values.
+    ///
+    /// Returns `None` unless statistics collection is enabled.
+    pub fn statistics_histogram(&self, histogram: Histogram) -> Option<HistogramStats> {
+        if !self.config.enable_statistics {
+            return None;
+        }
+        let data = self.db_opts.get_histogram_data(histogram);
+        Some(HistogramStats {
+            median: data.median(),
+            average: data.average(),
+            p95: data.p95(),
+            p99: data.p99(),
+            max: data.max(),
+            sum: data.sum(),
+            count: data.count(),
+        })
+    }
+
+    /// Integer-valued DB-level property (e.g. [`props::BLOCK_CACHE_USAGE`]).
+    ///
+    /// Computed on demand from live engine state; works regardless of
+    /// [`StorageConfig::enable_statistics`]. Returns `Ok(None)` if the
+    /// property does not exist or is not integer-valued.
+    pub fn property_int(&self, name: &str) -> Result<Option<u64>> {
+        Ok(self.db.property_int_value(name)?)
+    }
+
+    /// Integer-valued per-column-family property (e.g.
+    /// [`props::CUR_SIZE_ALL_MEM_TABLES`]).
+    ///
+    /// Computed on demand; works regardless of
+    /// [`StorageConfig::enable_statistics`].
+    pub fn property_int_cf(&self, cf_name: &str, name: &str) -> Result<Option<u64>> {
+        let cf = self.get_cf(cf_name)?;
+        Ok(self.db.property_int_value_cf(&cf, name)?)
+    }
+
     /// Flush the database
     pub fn flush(&self) -> Result<()> {
         for cf_name in cf::ALL {
@@ -631,6 +709,76 @@ mod tests {
             .statistics_ticker(Ticker::BytesWritten)
             .expect("ticker when enabled");
         assert!(written > 0, "BytesWritten should count the put");
+    }
+
+    #[test]
+    fn test_statistics_histogram() {
+        // Disabled by default…
+        let db = Database::open_temp().unwrap();
+        assert!(db
+            .statistics_histogram(Histogram::WalFileSyncMicros)
+            .is_none());
+        drop(db);
+
+        // …and populated by a sync (WAL-fsync) write when enabled.
+        let (db, _dir) = open_temp_with(|c| c.enable_statistics = true);
+        let mut batch = WriteBatch::new();
+        batch.put(cf::METADATA, b"k".to_vec(), b"v".to_vec());
+        db.write_batch_sync(batch).unwrap();
+
+        let h = db
+            .statistics_histogram(Histogram::WalFileSyncMicros)
+            .expect("histogram when enabled");
+        assert!(h.count >= 1, "sync write should record a WAL fsync");
+        assert!(h.sum > 0);
+    }
+
+    #[test]
+    fn test_property_int_works_without_statistics() {
+        // Properties are live engine state, independent of enable_statistics.
+        let db = Database::open_temp().unwrap();
+        assert!(!db.statistics_enabled());
+
+        db.put(cf::STATE, b"key", b"value").unwrap();
+
+        let memtable = db
+            .property_int_cf(cf::STATE, props::CUR_SIZE_ALL_MEM_TABLES)
+            .unwrap()
+            .expect("memtable size property");
+        assert!(memtable > 0, "memtable should be non-empty after a put");
+
+        for name in [
+            props::ESTIMATE_PENDING_COMPACTION_BYTES,
+            props::NUM_IMMUTABLE_MEM_TABLE,
+            props::NUM_FILES_AT_LEVEL0,
+        ] {
+            assert!(
+                db.property_int_cf(cf::STATE, name).unwrap().is_some(),
+                "per-CF property `{name}` should be integer-valued"
+            );
+        }
+
+        for name in [
+            props::BLOCK_CACHE_USAGE,
+            props::IS_WRITE_STOPPED,
+            props::ACTUAL_DELAYED_WRITE_RATE,
+        ] {
+            assert!(
+                db.property_int(name).unwrap().is_some(),
+                "DB property `{name}` should be integer-valued"
+            );
+        }
+
+        // Unknown property: Ok(None), not an error.
+        assert!(db.property_int("rocksdb.does-not-exist").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_property_int_cf_unknown_cf() {
+        let db = Database::open_temp().unwrap();
+        assert!(db
+            .property_int_cf("no_such_cf", props::CUR_SIZE_ALL_MEM_TABLES)
+            .is_err());
     }
 
     #[test]

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -8,8 +8,16 @@ Dashboard and alert rules for the qfc-node Prometheus exporter
 
 Every node serves Prometheus text-format metrics on
 `http://<node>:6060/metrics` (configurable via `--metrics-addr` /
-`QFC_METRICS_ADDR`). No extra flags needed — chain, sync, mempool, and RPC
-metrics are always on.
+`QFC_METRICS_ADDR`). No extra flags needed — chain, sync, mempool, RPC, and
+RocksDB *property* metrics (memtable size, pending-compaction bytes, L0 files,
+write-stall state) are always on.
+
+RocksDB statistics *counters* (`qfc_rocksdb_*_total`, WAL sync latency)
+additionally require starting the node with `--db-statistics` /
+`QFC_DB_STATISTICS=1`, which enables RocksDB ticker/histogram collection at the
+cost of a few percent of storage throughput. The
+`qfc_storage_statistics_enabled` gauge (0/1) tells you which mode a node is in;
+with statistics off the counter metrics are simply absent.
 
 Scrape config:
 
@@ -49,8 +57,11 @@ Commented placeholders at the bottom of the file are intentionally disabled
 until their metrics exist:
 
 - **Backup freshness** — enable after T4 exports `qfc_backup_last_success_timestamp_seconds`.
-- **RocksDB write stall / compaction backlog** — enable after T2.1 lands the
-  qfc-storage statistics hook.
+
+The `qfc-rocksdb` group (T2.1) is active. Its property-based alerts
+(`QfcRocksdbWriteStopped`, `QfcRocksdbCompactionBacklog*`) work on every node;
+the stall-rate alert (`QfcRocksdbWriteStall`) only produces data on nodes
+running with `--db-statistics` and never fires elsewhere.
 
 ## Loading the Grafana dashboard
 
@@ -104,6 +115,50 @@ and place `grafana-dashboard.json` in that path. The dashboard has an
 | `qfc_rpc_request_duration_seconds` | histogram | `method`, `le` | RPC middleware |
 | `qfc_rpc_errors_total` | counter | `method`, `code` | RPC middleware |
 
+## Metric inventory — RocksDB (T2.1)
+
+Property-based gauges, always exported (computed on demand from live engine
+state; `cf` ranges over all 18 column families):
+
+| Metric | Type | Labels | Source (RocksDB property) |
+|---|---|---|---|
+| `qfc_rocksdb_memtable_bytes` | gauge | `cf` | `rocksdb.cur-size-all-mem-tables` |
+| `qfc_rocksdb_pending_compaction_bytes` | gauge | `cf` | `rocksdb.estimate-pending-compaction-bytes` |
+| `qfc_rocksdb_immutable_memtables` | gauge | `cf` | `rocksdb.num-immutable-mem-table` |
+| `qfc_rocksdb_l0_files` | gauge | `cf` | `rocksdb.num-files-at-level0` |
+| `qfc_rocksdb_block_cache_usage_bytes` | gauge | — | `rocksdb.block-cache-usage` (cache is shared) |
+| `qfc_rocksdb_write_stopped` | gauge (0/1) | — | `rocksdb.is-write-stopped` |
+| `qfc_rocksdb_actual_delayed_write_rate` | gauge | — | `rocksdb.actual-delayed-write-rate` |
+| `qfc_storage_statistics_enabled` | gauge (0/1) | — | `StorageConfig::enable_statistics` |
+
+Statistics counters, only exported when the node runs with `--db-statistics`
+(all DB-wide; RocksDB tickers are not per-CF):
+
+| Metric | Type | Labels | Source (RocksDB ticker/histogram) |
+|---|---|---|---|
+| `qfc_rocksdb_stall_micros_total` | counter | — | `rocksdb.stall.micros` |
+| `qfc_rocksdb_block_cache_hits_total` | counter | — | `rocksdb.block.cache.hit` |
+| `qfc_rocksdb_block_cache_misses_total` | counter | — | `rocksdb.block.cache.miss` |
+| `qfc_rocksdb_bloom_filter_useful_total` | counter | — | `rocksdb.bloom.filter.useful` |
+| `qfc_rocksdb_bytes_written_total` | counter | — | `rocksdb.bytes.written` |
+| `qfc_rocksdb_bytes_read_total` | counter | — | `rocksdb.bytes.read` |
+| `qfc_rocksdb_compaction_read_bytes_total` | counter | — | `rocksdb.compact.read.bytes` |
+| `qfc_rocksdb_compaction_write_bytes_total` | counter | — | `rocksdb.compact.write.bytes` |
+| `qfc_rocksdb_flush_write_bytes_total` | counter | — | `rocksdb.flush.write.bytes` |
+| `qfc_rocksdb_wal_syncs_total` | counter | — | `rocksdb.wal.synced` |
+| `qfc_rocksdb_wal_bytes_total` | counter | — | `rocksdb.wal.bytes` |
+| `qfc_rocksdb_wal_sync_duration_seconds_sum` | counter | — | `rocksdb.wal.file.sync.micros` (sum) |
+| `qfc_rocksdb_wal_sync_duration_seconds_count` | counter | — | `rocksdb.wal.file.sync.micros` (count) |
+| `qfc_rocksdb_wal_sync_duration_seconds_p99` | gauge | — | `rocksdb.wal.file.sync.micros` (engine p99 since open) |
+
+Selection rationale: the ticker set is deliberately small — stall time (the
+top-level "engine is unhealthy" signal), cache/bloom effectiveness (validates
+the T3.1 cache/bloom work), user vs compaction vs flush byte volume (write
+amplification = (compaction+flush)/user bytes), and WAL sync behaviour
+(durability cost of the T3.2 sync-commit policy). Everything else in the
+~200-ticker catalogue is diagnostic rather than alertable and can be read
+ad-hoc via `Database::statistics()`.
+
 Notes:
 
 - `qfc_reorgs_detected_total` counts canonical-chain rewrites observed between
@@ -112,5 +167,7 @@ Notes:
   ships with the T2.1/T3 follow-up (needs a hook in `qfc-chain`).
 - RPC histogram buckets span 500µs–10s (14 buckets), tuned so
   `histogram_quantile()` gives usable p50/p99/p999.
-- RocksDB metrics (`qfc_rocksdb_*`) are **not exported yet** — T2.1 is
-  deferred to a follow-up PR; the exporter has a marked seam for it.
+- WAL sync latency is exported as a cumulative sum/count pair —
+  `rate(..._sum[5m]) / rate(..._count[5m])` gives the windowed mean — plus an
+  engine-side p99 gauge. RocksDB's C API exposes histogram percentiles, not
+  bucket boundaries, so a full Prometheus histogram is not derivable.

--- a/docs/observability/alert-rules.yaml
+++ b/docs/observability/alert-rules.yaml
@@ -260,6 +260,76 @@ groups:
             The exporter observed a canonical-chain rewrite (scrape-granularity
             detection). Investigate consensus health and peer divergence.
 
+  # ----------------------------------------------------------- rocksdb (T2.1)
+  # Metric sources: crates/qfc-node/src/metrics.rs `render_storage_metrics`.
+  # Property gauges (qfc_rocksdb_write_stopped, qfc_rocksdb_pending_compaction_bytes,
+  # qfc_rocksdb_l0_files, ...) are always exported; ticker counters
+  # (qfc_rocksdb_stall_micros_total, ...) require the node to run with
+  # --db-statistics (check qfc_storage_statistics_enabled). Alerts on ticker
+  # metrics simply never fire on nodes with statistics off — the hard-stop
+  # property alert below covers those nodes too.
+  - name: qfc-rocksdb
+    rules:
+      # Hard stall: RocksDB has stopped accepting writes entirely. The node
+      # cannot import blocks while this is 1. Property-based: fires even
+      # without --db-statistics.
+      - alert: QfcRocksdbWriteStopped
+        expr: qfc_rocksdb_write_stopped == 1
+        for: 1m
+        labels:
+          severity: page
+        annotations:
+          summary: "RocksDB writes are STOPPED on {{ $labels.instance }}"
+          description: >-
+            rocksdb.is-write-stopped = 1: L0/memtable/pending-compaction limits
+            were hit and writes are blocked. Block import is stalled. Check
+            qfc_rocksdb_l0_files and qfc_rocksdb_pending_compaction_bytes.
+
+      # Sustained soft stall: stall.micros is cumulative microseconds writer
+      # threads spent stalled, so rate() is stalled-µs per second. 50000 = 5%
+      # of wall-clock time spent stalled, sustained for 10m. Needs
+      # --db-statistics.
+      - alert: QfcRocksdbWriteStall
+        expr: rate(qfc_rocksdb_stall_micros_total[5m]) > 50000
+        for: 10m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "RocksDB write stalls >5% of wall time on {{ $labels.instance }}"
+          description: >-
+            Compaction/flush cannot keep up with the write rate
+            ({{ $value | printf "%.0f" }}µs stalled per second). Check
+            pending-compaction bytes and L0 file counts per CF.
+
+      # Absolute compaction backlog. Property-based; pending bytes are per-CF,
+      # so sum to a node-level debt figure.
+      - alert: QfcRocksdbCompactionBacklog
+        expr: sum by (instance, job) (qfc_rocksdb_pending_compaction_bytes) > 64 * 1024 * 1024 * 1024
+        for: 30m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "RocksDB pending compaction backlog >64GiB ({{ $labels.instance }})"
+          description: >-
+            Total estimate-pending-compaction-bytes has exceeded 64GiB for 30m;
+            the LSM tree is falling behind and write stalls will follow.
+
+      # Growing backlog: debt rising for a sustained period while already
+      # non-trivial (>8GiB) — catches the trend before the absolute alert.
+      - alert: QfcRocksdbCompactionBacklogGrowing
+        expr: |
+          sum by (instance, job) (deriv(qfc_rocksdb_pending_compaction_bytes[30m])) > 0
+          and
+          sum by (instance, job) (qfc_rocksdb_pending_compaction_bytes) > 8 * 1024 * 1024 * 1024
+        for: 30m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "RocksDB compaction backlog growing on {{ $labels.instance }}"
+          description: >-
+            Pending compaction bytes have been trending upward for 30m from an
+            already-elevated level. Compaction is not keeping pace with writes.
+
   # ------------------------------------------------------------- placeholders
   #
   # T4 (DR automation) — backup freshness. Enable once the backup task exports
@@ -281,24 +351,3 @@ groups:
   #         severity: page
   #       annotations:
   #         summary: "No successful backup for >12h ({{ $labels.instance }})"
-  #
-  # T2.1 (RocksDB statistics export) — write-stall and compaction pressure.
-  # Enable once qfc-storage exports rocksdb statistics (parallel branch).
-  #
-  # - name: qfc-rocksdb
-  #   rules:
-  #     - alert: QfcRocksdbWriteStall
-  #       expr: rate(qfc_rocksdb_stall_micros_total[5m]) > 0
-  #       for: 5m
-  #       labels:
-  #         severity: ticket
-  #       annotations:
-  #         summary: "RocksDB write stalls on {{ $labels.instance }}"
-  #         description: "Compaction/flush cannot keep up with the write rate."
-  #     - alert: QfcRocksdbCompactionBacklog
-  #       expr: qfc_rocksdb_pending_compaction_bytes > 64 * 1024 * 1024 * 1024
-  #       for: 30m
-  #       labels:
-  #         severity: ticket
-  #       annotations:
-  #         summary: "RocksDB pending compaction backlog >64GiB ({{ $labels.instance }})"

--- a/docs/observability/grafana-dashboard.json
+++ b/docs/observability/grafana-dashboard.json
@@ -14,7 +14,7 @@
   "tags": ["qfc", "blockchain", "sre"],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 1,
+  "version": 2,
   "refresh": "15s",
   "time": { "from": "now-6h", "to": "now" },
   "templating": {
@@ -419,6 +419,182 @@
             "properties": [{ "id": "unit", "value": "none" }]
           }
         ]
+      }
+    },
+    {
+      "type": "row",
+      "title": "RocksDB storage engine",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Write stall time (fraction of wall clock; counters need --db-statistics)",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 42 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "rate(qfc_rocksdb_stall_micros_total{instance=~\"$instance\"}[5m]) / 1e6",
+          "legendFormat": "stalled fraction {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "qfc_rocksdb_write_stopped{instance=~\"$instance\"}",
+          "legendFormat": "write-stopped (0/1) {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Pending compaction bytes (alert at 64GiB total)",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 42 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (instance) (qfc_rocksdb_pending_compaction_bytes{instance=~\"$instance\"})",
+          "legendFormat": "total {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "topk(5, qfc_rocksdb_pending_compaction_bytes{instance=~\"$instance\"})",
+          "legendFormat": "{{cf}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 68719476736 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Block cache hit ratio & bloom negatives (need --db-statistics)",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 42 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "rate(qfc_rocksdb_block_cache_hits_total{instance=~\"$instance\"}[5m]) / clamp_min(rate(qfc_rocksdb_block_cache_hits_total{instance=~\"$instance\"}[5m]) + rate(qfc_rocksdb_block_cache_misses_total{instance=~\"$instance\"}[5m]), 1e-10)",
+          "legendFormat": "hit ratio {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(qfc_rocksdb_bloom_filter_useful_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "bloom negatives/s {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byFrameRefID", "options": "B" },
+            "properties": [{ "id": "unit", "value": "ops" }]
+          }
+        ]
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Storage memory: memtables (top CFs) & shared block cache",
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 50 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "topk(8, qfc_rocksdb_memtable_bytes{instance=~\"$instance\"})",
+          "legendFormat": "memtable {{cf}}",
+          "refId": "A"
+        },
+        {
+          "expr": "qfc_rocksdb_block_cache_usage_bytes{instance=~\"$instance\"}",
+          "legendFormat": "block cache {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Compaction pressure: L0 files & immutable memtables (top CFs)",
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 50 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "topk(5, qfc_rocksdb_l0_files{instance=~\"$instance\"})",
+          "legendFormat": "l0 {{cf}}",
+          "refId": "A"
+        },
+        {
+          "expr": "topk(5, qfc_rocksdb_immutable_memtables{instance=~\"$instance\"})",
+          "legendFormat": "imm-memtables {{cf}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "WAL fsync latency (needs --db-statistics)",
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 50 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "rate(qfc_rocksdb_wal_sync_duration_seconds_sum{instance=~\"$instance\"}[5m]) / clamp_min(rate(qfc_rocksdb_wal_sync_duration_seconds_count{instance=~\"$instance\"}[5m]), 1e-10)",
+          "legendFormat": "mean (5m) {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "qfc_rocksdb_wal_sync_duration_seconds_p99{instance=~\"$instance\"}",
+          "legendFormat": "p99 (since start) {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": []
       }
     }
   ]


### PR DESCRIPTION
Implements roadmap **T2.1** (docs/ROADMAP-SRE.md): export RocksDB engine health from the live `Database` through the `qfc-node` Prometheus exporter, with matching dashboard panels and now-active stall alerts. Builds on the statistics hook from #105 and fills the `render_storage_metrics` seam left by #104.

## Design

Two layers, different availability:

- **Property gauges — always exported.** Computed on demand from live engine state (`Database::property_int{,_cf}`, new in this PR); zero steady-state overhead, so memtable/compaction/L0/stall-condition visibility does not depend on any flag.
- **Statistics counters — gated on `--db-statistics` / `QFC_DB_STATISTICS`** (new flag, plumbs `StorageConfig::enable_statistics` from #105; costs a few percent of storage throughput). With the flag off the exporter degrades to a single `qfc_storage_statistics_enabled 0` gauge and the counter families are absent.

## Metric inventory

Properties (per-CF ones labeled `{cf="…"}` across all 18 CFs in `cf::ALL`):

| Metric | Type | Labels | Source |
|---|---|---|---|
| `qfc_rocksdb_memtable_bytes` | gauge | `cf` | property `rocksdb.cur-size-all-mem-tables` |
| `qfc_rocksdb_pending_compaction_bytes` | gauge | `cf` | property `rocksdb.estimate-pending-compaction-bytes` |
| `qfc_rocksdb_immutable_memtables` | gauge | `cf` | property `rocksdb.num-immutable-mem-table` |
| `qfc_rocksdb_l0_files` | gauge | `cf` | property `rocksdb.num-files-at-level0` |
| `qfc_rocksdb_block_cache_usage_bytes` | gauge | — | property `rocksdb.block-cache-usage` (shared cache) |
| `qfc_rocksdb_write_stopped` | gauge 0/1 | — | property `rocksdb.is-write-stopped` |
| `qfc_rocksdb_actual_delayed_write_rate` | gauge | — | property `rocksdb.actual-delayed-write-rate` |
| `qfc_storage_statistics_enabled` | gauge 0/1 | — | `StorageConfig::enable_statistics` |

Statistics (DB-wide; RocksDB tickers are not per-CF):

| Metric | Type | Source |
|---|---|---|
| `qfc_rocksdb_stall_micros_total` | counter | `Ticker::StallMicros` |
| `qfc_rocksdb_block_cache_hits_total` / `_misses_total` | counter | `Ticker::BlockCacheHit/Miss` |
| `qfc_rocksdb_bloom_filter_useful_total` | counter | `Ticker::BloomFilterUseful` |
| `qfc_rocksdb_bytes_written_total` / `_read_total` | counter | `Ticker::BytesWritten/Read` |
| `qfc_rocksdb_compaction_read_bytes_total` / `_write_bytes_total` | counter | `Ticker::CompactRead/WriteBytes` |
| `qfc_rocksdb_flush_write_bytes_total` | counter | `Ticker::FlushWriteBytes` |
| `qfc_rocksdb_wal_syncs_total` / `qfc_rocksdb_wal_bytes_total` | counter | `Ticker::WalFileSynced/WalFileBytes` |
| `qfc_rocksdb_wal_sync_duration_seconds_sum` / `_count` | counter | `Histogram::WalFileSyncMicros` |
| `qfc_rocksdb_wal_sync_duration_seconds_p99` | gauge | `Histogram::WalFileSyncMicros` (engine p99 since open) |

**Selection rationale:** stall time is the top-level "engine unhealthy" signal; cache/bloom counters validate the T3.1 cache+bloom work; user vs compaction vs flush byte volume gives write amplification; WAL sync count/bytes/latency measures the T3.2 sync-commit durability cost. The rest of the ~200-ticker catalogue is diagnostic, not alertable — readable ad-hoc via `Database::statistics()`.

**Deliberately excluded:**
- Per-ticker dump of the full statistics string (noise, cardinality).
- Per-CF read/write byte volume — RocksDB tickers are DB-global; per-CF volume would need perf-context plumbing per operation. Per-CF *state* (memtable/L0/pending) covers the per-CF dimension instead.
- A true Prometheus histogram for WAL sync: the C API exposes percentiles, not bucket boundaries, so we export a sum/count pair (windowed mean via `rate()/rate()`) + engine p99 gauge.
- Stall-*cause* breakdown tickers (not exposed in rust-rocksdb 0.22); `is-write-stopped` + `actual-delayed-write-rate` properties cover the condition.

## qfc-storage additions (db.rs)

- `props` module with the property-name constants
- `Database::property_int(name)` / `property_int_cf(cf, name)` — `Ok(None)` for unknown properties, work without statistics
- `Database::statistics_histogram(Histogram) -> Option<HistogramStats>` (plain-value snapshot; `Histogram` re-exported alongside `Ticker`)

## docs/observability

- **Dashboard:** new "RocksDB storage engine" row — write-stall fraction (+write-stopped), pending compaction bytes (total + top CFs, 64GiB threshold), block-cache hit ratio + bloom negatives, memtable/block-cache memory, L0/immutable-memtable pressure, WAL fsync latency (mean via rate(sum)/rate(count) + p99).
- **Alerts:** the commented T2.1 placeholder group is now active — `QfcRocksdbWriteStopped` (page, property-based so it fires on every node), `QfcRocksdbWriteStall` (ticket, >5% of wall time stalled sustained 10m, needs `--db-statistics`), `QfcRocksdbCompactionBacklog` (>64GiB for 30m), `QfcRocksdbCompactionBacklogGrowing` (positive 30m trend from >8GiB).
- **README:** RocksDB metric inventory + flag documentation; stale "not exported yet" note removed.

Metric names in dashboard/alerts are enforced by the extended `render_metrics_includes_expected_metric_names` test (now also asserts the `{cf="…"}` label for every CF), plus a new `render_metrics_degrades_without_statistics` test; cross-checked every `qfc_*` name in docs/ against the exporter source (only the intentional T4 backup placeholder is unimplemented).

## Tests

- `cargo test -p qfc-storage`: **17 passed** (4 new: property accessors with stats off, unknown property/CF handling, WAL-sync histogram)
- `cargo test -p qfc-node --bins`: **11 passed** (2 metrics tests incl. degradation)
- Integration tests need `target/release/qfc-node` (absent locally; CI builds release) — `cargo build -p qfc-node` passes
- `cargo fmt --all --check` clean; `cargo clippy -p qfc-storage -p qfc-node --all-targets -- -D clippy::correctness -W clippy::all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)