### PR TITLE
AI-V3 Feature A (A0–A2): qfc-ps — ADRs, sharded param store, SSP service, byzantine-robust aggregation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ members = [
     "crates/qfc-miner",
     # v2.0: Cross-chain bridge
     "crates/qfc-bridge",
+    # v3: decentralized training (off-chain parameter server)
+    "crates/qfc-ps",
 ]
 
 
@@ -137,6 +139,7 @@ qfc-inference = { path = "crates/qfc-inference" }
 qfc-ai-coordinator = { path = "crates/qfc-ai-coordinator" }
 qfc-miner = { path = "crates/qfc-miner" }
 qfc-bridge = { path = "crates/qfc-bridge" }
+qfc-ps = { path = "crates/qfc-ps" }
 
 [profile.release]
 lto = true

--- a/crates/qfc-ps/Cargo.toml
+++ b/crates/qfc-ps/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "qfc-ps"
+description = "Off-chain parameter server for decentralized training (ROADMAP-AI-V3 Feature A)"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+qfc-types.workspace = true
+qfc-crypto.workspace = true
+qfc-storage.workspace = true
+borsh.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+rand.workspace = true
+tempfile.workspace = true

--- a/crates/qfc-ps/Cargo.toml
+++ b/crates/qfc-ps/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 qfc-types.workspace = true
 qfc-crypto.workspace = true
 qfc-storage.workspace = true
+blake3.workspace = true
 borsh.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/qfc-ps/src/aggregate.rs
+++ b/crates/qfc-ps/src/aggregate.rs
@@ -4,6 +4,12 @@
 //! (ADR-0006) the configured [`AggregationRule`] reduces each range's
 //! buffered updates to one delta vector. Plain averaging is forbidden as a
 //! production rule — workers are untrusted.
+//!
+//! Buffer keys are the *registered assignment ranges* admitted by
+//! `ShardService` (fixed per epoch, pairwise disjoint, each inside the owned
+//! range). Disjointness means no parameter coordinate can receive two
+//! aggregated deltas in one epoch (no overlap double-apply), and the fixed
+//! key set bounds buffer memory (see [`UpdateBuffer`]).
 
 use std::collections::HashMap;
 
@@ -16,6 +22,14 @@ pub trait AggregationRule {
     /// have ranges equal to `range`. Must be deterministic: callers sort
     /// updates by worker address before invoking (ADR-0003).
     fn aggregate(&self, updates: &[&ParamUpdate], range: &ParamRange) -> Result<Vec<f32>, PsError>;
+
+    /// Minimum number of buffered updates this rule needs to produce a
+    /// meaningful delta. The epoch barrier skips (deterministic no-op, with a
+    /// warning) any range with fewer updates instead of aborting — thin
+    /// participation on one range must not block the whole epoch.
+    fn min_updates(&self) -> usize {
+        1
+    }
 }
 
 /// Coordinate-wise trimmed mean with trim fraction `beta` per side
@@ -37,19 +51,111 @@ impl TrimmedMean {
     }
 }
 
+/// Defensive input checks shared by aggregation rules. The trait contract
+/// already guarantees these (updates validated, ranges equal), so this only
+/// re-checks what is cheap: non-empty input, range equality, value length.
+/// It does NOT re-run full `ParamUpdate::validate` (finiteness etc.).
+fn check_inputs(updates: &[&ParamUpdate], range: &ParamRange) -> Result<usize, PsError> {
+    if updates.is_empty() {
+        return Err(PsError::Aggregation(format!(
+            "no updates to aggregate for {}",
+            range
+        )));
+    }
+    let dim = range.len() as usize;
+    for u in updates {
+        if u.range != *range {
+            return Err(PsError::Aggregation(format!(
+                "update range {} != aggregation range {}",
+                u.range, range
+            )));
+        }
+        if u.values.len() != dim {
+            return Err(PsError::Aggregation(format!(
+                "value count {} != range length {} for {}",
+                u.values.len(),
+                dim,
+                range
+            )));
+        }
+    }
+    Ok(dim)
+}
+
 impl AggregationRule for TrimmedMean {
     fn aggregate(&self, updates: &[&ParamUpdate], range: &ParamRange) -> Result<Vec<f32>, PsError> {
-        // Implemented in milestone A2.
-        let _ = (updates, range);
-        todo!("A2: coordinate-wise trimmed mean")
+        let dim = check_inputs(updates, range)?;
+        let n = updates.len();
+        // ADR-0003: drop the top and bottom ceil(beta * n) per coordinate.
+        let trim = (self.beta * n as f64).ceil() as usize;
+        let kept = n.saturating_sub(2 * trim);
+        if kept == 0 {
+            return Err(PsError::Aggregation(format!(
+                "trimmed mean over n = {} updates with beta = {} trims {} per \
+                 side and leaves nothing; caller must assign enough workers \
+                 per range (ADR-0003)",
+                n, self.beta, trim
+            )));
+        }
+        // Determinism note: per-coordinate sorting makes the result invariant
+        // to the order of `updates`, so the trait's "callers pre-sort by
+        // worker address" requirement is not load-bearing for TrimmedMean.
+        // It exists for rules that are NOT permutation-invariant.
+        let mut out = Vec::with_capacity(dim);
+        // One column buffer reused across coordinates (clear + refill), so the
+        // whole aggregation allocates O(n) scratch, not O(n * dim).
+        let mut column: Vec<f32> = Vec::with_capacity(n);
+        for j in 0..dim {
+            column.clear();
+            column.extend(updates.iter().map(|u| u.values[j]));
+            // Values are finite per the input contract, but total_cmp gives a
+            // total order on f32 regardless, so sorting can never misbehave.
+            column.sort_unstable_by(f32::total_cmp);
+            // Accumulate in f64 (ADR-0003); the sorted column also fixes the
+            // summation order independent of worker permutation.
+            let sum: f64 = column[trim..n - trim].iter().map(|&v| f64::from(v)).sum();
+            out.push((sum / kept as f64) as f32);
+        }
+        Ok(out)
+    }
+
+    /// Smallest `n` with `n - 2·⌈β·n⌉ >= 1` — below this, trimming leaves
+    /// nothing and the barrier skips the range instead of aborting.
+    fn min_updates(&self) -> usize {
+        (1usize..)
+            .find(|&n| n.saturating_sub(2 * ((self.beta * n as f64).ceil() as usize)) >= 1)
+            .expect("beta < 0.5 guarantees a finite minimum")
+    }
+}
+
+#[doc = "FedAvg-style plain mean. POISONABLE — exists only as a test baseline and for trusted-cluster experiments; never the production rule (ADR-0003)."]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Mean;
+
+impl AggregationRule for Mean {
+    fn aggregate(&self, updates: &[&ParamUpdate], range: &ParamRange) -> Result<Vec<f32>, PsError> {
+        let dim = check_inputs(updates, range)?;
+        let n = updates.len() as f64;
+        let mut out = Vec::with_capacity(dim);
+        for j in 0..dim {
+            // f64 accumulation, same as TrimmedMean (ADR-0003).
+            let sum: f64 = updates.iter().map(|u| f64::from(u.values[j])).sum();
+            out.push((sum / n) as f32);
+        }
+        Ok(out)
     }
 }
 
 /// Per-epoch buffer of pushed updates, keyed by exact range.
 ///
-/// Enforces the per-range worker cap — the O(workers × shard_size)
-/// aggregation memory bound from ADR-0003 — and one-update-per-(worker, clock)
-/// dedup. Cleared at the epoch barrier.
+/// `ShardService` only feeds this buffer updates whose range is exactly one
+/// of the registered assignment ranges (fixed per epoch, pairwise disjoint,
+/// each inside the owned range), so the key set is bounded and
+/// attacker-independent. Together with the per-range worker cap this gives a
+/// hard memory bound: `max_per_range × Σ registered range lengths
+/// ≤ cap × owned_range.len()` buffered f32s — the O(workers × shard_size)
+/// aggregation memory bound from ADR-0003. Also enforces
+/// one-update-per-(worker, clock) dedup. Cleared at the epoch barrier.
 #[derive(Debug, Default)]
 pub struct UpdateBuffer {
     max_per_range: usize,
@@ -118,6 +224,359 @@ impl UpdateBuffer {
     /// Drain everything at the epoch barrier.
     pub fn clear(&mut self) {
         self.buffered.clear();
+    }
+}
+
+#[cfg(test)]
+mod aggregation_tests {
+    use super::*;
+    use qfc_types::Address;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    fn upd(worker: u8, range: ParamRange, values: Vec<f32>) -> ParamUpdate {
+        ParamUpdate {
+            worker: Address::new([worker; 20]),
+            epoch: 1,
+            clock: 0,
+            range,
+            values,
+            flops_estimated: 1,
+        }
+    }
+
+    fn refs(updates: &[ParamUpdate]) -> Vec<&ParamUpdate> {
+        updates.iter().collect()
+    }
+
+    /// Coordinate-wise mean of honest updates only, accumulated in f64 —
+    /// the reference point the robustness bound is measured against.
+    fn honest_mean(updates: &[ParamUpdate], dim: usize) -> Vec<f32> {
+        (0..dim)
+            .map(|j| {
+                let sum: f64 = updates.iter().map(|u| f64::from(u.values[j])).sum();
+                (sum / updates.len() as f64) as f32
+            })
+            .collect()
+    }
+
+    /// n honest updates drawn around `g` with per-coordinate uniform noise
+    /// in [-sigma, sigma].
+    fn honest_updates(
+        rng: &mut StdRng,
+        n: usize,
+        g: &[f32],
+        sigma: f32,
+        range: ParamRange,
+    ) -> Vec<ParamUpdate> {
+        (0..n)
+            .map(|w| {
+                let values = g
+                    .iter()
+                    .map(|&gj| gj + sigma * rng.gen_range(-1.0f32..1.0))
+                    .collect();
+                upd(w as u8 + 1, range, values)
+            })
+            .collect()
+    }
+
+    /// f colluding malicious updates, worst case: all push the same
+    /// direction with an extreme magnitude.
+    fn malicious_updates(f: usize, dim: usize, range: ParamRange) -> Vec<ParamUpdate> {
+        (0..f)
+            .map(|k| upd(200 + k as u8, range, vec![1e30; dim]))
+            .collect()
+    }
+
+    /// Test 1 (A2): hand-computed trimmed mean on a tiny fixture.
+    /// 5 updates x 4 coords, beta = 0.2 -> ceil(0.2 * 5) = 1 dropped per end
+    /// per coordinate.
+    #[test]
+    fn test_trimmed_mean_hand_computed() {
+        let r = ParamRange::new(0, 4).unwrap();
+        // Per-coordinate columns:
+        //   c0: [1, 2, 3, 4, 100]   -> drop 1, 100   -> mean(2, 3, 4)    = 3
+        //   c1: [3, -50, 0, 1, 2]   -> drop -50, 3   -> mean(0, 1, 2)    = 1
+        //   c2: [5, 5, 5, 5, 5]     -> drop 5, 5     -> mean(5, 5, 5)    = 5
+        //   c3: [40, 0, 30, 10, 20] -> drop 0, 40    -> mean(10, 20, 30) = 20
+        let updates = vec![
+            upd(1, r, vec![1.0, 3.0, 5.0, 40.0]),
+            upd(2, r, vec![2.0, -50.0, 5.0, 0.0]),
+            upd(3, r, vec![3.0, 0.0, 5.0, 30.0]),
+            upd(4, r, vec![4.0, 1.0, 5.0, 10.0]),
+            upd(5, r, vec![100.0, 2.0, 5.0, 20.0]),
+        ];
+        let rule = TrimmedMean::new(0.2).unwrap();
+        let agg = rule.aggregate(&refs(&updates), &r).unwrap();
+        assert_eq!(agg, vec![3.0, 1.0, 5.0, 20.0]);
+
+        // Determinism / permutation invariance: reversed worker order gives
+        // bit-identical output (per-coordinate sort erases input order).
+        let mut rev = refs(&updates);
+        rev.reverse();
+        assert_eq!(rule.aggregate(&rev, &r).unwrap(), agg);
+    }
+
+    /// Test 2 (A2, ADR-0003): the robustness bound holds below the threshold.
+    /// 20 honest + f = 3 colluding extremes (f < beta * n = 0.2 * 23 = 4.6);
+    /// trim = ceil(0.2 * 23) = 5 per end, so every extreme is trimmed and the
+    /// aggregate stays within a generous 4 * sigma of the honest mean. Fixed
+    /// seeds (StdRng::seed_from_u64) keep CI deterministic.
+    #[test]
+    fn test_robustness_bound_holds_below_threshold() {
+        let dim = 8usize;
+        let r = ParamRange::new(0, dim as u64).unwrap();
+        let sigma = 0.05f32;
+        let rule = TrimmedMean::new(0.2).unwrap();
+        let mut max_shift = 0.0f32;
+        for seed in 0..300u64 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let g: Vec<f32> = (0..dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+            let honest = honest_updates(&mut rng, 20, &g, sigma, r);
+            let malicious = malicious_updates(3, dim, r);
+            let reference = honest_mean(&honest, dim);
+
+            let all: Vec<&ParamUpdate> = honest.iter().chain(malicious.iter()).collect();
+            let agg = rule.aggregate(&all, &r).unwrap();
+            for j in 0..dim {
+                let shift = (agg[j] - reference[j]).abs();
+                max_shift = max_shift.max(shift);
+                assert!(
+                    shift <= 4.0 * sigma,
+                    "seed {}: coord {} shifted {} > 4*sigma = {}",
+                    seed,
+                    j,
+                    shift,
+                    4.0 * sigma
+                );
+            }
+        }
+        println!(
+            "robustness bound: max adversarial shift {:.6} over 300 seeds (bound {:.6})",
+            max_shift,
+            4.0 * sigma
+        );
+    }
+
+    /// Test 3 (A2, ADR-0003): "test documents the cliff". ADR-0003 tolerates
+    /// f < beta * n; this pins down exactly where one-sided collusion breaks
+    /// through, so the assignment-layer cap on malicious share (A3) is
+    /// visibly load-bearing.
+    ///
+    /// With trim t = ceil(beta * n) per end, an extreme survives into the
+    /// kept window iff f > t. NOTE: at f = ceil(beta * n) exactly (the
+    /// nominal threshold) the ceil still trims every extreme — the
+    /// implementation is one update *better* than ADR-0003's stated
+    /// "f < beta * n" guarantee. The first breaking f is ceil(beta * n) + 1,
+    /// which satisfies the ADR's break condition f >= beta * n. Both edges
+    /// are asserted here: n = 20, beta = 0.2, t = 4 -> f = 4 still bounded,
+    /// f = 5 catastrophic (a 1e30 extreme survives in every coordinate).
+    #[test]
+    fn test_robustness_cliff_at_threshold() {
+        let dim = 8usize;
+        let r = ParamRange::new(0, dim as u64).unwrap();
+        let sigma = 0.05f32;
+        let rule = TrimmedMean::new(0.2).unwrap();
+        let mut broken_seeds = 0usize;
+        let mut max_break_shift = 0.0f32;
+        for seed in 0..100u64 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let g: Vec<f32> = (0..dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+
+            // Edge of the guarantee: 16 honest + 4 extremes, n = 20,
+            // f = t = ceil(0.2 * 20) = 4 -> all extremes still trimmed.
+            let honest = honest_updates(&mut rng, 16, &g, sigma, r);
+            let reference = honest_mean(&honest, dim);
+            let malicious = malicious_updates(4, dim, r);
+            let all: Vec<&ParamUpdate> = honest.iter().chain(malicious.iter()).collect();
+            let agg = rule.aggregate(&all, &r).unwrap();
+            for j in 0..dim {
+                assert!(
+                    (agg[j] - reference[j]).abs() <= 4.0 * sigma,
+                    "seed {}: f = t should still be trimmed away",
+                    seed
+                );
+            }
+
+            // One past the edge: 15 honest + 5 extremes, n = 20, f = 5 > t = 4
+            // (f >= beta * n = 4, ADR-0003's break condition). One 1e30
+            // survives per coordinate; kept = 12, so the aggregate lands near
+            // 1e30 / 12 ~ 8.3e28 — the adversary owns the result.
+            let honest = honest_updates(&mut rng, 15, &g, sigma, r);
+            let reference = honest_mean(&honest, dim);
+            let malicious = malicious_updates(5, dim, r);
+            let all: Vec<&ParamUpdate> = honest.iter().chain(malicious.iter()).collect();
+            let agg = rule.aggregate(&all, &r).unwrap();
+            let shift = (0..dim)
+                .map(|j| (agg[j] - reference[j]).abs())
+                .fold(0.0f32, f32::max);
+            if shift > 4.0 * sigma {
+                broken_seeds += 1;
+                max_break_shift = max_break_shift.max(shift);
+            }
+            assert!(
+                shift > 1e20,
+                "seed {}: expected catastrophic break at f > ceil(beta*n), got shift {}",
+                seed,
+                shift
+            );
+        }
+        assert_eq!(broken_seeds, 100, "the cliff must break for every seed");
+        println!(
+            "cliff: f = ceil(beta*n)+1 broke 100/100 seeds, max shift {:.3e}",
+            max_break_shift
+        );
+    }
+
+    /// Test 4 (A2, ADR-0003): plain Mean is poisonable — a single malicious
+    /// worker among 19 honest moves the average arbitrarily far. This is why
+    /// FedAvg is permanently rejected as a production rule.
+    #[test]
+    fn test_mean_baseline_poisonable() {
+        let dim = 4usize;
+        let r = ParamRange::new(0, dim as u64).unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+        let g: Vec<f32> = (0..dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+        let honest = honest_updates(&mut rng, 19, &g, 0.05, r);
+        let reference = honest_mean(&honest, dim);
+        let malicious = malicious_updates(1, dim, r);
+        let all: Vec<&ParamUpdate> = honest.iter().chain(malicious.iter()).collect();
+        let agg = Mean.aggregate(&all, &r).unwrap();
+        for j in 0..dim {
+            // 1e30 / 20 = 5e28: one worker fully owns the aggregate.
+            assert!(
+                (agg[j] - reference[j]).abs() > 1e20,
+                "Mean should be unboundedly poisonable"
+            );
+        }
+    }
+
+    /// Test 5 (A2): degenerate inputs and defensive checks.
+    #[test]
+    fn test_degenerate_inputs() {
+        let r = ParamRange::new(0, 2).unwrap();
+        let rule = TrimmedMean::new(0.2).unwrap();
+
+        // Empty update set errors.
+        assert!(matches!(
+            rule.aggregate(&[], &r),
+            Err(PsError::Aggregation(_))
+        ));
+        assert!(matches!(
+            Mean.aggregate(&[], &r),
+            Err(PsError::Aggregation(_))
+        ));
+
+        // Range mismatch errors.
+        let other = ParamRange::new(2, 4).unwrap();
+        let mismatched = upd(1, other, vec![1.0, 2.0]);
+        assert!(matches!(
+            rule.aggregate(&[&mismatched], &r),
+            Err(PsError::Aggregation(_))
+        ));
+
+        // Value-length mismatch errors.
+        let short = upd(1, r, vec![1.0]);
+        assert!(matches!(
+            rule.aggregate(&[&short], &r),
+            Err(PsError::Aggregation(_))
+        ));
+
+        // Too few updates for beta: n = 2, beta = 0.4 trims ceil(0.8) = 1 per
+        // end, leaving nothing. Error message names n and beta so operators
+        // can see which knob to turn.
+        let rule04 = TrimmedMean::new(0.4).unwrap();
+        let updates = vec![upd(1, r, vec![1.0, 2.0]), upd(2, r, vec![3.0, 4.0])];
+        match rule04.aggregate(&refs(&updates), &r) {
+            Err(PsError::Aggregation(msg)) => {
+                assert!(msg.contains("n = 2"), "message must name n: {}", msg);
+                assert!(
+                    msg.contains("beta = 0.4"),
+                    "message must name beta: {}",
+                    msg
+                );
+            }
+            other => panic!("expected Aggregation error, got {:?}", other),
+        }
+        // A single update trims away at any beta > 0 too.
+        assert!(rule.aggregate(&[&updates[0]], &r).is_err());
+
+        // Single update with beta = 0 passes through as the identity.
+        let rule0 = TrimmedMean::new(0.0).unwrap();
+        let one = vec![upd(1, r, vec![1.25, -7.5])];
+        assert_eq!(rule0.aggregate(&refs(&one), &r).unwrap(), vec![1.25, -7.5]);
+
+        // beta = 0 over multiple updates == plain mean (exactly, with
+        // dyadic-friendly values: both rules accumulate in f64).
+        let many = vec![
+            upd(1, r, vec![1.0, -2.0]),
+            upd(2, r, vec![2.5, 0.5]),
+            upd(3, r, vec![-0.5, 7.5]),
+            upd(4, r, vec![5.0, 2.0]),
+        ];
+        let trimmed0 = rule0.aggregate(&refs(&many), &r).unwrap();
+        let plain = Mean.aggregate(&refs(&many), &r).unwrap();
+        assert_eq!(trimmed0, plain);
+        assert_eq!(plain, vec![2.0, 2.0]);
+    }
+
+    /// `min_updates` is the exact boundary where trimming stops erasing
+    /// everything: aggregation succeeds at `min_updates` and the barrier
+    /// skips (rather than aborts on) anything below it.
+    #[test]
+    fn test_min_updates_boundary() {
+        assert_eq!(Mean.min_updates(), 1);
+        assert_eq!(TrimmedMean::new(0.0).unwrap().min_updates(), 1);
+        // beta = 0.2: n = 3 trims 1 per side, keeps 1.
+        assert_eq!(TrimmedMean::new(0.2).unwrap().min_updates(), 3);
+        // beta = 0.4: n = 5 trims 2 per side, keeps 1 (n = 3, 4 keep 0).
+        assert_eq!(TrimmedMean::new(0.4).unwrap().min_updates(), 5);
+
+        let r = ParamRange::new(0, 1).unwrap();
+        for beta in [0.0, 0.1, 0.2, 0.25, 0.4, 0.499] {
+            let rule = TrimmedMean::new(beta).unwrap();
+            let n = rule.min_updates();
+            // Worker ids may repeat for large n (beta near 0.5 needs many
+            // updates); aggregate() does not dedup, so that is fine here.
+            let updates: Vec<ParamUpdate> = (0..n).map(|w| upd(w as u8, r, vec![1.0])).collect();
+            assert!(
+                rule.aggregate(&refs(&updates), &r).is_ok(),
+                "beta {}: aggregate must succeed at min_updates = {}",
+                beta,
+                n
+            );
+            if n > 1 {
+                assert!(
+                    rule.aggregate(&refs(&updates[..n - 1]), &r).is_err(),
+                    "beta {}: aggregate must fail below min_updates",
+                    beta
+                );
+            }
+        }
+    }
+
+    /// Test 6 (A2): constructor rejects beta outside [0, 0.5).
+    #[test]
+    fn test_new_rejects_invalid_beta() {
+        assert!(matches!(
+            TrimmedMean::new(-0.1),
+            Err(PsError::Aggregation(_))
+        ));
+        assert!(matches!(
+            TrimmedMean::new(0.5),
+            Err(PsError::Aggregation(_))
+        ));
+        assert!(matches!(
+            TrimmedMean::new(1.0),
+            Err(PsError::Aggregation(_))
+        ));
+        assert!(matches!(
+            TrimmedMean::new(f64::NAN),
+            Err(PsError::Aggregation(_))
+        ));
+        assert_eq!(TrimmedMean::new(0.0).unwrap().beta, 0.0);
+        assert_eq!(TrimmedMean::new(0.2).unwrap().beta, 0.2);
+        assert_eq!(TrimmedMean::new(0.499).unwrap().beta, 0.499);
     }
 }
 

--- a/crates/qfc-ps/src/aggregate.rs
+++ b/crates/qfc-ps/src/aggregate.rs
@@ -1,0 +1,176 @@
+//! Byzantine-robust aggregation (ADR-0003).
+//!
+//! Updates buffer per range during the epoch; at the SSP barrier
+//! (ADR-0006) the configured [`AggregationRule`] reduces each range's
+//! buffered updates to one delta vector. Plain averaging is forbidden as a
+//! production rule — workers are untrusted.
+
+use std::collections::HashMap;
+
+use crate::types::{ParamRange, ParamUpdate};
+use crate::PsError;
+
+/// Reduces one range's buffered updates to a single delta vector.
+pub trait AggregationRule {
+    /// `updates` are structurally valid (see `ParamUpdate::validate`) and all
+    /// have ranges equal to `range`. Must be deterministic: callers sort
+    /// updates by worker address before invoking (ADR-0003).
+    fn aggregate(&self, updates: &[&ParamUpdate], range: &ParamRange) -> Result<Vec<f32>, PsError>;
+}
+
+/// Coordinate-wise trimmed mean with trim fraction `beta` per side
+/// (ADR-0003). Tolerates `f < beta * n` malicious updates per range.
+#[derive(Clone, Copy, Debug)]
+pub struct TrimmedMean {
+    pub beta: f64,
+}
+
+impl TrimmedMean {
+    pub fn new(beta: f64) -> Result<Self, PsError> {
+        if !(0.0..0.5).contains(&beta) {
+            return Err(PsError::Aggregation(format!(
+                "trim beta {} outside [0, 0.5)",
+                beta
+            )));
+        }
+        Ok(Self { beta })
+    }
+}
+
+impl AggregationRule for TrimmedMean {
+    fn aggregate(&self, updates: &[&ParamUpdate], range: &ParamRange) -> Result<Vec<f32>, PsError> {
+        // Implemented in milestone A2.
+        let _ = (updates, range);
+        todo!("A2: coordinate-wise trimmed mean")
+    }
+}
+
+/// Per-epoch buffer of pushed updates, keyed by exact range.
+///
+/// Enforces the per-range worker cap — the O(workers × shard_size)
+/// aggregation memory bound from ADR-0003 — and one-update-per-(worker, clock)
+/// dedup. Cleared at the epoch barrier.
+#[derive(Debug, Default)]
+pub struct UpdateBuffer {
+    max_per_range: usize,
+    buffered: HashMap<ParamRange, Vec<ParamUpdate>>,
+}
+
+impl UpdateBuffer {
+    /// `max_per_range = 0` means uncapped (tests only; production always caps).
+    pub fn new(max_per_range: usize) -> Self {
+        Self {
+            max_per_range,
+            buffered: HashMap::new(),
+        }
+    }
+
+    /// Buffer a validated update. Rejects duplicates (same worker + clock on
+    /// the same range) and pushes beyond the worker cap.
+    pub fn add(&mut self, update: ParamUpdate) -> Result<(), PsError> {
+        update.validate()?;
+        let entry = self.buffered.entry(update.range).or_default();
+        if entry
+            .iter()
+            .any(|u| u.worker == update.worker && u.clock == update.clock)
+        {
+            return Err(PsError::InvalidUpdate(format!(
+                "duplicate update from {} at clock {} for {}",
+                update.worker, update.clock, update.range
+            )));
+        }
+        if self.max_per_range > 0 && entry.len() >= self.max_per_range {
+            return Err(PsError::WorkerCapExceeded {
+                cap: self.max_per_range,
+            });
+        }
+        entry.push(update);
+        Ok(())
+    }
+
+    /// Updates for a range, sorted by (worker, clock) for deterministic
+    /// aggregation order (ADR-0003).
+    pub fn updates_for(&self, range: &ParamRange) -> Vec<&ParamUpdate> {
+        let mut v: Vec<&ParamUpdate> = self
+            .buffered
+            .get(range)
+            .map(|u| u.iter().collect())
+            .unwrap_or_default();
+        v.sort_by_key(|u| (*u.worker.as_bytes(), u.clock));
+        v
+    }
+
+    /// All ranges with at least one buffered update, sorted.
+    pub fn ranges(&self) -> Vec<ParamRange> {
+        let mut r: Vec<ParamRange> = self.buffered.keys().copied().collect();
+        r.sort();
+        r
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffered.values().map(|v| v.len()).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Drain everything at the epoch barrier.
+    pub fn clear(&mut self) {
+        self.buffered.clear();
+    }
+}
+
+#[cfg(test)]
+mod buffer_tests {
+    use super::*;
+    use qfc_types::Address;
+
+    fn update(worker: u8, clock: u64, range: ParamRange) -> ParamUpdate {
+        ParamUpdate {
+            worker: Address::new([worker; 20]),
+            epoch: 1,
+            clock,
+            range,
+            values: vec![1.0; range.len() as usize],
+            flops_estimated: 1,
+        }
+    }
+
+    #[test]
+    fn test_buffer_dedup_and_cap() {
+        let r = ParamRange::new(0, 4).unwrap();
+        let mut buf = UpdateBuffer::new(2);
+        buf.add(update(1, 0, r)).unwrap();
+        // Same worker, new clock: allowed
+        buf.add(update(1, 1, r)).unwrap();
+        // Duplicate (worker, clock): rejected
+        assert!(matches!(
+            buf.add(update(1, 0, r)),
+            Err(PsError::InvalidUpdate(_))
+        ));
+        // Cap reached
+        assert!(matches!(
+            buf.add(update(2, 0, r)),
+            Err(PsError::WorkerCapExceeded { cap: 2 })
+        ));
+        assert_eq!(buf.len(), 2);
+        buf.clear();
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_buffer_deterministic_order() {
+        let r = ParamRange::new(0, 2).unwrap();
+        let mut buf = UpdateBuffer::new(0);
+        buf.add(update(3, 0, r)).unwrap();
+        buf.add(update(1, 1, r)).unwrap();
+        buf.add(update(1, 0, r)).unwrap();
+        let order: Vec<(u8, u64)> = buf
+            .updates_for(&r)
+            .iter()
+            .map(|u| (u.worker.as_bytes()[0], u.clock))
+            .collect();
+        assert_eq!(order, vec![(1, 0), (1, 1), (3, 0)]);
+    }
+}

--- a/crates/qfc-ps/src/clock.rs
+++ b/crates/qfc-ps/src/clock.rs
@@ -13,6 +13,178 @@
 //!   return `PsError::StaleUpdate` (ADR-0006: stale ≠ slashable).
 //! - `barrier(&mut self)` — epoch barrier: resets clocks for the next epoch,
 //!   returns the final per-worker clock map (feeds acceptance accounting).
+//!
+//! Step-increment policy (ADR-0006): a worker's clock advances by exactly
+//! one per *accepted push* — there is no out-of-band clock report. This
+//! bounds `fastest_clock` growth (and hence the admission floor that can
+//! starve other workers) to accepted, metered, audit-eligible work — a
+//! cost-free clock-ratchet DoS is impossible. `SspClock` itself only checks
+//! monotonicity; the step-increment policy is enforced by `ShardService`.
 
-#[allow(unused_imports)]
+use std::collections::HashMap;
+
+use qfc_types::Address;
+use tracing::debug;
+
 use crate::{types::StepClock, PsError};
+
+/// Per-epoch SSP clock state: one logical clock (step count) per worker,
+/// plus the staleness bound that gates push admission.
+#[derive(Debug)]
+pub struct SspClock {
+    staleness_bound: u64,
+    clocks: HashMap<Address, StepClock>,
+}
+
+impl SspClock {
+    pub fn new(staleness_bound: u64) -> Self {
+        Self {
+            staleness_bound,
+            clocks: HashMap::new(),
+        }
+    }
+
+    pub fn staleness_bound(&self) -> u64 {
+        self.staleness_bound
+    }
+
+    /// Register a worker at clock 0 (no-op if already registered).
+    pub fn register_worker(&mut self, worker: Address) {
+        self.clocks.entry(worker).or_insert(0);
+    }
+
+    /// The worker's current clock, if registered.
+    pub fn worker_clock(&self, worker: Address) -> Option<StepClock> {
+        self.clocks.get(&worker).copied()
+    }
+
+    /// Worker reports step completion. Auto-registers unknown workers.
+    /// Clocks are monotonic per worker: regression is an error
+    /// (`PsError::InvalidUpdate`); re-reporting the current clock is a no-op.
+    ///
+    /// This is the internal advancement mechanism — it only checks
+    /// monotonicity. Callers must enforce the step-increment policy (exactly
+    /// one step per accepted push, ADR-0006); `ShardService` does.
+    pub fn advance(&mut self, worker: Address, clock: StepClock) -> Result<(), PsError> {
+        let entry = self.clocks.entry(worker).or_insert(0);
+        if clock < *entry {
+            return Err(PsError::InvalidUpdate(format!(
+                "clock regression for worker {}: {} < {}",
+                worker, clock, entry
+            )));
+        }
+        *entry = clock;
+        Ok(())
+    }
+
+    /// Slowest registered worker (0 when none are registered).
+    pub fn min_clock(&self) -> StepClock {
+        self.clocks.values().copied().min().unwrap_or(0)
+    }
+
+    /// Fastest registered worker (0 when none are registered).
+    pub fn fastest_clock(&self) -> StepClock {
+        self.clocks.values().copied().max().unwrap_or(0)
+    }
+
+    /// SSP admission: a push at `worker_clock` is admitted iff
+    /// `worker_clock + staleness_bound >= fastest_clock`, i.e. it is no
+    /// further than the staleness bound behind the fastest worker. Rejection
+    /// is `PsError::StaleUpdate` — an error, never a slash (ADR-0006).
+    pub fn admit(&self, worker_clock: StepClock) -> Result<(), PsError> {
+        let floor = self.fastest_clock().saturating_sub(self.staleness_bound);
+        if worker_clock < floor {
+            return Err(PsError::StaleUpdate {
+                worker_clock,
+                floor,
+                bound: self.staleness_bound,
+            });
+        }
+        Ok(())
+    }
+
+    /// Epoch barrier: returns the final per-worker clock map for acceptance
+    /// accounting and resets all clocks for the next epoch (workers
+    /// re-register as they participate).
+    pub fn barrier(&mut self) -> HashMap<Address, StepClock> {
+        debug!(workers = self.clocks.len(), "ssp clock barrier");
+        std::mem::take(&mut self.clocks)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(b: u8) -> Address {
+        Address::new([b; 20])
+    }
+
+    #[test]
+    fn test_admission_within_and_outside_bound() {
+        let mut clock = SspClock::new(3);
+        // No workers yet: floor is 0, everything admits.
+        assert!(clock.admit(0).is_ok());
+
+        clock.advance(addr(1), 10).unwrap();
+        clock.advance(addr(2), 4).unwrap();
+        assert_eq!(clock.fastest_clock(), 10);
+        assert_eq!(clock.min_clock(), 4);
+
+        // Floor = 10 - 3 = 7.
+        assert!(clock.admit(7).is_ok());
+        assert!(clock.admit(10).is_ok());
+        assert!(matches!(
+            clock.admit(6),
+            Err(PsError::StaleUpdate {
+                worker_clock: 6,
+                floor: 7,
+                bound: 3
+            })
+        ));
+    }
+
+    #[test]
+    fn test_monotonicity_violation() {
+        let mut clock = SspClock::new(3);
+        clock.advance(addr(1), 5).unwrap();
+        // Equal clock: idempotent no-op.
+        clock.advance(addr(1), 5).unwrap();
+        // Regression: error, clock unchanged.
+        assert!(matches!(
+            clock.advance(addr(1), 4),
+            Err(PsError::InvalidUpdate(_))
+        ));
+        assert_eq!(clock.worker_clock(addr(1)), Some(5));
+    }
+
+    #[test]
+    fn test_register_and_worker_clock() {
+        let mut clock = SspClock::new(3);
+        assert_eq!(clock.worker_clock(addr(1)), None);
+        clock.register_worker(addr(1));
+        assert_eq!(clock.worker_clock(addr(1)), Some(0));
+        // Re-register does not reset.
+        clock.advance(addr(1), 2).unwrap();
+        clock.register_worker(addr(1));
+        assert_eq!(clock.worker_clock(addr(1)), Some(2));
+    }
+
+    #[test]
+    fn test_barrier_returns_final_map_and_resets() {
+        let mut clock = SspClock::new(3);
+        clock.advance(addr(1), 7).unwrap();
+        clock.advance(addr(2), 9).unwrap();
+
+        let finals = clock.barrier();
+        assert_eq!(finals.len(), 2);
+        assert_eq!(finals[&addr(1)], 7);
+        assert_eq!(finals[&addr(2)], 9);
+
+        // Reset: clocks cleared, admission floor back to 0.
+        assert_eq!(clock.worker_clock(addr(1)), None);
+        assert_eq!(clock.fastest_clock(), 0);
+        assert!(clock.admit(0).is_ok());
+        assert!(clock.barrier().is_empty());
+    }
+}

--- a/crates/qfc-ps/src/clock.rs
+++ b/crates/qfc-ps/src/clock.rs
@@ -1,0 +1,18 @@
+//! SSP (stale-synchronous parallel) clock tracking (ADR-0006).
+//!
+//! Implemented in milestone A1. Required API:
+//!
+//! - `SspClock::new(staleness_bound)` — per-epoch state.
+//! - `register_worker(&mut self, worker)` / `worker_clock(&self, worker)`.
+//! - `advance(&mut self, worker, clock)` — worker reports step completion;
+//!   clocks are monotonic per worker.
+//! - `min_clock(&self) -> StepClock` — slowest registered worker.
+//! - `admit(&self, worker_clock) -> Result<(), PsError>` — SSP admission:
+//!   a push at `worker_clock` is admitted iff
+//!   `worker_clock + staleness_bound >= fastest_clock`; rejected pushes
+//!   return `PsError::StaleUpdate` (ADR-0006: stale ≠ slashable).
+//! - `barrier(&mut self)` — epoch barrier: resets clocks for the next epoch,
+//!   returns the final per-worker clock map (feeds acceptance accounting).
+
+#[allow(unused_imports)]
+use crate::{types::StepClock, PsError};

--- a/crates/qfc-ps/src/kv.rs
+++ b/crates/qfc-ps/src/kv.rs
@@ -1,0 +1,25 @@
+//! Range-sharded parameter storage on `qfc_storage::Database`.
+//!
+//! Implemented in milestone A1. Required API (service.rs builds on this):
+//!
+//! - `ShardStore::open(path, owned_range) -> Result<Self, PsError>` and
+//!   `ShardStore::open_temp(owned_range)` for tests — a dedicated RocksDB
+//!   instance (NOT the chain DB), reusing `qfc_storage::Database`.
+//! - Keys: parameter index as 8-byte big-endian (matches the workspace's
+//!   BE-ordered key convention; gives natural range iteration). Values: f32 LE.
+//!   Stored row-batched per a fixed chunk width to avoid one-KV-per-f32.
+//! - `get_range(&self, range) -> Result<Vec<f32>, PsError>` — zero-filled for
+//!   never-written keys inside the owned range; error outside it.
+//! - `apply_delta(&self, range, delta: &[f32]) -> Result<(), PsError>` —
+//!   read-modify-write, atomic via `WriteBatch` (epoch barrier applies the
+//!   aggregated delta).
+//! - `set_range(&self, range, values)` — initial load of a model version.
+//! - `params_hash(&self) -> Result<qfc_types::Hash, PsError>` — streaming
+//!   Blake3 over the owned range in key order (the shard's contribution to
+//!   the epoch version commit, ADR-0006).
+//! - `export_snapshot(&self, path) -> Result<(), PsError>` — raw f32-LE dump
+//!   of the owned range, the input to B-1 `ShardManifest::split_file`
+//!   (ADR-0007: snapshots reuse the shard-manifest format).
+
+#[allow(unused_imports)]
+use crate::{types::ParamRange, PsError};

--- a/crates/qfc-ps/src/kv.rs
+++ b/crates/qfc-ps/src/kv.rs
@@ -21,5 +21,408 @@
 //!   of the owned range, the input to B-1 `ShardManifest::split_file`
 //!   (ADR-0007: snapshots reuse the shard-manifest format).
 
-#[allow(unused_imports)]
+use std::io::Write;
+use std::path::Path;
+
+use qfc_storage::{cf, Database, StorageConfig, WriteBatch};
+use qfc_types::Hash;
+use tracing::debug;
+
 use crate::{types::ParamRange, PsError};
+
+/// Parameters per RocksDB value row. One row = `CHUNK` f32s (4 KiB), keyed by
+/// chunk index as 8-byte BE — chunk i covers absolute keys
+/// `[i * CHUNK, (i + 1) * CHUNK)`.
+pub const CHUNK: u64 = 1024;
+
+/// A1-pragmatic CF choice: `Database::open` hardcodes the chain's CF set
+/// (`cf::ALL`) with no custom-CF support, so we reuse `cf::STATE` purely as a
+/// namespace for parameter chunk rows. This is fine per ADR-0002/0006 because
+/// a `ShardStore` is a *dedicated* DB instance at its own path — the chain DB
+/// never sees these rows. A later milestone can teach `qfc-storage` custom CF
+/// lists if the unused chain CFs become an annoyance.
+const PARAMS_CF: &str = cf::STATE;
+
+fn storage_err(e: impl std::fmt::Display) -> PsError {
+    PsError::Storage(e.to_string())
+}
+
+fn encode_chunk(chunk: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(chunk.len() * 4);
+    for v in chunk {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+fn decode_chunk(bytes: &[u8]) -> Result<Vec<f32>, PsError> {
+    if bytes.len() != (CHUNK as usize) * 4 {
+        return Err(PsError::Storage(format!(
+            "corrupt chunk row: {} bytes, expected {}",
+            bytes.len(),
+            CHUNK * 4
+        )));
+    }
+    Ok(bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().expect("chunks_exact(4) yields 4-byte slices")))
+        .collect())
+}
+
+/// Range-sharded parameter store: one shard's contiguous `owned_range` of
+/// dense model parameters, persisted in a dedicated RocksDB instance.
+pub struct ShardStore {
+    db: Database,
+    owned_range: ParamRange,
+}
+
+impl ShardStore {
+    /// Open (or create) the shard's dedicated database at `path`.
+    pub fn open(path: impl AsRef<Path>, owned_range: ParamRange) -> Result<Self, PsError> {
+        let config = StorageConfig {
+            path: path.as_ref().to_path_buf(),
+            create_if_missing: true,
+            ..Default::default()
+        };
+        let db = Database::open(config).map_err(storage_err)?;
+        debug!(path = %path.as_ref().display(), range = %owned_range, "opened shard store");
+        Ok(Self { db, owned_range })
+    }
+
+    /// Open a throwaway store for tests; the backing directory is removed
+    /// when the store drops.
+    pub fn open_temp(owned_range: ParamRange) -> Result<Self, PsError> {
+        let db = Database::open_temp().map_err(storage_err)?;
+        Ok(Self { db, owned_range })
+    }
+
+    /// The contiguous parameter range this shard owns.
+    pub fn owned_range(&self) -> ParamRange {
+        self.owned_range
+    }
+
+    fn check_owned(&self, range: &ParamRange) -> Result<(), PsError> {
+        if !self.owned_range.covers(range) {
+            return Err(PsError::InvalidRange(format!(
+                "range {} outside owned range {}",
+                range, self.owned_range
+            )));
+        }
+        Ok(())
+    }
+
+    fn chunk_key(idx: u64) -> [u8; 8] {
+        idx.to_be_bytes()
+    }
+
+    /// Load chunk `idx` as a full `CHUNK`-wide vector, zero-filled if the row
+    /// was never written.
+    fn load_chunk(&self, idx: u64) -> Result<Vec<f32>, PsError> {
+        match self
+            .db
+            .get(PARAMS_CF, &Self::chunk_key(idx))
+            .map_err(storage_err)?
+        {
+            Some(bytes) => decode_chunk(&bytes),
+            None => Ok(vec![0.0; CHUNK as usize]),
+        }
+    }
+
+    /// Read-modify-write every chunk overlapping `range`, applying
+    /// `f(stored_slot, incoming_value)` over the intersection, then commit all
+    /// rows in one atomic `WriteBatch`.
+    fn modify_range(
+        &self,
+        range: &ParamRange,
+        values: &[f32],
+        f: impl Fn(&mut f32, f32),
+    ) -> Result<(), PsError> {
+        self.check_owned(range)?;
+        if values.len() as u64 != range.len() {
+            return Err(PsError::InvalidUpdate(format!(
+                "value count {} != range length {} for {}",
+                values.len(),
+                range.len(),
+                range
+            )));
+        }
+        let first = range.start / CHUNK;
+        let last = (range.end - 1) / CHUNK;
+        let mut batch = WriteBatch::with_capacity((last - first + 1) as usize);
+        for idx in first..=last {
+            let chunk_start = idx * CHUNK;
+            let lo = range.start.max(chunk_start);
+            let hi = range.end.min(chunk_start.saturating_add(CHUNK));
+            let mut chunk = self.load_chunk(idx)?;
+            let dst = &mut chunk[(lo - chunk_start) as usize..(hi - chunk_start) as usize];
+            let src = &values[(lo - range.start) as usize..(hi - range.start) as usize];
+            for (slot, v) in dst.iter_mut().zip(src) {
+                f(slot, *v);
+            }
+            batch.put(
+                PARAMS_CF,
+                Self::chunk_key(idx).to_vec(),
+                encode_chunk(&chunk),
+            );
+        }
+        self.db.write_batch(batch).map_err(storage_err)
+    }
+
+    /// Current parameters for `range` (must lie within the owned range).
+    /// Never-written keys read as 0.0.
+    pub fn get_range(&self, range: ParamRange) -> Result<Vec<f32>, PsError> {
+        self.check_owned(&range)?;
+        let mut out = vec![0.0f32; range.len() as usize];
+        let first = range.start / CHUNK;
+        let last = (range.end - 1) / CHUNK;
+        for idx in first..=last {
+            if let Some(bytes) = self
+                .db
+                .get(PARAMS_CF, &Self::chunk_key(idx))
+                .map_err(storage_err)?
+            {
+                let chunk = decode_chunk(&bytes)?;
+                let chunk_start = idx * CHUNK;
+                let lo = range.start.max(chunk_start);
+                let hi = range.end.min(chunk_start.saturating_add(CHUNK));
+                out[(lo - range.start) as usize..(hi - range.start) as usize].copy_from_slice(
+                    &chunk[(lo - chunk_start) as usize..(hi - chunk_start) as usize],
+                );
+            }
+        }
+        Ok(out)
+    }
+
+    /// Overwrite `range` with `values` (initial load of a model version).
+    /// Atomic across all affected chunk rows.
+    pub fn set_range(&self, range: ParamRange, values: &[f32]) -> Result<(), PsError> {
+        self.modify_range(&range, values, |slot, v| *slot = v)
+    }
+
+    /// Add `delta` element-wise onto `range`. Atomic: all affected chunks are
+    /// read-modified-written in a single `WriteBatch` (the epoch barrier
+    /// applies the aggregated delta through this).
+    pub fn apply_delta(&self, range: ParamRange, delta: &[f32]) -> Result<(), PsError> {
+        self.modify_range(&range, delta, |slot, d| *slot += d)
+    }
+
+    /// Stream the owned range's raw f32-LE bytes, chunk by chunk in key
+    /// order (zero-filled gaps included), into `sink`. This byte sequence is
+    /// the canonical shard image: both `params_hash` and `export_snapshot`
+    /// are defined over it.
+    fn stream_owned(
+        &self,
+        mut sink: impl FnMut(&[u8]) -> Result<(), PsError>,
+    ) -> Result<(), PsError> {
+        let range = self.owned_range;
+        let first = range.start / CHUNK;
+        let last = (range.end - 1) / CHUNK;
+        for idx in first..=last {
+            let chunk = self.load_chunk(idx)?;
+            let chunk_start = idx * CHUNK;
+            let lo = range.start.max(chunk_start);
+            let hi = range.end.min(chunk_start.saturating_add(CHUNK));
+            let bytes =
+                encode_chunk(&chunk[(lo - chunk_start) as usize..(hi - chunk_start) as usize]);
+            sink(&bytes)?;
+        }
+        Ok(())
+    }
+
+    /// Streaming Blake3 over the owned range's f32-LE bytes in key order —
+    /// the shard's contribution to the epoch version commit (ADR-0006).
+    /// Deterministic: unwritten keys hash as 0.0.
+    pub fn params_hash(&self) -> Result<Hash, PsError> {
+        let mut hasher = blake3::Hasher::new();
+        self.stream_owned(|bytes| {
+            hasher.update(bytes);
+            Ok(())
+        })?;
+        Ok(Hash::new(*hasher.finalize().as_bytes()))
+    }
+
+    /// Raw f32-LE dump of the owned range to `path` — byte-identical to the
+    /// `params_hash` input, and the input to B-1 `ShardManifest::split_file`
+    /// (ADR-0007).
+    pub fn export_snapshot(&self, path: impl AsRef<Path>) -> Result<(), PsError> {
+        let file = std::fs::File::create(path.as_ref()).map_err(storage_err)?;
+        let mut writer = std::io::BufWriter::new(file);
+        self.stream_owned(|bytes| writer.write_all(bytes).map_err(storage_err))?;
+        writer.flush().map_err(storage_err)?;
+        debug!(path = %path.as_ref().display(), range = %self.owned_range, "exported snapshot");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range(start: u64, end: u64) -> ParamRange {
+        ParamRange::new(start, end).unwrap()
+    }
+
+    /// Pattern values distinct per key so cross-chunk copies are detectable.
+    fn pattern(r: ParamRange) -> Vec<f32> {
+        (r.start..r.end).map(|k| k as f32 * 0.5 - 7.0).collect()
+    }
+
+    #[test]
+    fn test_set_get_round_trip_partial_chunks() {
+        // Owned range starts and ends mid-chunk and spans 3 chunk rows.
+        let owned = range(1000, 3100);
+        let store = ShardStore::open_temp(owned).unwrap();
+        store.set_range(owned, &pattern(owned)).unwrap();
+
+        assert_eq!(store.get_range(owned).unwrap(), pattern(owned));
+
+        // Sub-range crossing the 1024 and 2048 chunk boundaries.
+        let sub = range(1020, 2060);
+        assert_eq!(store.get_range(sub).unwrap(), pattern(sub));
+
+        // Single-key edges.
+        assert_eq!(
+            store.get_range(range(1000, 1001)).unwrap(),
+            pattern(range(1000, 1001))
+        );
+        assert_eq!(
+            store.get_range(range(3099, 3100)).unwrap(),
+            pattern(range(3099, 3100))
+        );
+    }
+
+    #[test]
+    fn test_zero_fill_for_unwritten() {
+        let owned = range(1000, 3100);
+        let store = ShardStore::open_temp(owned).unwrap();
+
+        // Nothing written: everything reads as zero.
+        assert_eq!(
+            store.get_range(owned).unwrap(),
+            vec![0.0; owned.len() as usize]
+        );
+
+        // Write only a middle slice; the flanks stay zero.
+        let mid = range(2000, 2100);
+        store.set_range(mid, &vec![1.5; 100]).unwrap();
+        let all = store.get_range(owned).unwrap();
+        assert!(all[..1000].iter().all(|&v| v == 0.0));
+        assert!(all[1000..1100].iter().all(|&v| v == 1.5));
+        assert!(all[1100..].iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn test_out_of_owned_range_rejected() {
+        let owned = range(1000, 2000);
+        let store = ShardStore::open_temp(owned).unwrap();
+
+        for bad in [
+            range(999, 1001),
+            range(1999, 2001),
+            range(0, 10),
+            range(5000, 5010),
+        ] {
+            assert!(matches!(
+                store.get_range(bad),
+                Err(PsError::InvalidRange(_))
+            ));
+            assert!(matches!(
+                store.set_range(bad, &vec![0.0; bad.len() as usize]),
+                Err(PsError::InvalidRange(_))
+            ));
+            assert!(matches!(
+                store.apply_delta(bad, &vec![0.0; bad.len() as usize]),
+                Err(PsError::InvalidRange(_))
+            ));
+        }
+
+        // Length mismatch is rejected before any write.
+        assert!(matches!(
+            store.set_range(range(1000, 1004), &[1.0; 3]),
+            Err(PsError::InvalidUpdate(_))
+        ));
+    }
+
+    #[test]
+    fn test_apply_delta_including_negative() {
+        let owned = range(0, 2500);
+        let store = ShardStore::open_temp(owned).unwrap();
+        store.set_range(owned, &vec![10.0; 2500]).unwrap();
+
+        // Delta spans a chunk boundary; mixes positive and negative.
+        let dr = range(1000, 1100);
+        let delta: Vec<f32> = (0..100)
+            .map(|i| if i % 2 == 0 { 2.5 } else { -4.0 })
+            .collect();
+        store.apply_delta(dr, &delta).unwrap();
+
+        let got = store.get_range(dr).unwrap();
+        for (i, v) in got.iter().enumerate() {
+            let expect = if i % 2 == 0 { 12.5 } else { 6.0 };
+            assert_eq!(*v, expect, "index {}", i);
+        }
+        // Delta on never-written keys starts from the zero fill.
+        let dr2 = range(2400, 2500);
+        store.apply_delta(dr2, &vec![-1.0; 100]).unwrap();
+        assert_eq!(store.get_range(range(2400, 2401)).unwrap(), vec![9.0]);
+    }
+
+    #[test]
+    fn test_params_hash_sensitivity_and_reopen_stability() {
+        let owned = range(1000, 3100);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shard-db");
+
+        let h1 = {
+            let store = ShardStore::open(&path, owned).unwrap();
+            store.set_range(owned, &pattern(owned)).unwrap();
+            store.params_hash().unwrap()
+        };
+
+        // Reopen from disk: identical hash.
+        let store = ShardStore::open(&path, owned).unwrap();
+        assert_eq!(store.params_hash().unwrap(), h1);
+
+        // Changing one parameter changes the hash.
+        store.set_range(range(2048, 2049), &[123.456]).unwrap();
+        let h2 = store.params_hash().unwrap();
+        assert_ne!(h1, h2);
+
+        // Hash of pristine (all-zero) shard differs from written shard.
+        let empty = ShardStore::open_temp(owned).unwrap();
+        assert_ne!(empty.params_hash().unwrap(), h1);
+    }
+
+    #[test]
+    fn test_export_snapshot_matches_get_range_bytes() {
+        let owned = range(1000, 3100);
+        let store = ShardStore::open_temp(owned).unwrap();
+        // Leave a zero gap in the middle on purpose.
+        store
+            .set_range(range(1000, 1500), &pattern(range(1000, 1500)))
+            .unwrap();
+        store
+            .set_range(range(2500, 3100), &pattern(range(2500, 3100)))
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let snap = dir.path().join("snapshot.f32le");
+        store.export_snapshot(&snap).unwrap();
+
+        let file_bytes = std::fs::read(&snap).unwrap();
+        let expect: Vec<u8> = store
+            .get_range(owned)
+            .unwrap()
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        assert_eq!(file_bytes, expect);
+        assert_eq!(file_bytes.len() as u64, owned.len() * 4);
+
+        // Snapshot bytes are exactly the params_hash preimage.
+        assert_eq!(
+            store.params_hash().unwrap(),
+            Hash::new(*blake3::hash(&file_bytes).as_bytes())
+        );
+    }
+}

--- a/crates/qfc-ps/src/lib.rs
+++ b/crates/qfc-ps/src/lib.rs
@@ -16,8 +16,10 @@ pub mod service;
 pub mod types;
 
 pub use aggregate::{AggregationRule, TrimmedMean, UpdateBuffer};
+pub use clock::SspClock;
+pub use kv::ShardStore;
+pub use service::{EpochOutcome, ShardService};
 pub use types::{AcceptanceRecord, Epoch, ParamRange, ParamUpdate, StepClock};
-// A1 adds: pub use clock::SspClock; pub use kv::ShardStore; pub use service::ShardService;
 
 use thiserror::Error;
 
@@ -43,7 +45,14 @@ pub enum PsError {
     #[error("epoch mismatch: expected {expected}, got {got}")]
     EpochMismatch { expected: u64, got: u64 },
 
-    #[error("worker cap exceeded for range: {cap} workers already buffered (ADR-0003 memory bound)")]
+    /// Per-range worker cap hit. Because pushes are admitted only for the
+    /// fixed set of registered assignment ranges (disjoint, inside the owned
+    /// range), this cap yields a hard buffer bound:
+    /// `cap × Σ registered range lengths ≤ cap × owned_range.len()` buffered
+    /// f32s (ADR-0003 memory bound).
+    #[error(
+        "worker cap exceeded for range: {cap} workers already buffered (ADR-0003 memory bound)"
+    )]
     WorkerCapExceeded { cap: usize },
 
     #[error("aggregation failed: {0}")]
@@ -67,8 +76,13 @@ pub struct PsConfig {
     pub slash_multiple: u64,
     /// Epoch snapshots retained for the audit window (ADR-0007)
     pub snapshot_retention: u64,
-    /// Max buffered updates per range — the O(workers × shard) aggregation
-    /// memory bound (ADR-0003); enforced at push, mirrored at assignment (A3)
+    /// Max buffered updates per registered assignment range. Pushes are
+    /// admitted only for the fixed, disjoint registered range set, so total
+    /// buffer memory is bounded by
+    /// `max_workers_per_range × Σ registered range lengths ≤
+    /// max_workers_per_range × owned_range.len()` f32s — the
+    /// O(workers × shard) aggregation memory bound (ADR-0003); enforced at
+    /// push, mirrored at assignment (A3)
     pub max_workers_per_range: usize,
 }
 

--- a/crates/qfc-ps/src/lib.rs
+++ b/crates/qfc-ps/src/lib.rs
@@ -1,0 +1,86 @@
+//! Off-chain parameter server for decentralized training.
+//!
+//! ROADMAP-AI-V3 Feature A. Design: `docs/adr/0002`–`0008`.
+//!
+//! This crate is strictly off-chain (ADR-0002): it implements the shard
+//! service a staked PS operator runs — range-sharded parameter storage
+//! (ps-lite-style contiguous key ranges over dense model parameters),
+//! push/pull with bounded-staleness admission (SSP, ADR-0006), and
+//! byzantine-robust aggregation at the epoch barrier (ADR-0003). The chain
+//! sees only the epoch-end version commit; nothing here is consensus state.
+
+pub mod aggregate;
+pub mod clock;
+pub mod kv;
+pub mod service;
+pub mod types;
+
+pub use aggregate::{AggregationRule, TrimmedMean, UpdateBuffer};
+pub use types::{AcceptanceRecord, Epoch, ParamRange, ParamUpdate, StepClock};
+// A1 adds: pub use clock::SspClock; pub use kv::ShardStore; pub use service::ShardService;
+
+use thiserror::Error;
+
+/// Errors from parameter-server operations
+#[derive(Debug, Error)]
+pub enum PsError {
+    #[error("invalid range: {0}")]
+    InvalidRange(String),
+
+    #[error("invalid update: {0}")]
+    InvalidUpdate(String),
+
+    #[error("stale update: worker clock {worker_clock} below admission floor {floor} (staleness bound {bound})")]
+    StaleUpdate {
+        worker_clock: u64,
+        floor: u64,
+        bound: u64,
+    },
+
+    #[error("epoch {epoch} is closed for pushes")]
+    EpochClosed { epoch: u64 },
+
+    #[error("epoch mismatch: expected {expected}, got {got}")]
+    EpochMismatch { expected: u64, got: u64 },
+
+    #[error("worker cap exceeded for range: {cap} workers already buffered (ADR-0003 memory bound)")]
+    WorkerCapExceeded { cap: usize },
+
+    #[error("aggregation failed: {0}")]
+    Aggregation(String),
+
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+/// Protocol constants from the Feature-A ADRs, in one place (ADR-0008).
+/// A5 mirrors these on-chain as governance parameters.
+#[derive(Clone, Debug)]
+pub struct PsConfig {
+    /// Trim fraction per side for coordinate-wise trimmed mean (ADR-0003)
+    pub trim_beta: f64,
+    /// SSP staleness bound in steps (ADR-0006)
+    pub staleness_bound: u64,
+    /// Sampled re-execution rate (ADR-0005)
+    pub spot_check_rate: f64,
+    /// Slash = this multiple of the per-step reward (ADR-0008)
+    pub slash_multiple: u64,
+    /// Epoch snapshots retained for the audit window (ADR-0007)
+    pub snapshot_retention: u64,
+    /// Max buffered updates per range — the O(workers × shard) aggregation
+    /// memory bound (ADR-0003); enforced at push, mirrored at assignment (A3)
+    pub max_workers_per_range: usize,
+}
+
+impl Default for PsConfig {
+    fn default() -> Self {
+        Self {
+            trim_beta: 0.2,
+            staleness_bound: 3,
+            spot_check_rate: 0.05,
+            slash_multiple: 40,
+            snapshot_retention: 4,
+            max_workers_per_range: 64,
+        }
+    }
+}

--- a/crates/qfc-ps/src/service.rs
+++ b/crates/qfc-ps/src/service.rs
@@ -1,28 +1,637 @@
 //! Shard service: push/pull + epoch barrier, tying together kv / clock /
 //! aggregate (the component a PS operator runs, ADR-0002).
 //!
-//! Implemented in milestone A1. Required API:
+//! Implemented in milestone A1, hardened after adversarial review. API:
 //!
-//! - `ShardService::new(store: ShardStore, config: PsConfig, epoch: Epoch)`.
+//! - `ShardService::new(store, config, epoch, ranges) -> Result<Self, PsError>`
+//!   — `ranges` is the fixed set of registered assignment ranges for this
+//!   shard (the assignment layer, A3, feeds them): non-empty, pairwise
+//!   disjoint, each inside the owned range. Workers do NOT choose ranges;
+//!   pushes are admitted only for exactly-registered ranges, which bounds
+//!   buffer memory and makes overlap double-apply impossible (ADR-0003).
 //! - `push(&mut self, update: ParamUpdate) -> Result<AcceptanceRecord, PsError>`
-//!   — validates epoch match + structure, SSP admission via `SspClock`,
+//!   — validates epoch match + structure, range registration, step-clock
+//!   sequence (a worker's clock advances by exactly one per accepted push;
+//!   first push must carry clock 0 — ADR-0006), SSP admission via `SspClock`,
 //!   buffers via `UpdateBuffer` (worker cap), records acceptance (ADR-0004).
 //!   Rejected-as-stale is an error, not a slash (ADR-0006).
 //! - `pull(&self, range: ParamRange) -> Result<Vec<f32>, PsError>` — current
 //!   shard parameters for any sub-range of the owned range.
-//! - `advance_clock(&mut self, worker, clock)` — worker step report.
-//! - `end_epoch(&mut self, rule: &dyn AggregationRule)
-//!      -> Result<EpochOutcome, PsError>` — the barrier (ADR-0006): for each
-//!   buffered range, aggregate (updates sorted by worker for determinism),
-//!   `apply_delta`, then clear buffer, bump epoch, and return
+//! - `end_epoch(&mut self) -> Result<EpochOutcome, PsError>` — the barrier
+//!   (ADR-0006) with the production rule, `TrimmedMean` at the configured
+//!   `trim_beta` (ADR-0003): for each buffered range with at least
+//!   `rule.min_updates()` updates, aggregate (updates sorted by worker for
+//!   determinism) and `apply_delta`; thinner ranges are skipped with a
+//!   warning (deterministic no-op, acceptance records kept — ADR-0004).
+//!   Then clear buffer, bump epoch, and return
 //!   `EpochOutcome { epoch, params_hash, accepted: Vec<AcceptanceRecord> }`
 //!   — the inputs of the on-chain version commit (A5).
+//!   `end_epoch_with_rule` exists for tests and trusted-cluster experiments.
 //! - Pushes for a closed/mismatched epoch → `PsError::EpochClosed` /
 //!   `EpochMismatch`.
 
-#[allow(unused_imports)]
+use qfc_types::Hash;
+use tracing::{debug, info, warn};
+
 use crate::{
-    aggregate::{AggregationRule, UpdateBuffer},
+    aggregate::{AggregationRule, TrimmedMean, UpdateBuffer},
+    clock::SspClock,
+    kv::ShardStore,
     types::{AcceptanceRecord, Epoch, ParamRange, ParamUpdate},
     PsConfig, PsError,
 };
+
+/// Result of closing an epoch at the barrier — the inputs of the on-chain
+/// version commit (A5): the epoch just closed, the post-aggregation shard
+/// parameter hash, and every acceptance record issued during the epoch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EpochOutcome {
+    /// The epoch that was just closed (the service is now at `epoch + 1`).
+    pub epoch: Epoch,
+    /// `ShardStore::params_hash` after applying the aggregated deltas.
+    pub params_hash: Hash,
+    /// All acceptance records issued by `push` during the closed epoch
+    /// (ADR-0004 — the unit reward distribution reads).
+    pub accepted: Vec<AcceptanceRecord>,
+}
+
+/// The shard service a staked PS operator runs (ADR-0002): SSP-gated
+/// push/pull within an epoch, byzantine-robust aggregation at the barrier.
+pub struct ShardService {
+    store: ShardStore,
+    config: PsConfig,
+    epoch: Epoch,
+    clock: SspClock,
+    buffer: UpdateBuffer,
+    /// The fixed set of registered assignment ranges (sorted, pairwise
+    /// disjoint, each inside the owned range). Pushes must target exactly
+    /// one of these — workers never choose ranges (ADR-0003, A3).
+    ranges: Vec<ParamRange>,
+    /// Acceptance records issued this epoch. Survives `buffer.clear()` at the
+    /// barrier — records are accounting, the buffer is working memory.
+    accepted: Vec<AcceptanceRecord>,
+}
+
+impl ShardService {
+    /// `ranges` are the assignment-layer ranges for this shard (A3 supplies
+    /// them; tests and the pilot use a partition of the owned range). They
+    /// must be non-empty, pairwise disjoint, and each inside the owned
+    /// range — otherwise `InvalidRange`.
+    pub fn new(
+        store: ShardStore,
+        config: PsConfig,
+        epoch: Epoch,
+        ranges: Vec<ParamRange>,
+    ) -> Result<Self, PsError> {
+        if ranges.is_empty() {
+            return Err(PsError::InvalidRange(
+                "registered assignment range set must be non-empty".to_string(),
+            ));
+        }
+        let mut ranges = ranges;
+        ranges.sort();
+        ranges.dedup();
+        for r in &ranges {
+            if !store.owned_range().covers(r) {
+                return Err(PsError::InvalidRange(format!(
+                    "registered range {} outside owned range {}",
+                    r,
+                    store.owned_range()
+                )));
+            }
+        }
+        for pair in ranges.windows(2) {
+            if pair[0].overlaps(&pair[1]) {
+                return Err(PsError::InvalidRange(format!(
+                    "registered ranges {} and {} overlap; assignment ranges \
+                     must be pairwise disjoint (ADR-0003)",
+                    pair[0], pair[1]
+                )));
+            }
+        }
+        let clock = SspClock::new(config.staleness_bound);
+        let buffer = UpdateBuffer::new(config.max_workers_per_range);
+        Ok(Self {
+            store,
+            config,
+            epoch,
+            clock,
+            buffer,
+            ranges,
+            accepted: Vec::new(),
+        })
+    }
+
+    /// Current (open) training epoch.
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    /// The underlying parameter store (e.g. for snapshot export, A4).
+    pub fn store(&self) -> &ShardStore {
+        &self.store
+    }
+
+    /// The registered assignment ranges (sorted, pairwise disjoint).
+    pub fn registered_ranges(&self) -> &[ParamRange] {
+        &self.ranges
+    }
+
+    /// Push a worker update: epoch check → structural validation → range
+    /// registration → step-clock sequence → SSP admission → buffer
+    /// (cap/dedup) → clock advance → acceptance record (ADR-0004).
+    pub fn push(&mut self, update: ParamUpdate) -> Result<AcceptanceRecord, PsError> {
+        if update.epoch != self.epoch {
+            return Err(if update.epoch < self.epoch {
+                PsError::EpochClosed {
+                    epoch: update.epoch,
+                }
+            } else {
+                PsError::EpochMismatch {
+                    expected: self.epoch,
+                    got: update.epoch,
+                }
+            });
+        }
+        update.validate()?;
+        // Range admission: only exactly-registered assignment ranges. This is
+        // what bounds buffer memory and rules out overlap double-apply —
+        // workers must not choose their own (sub-)ranges (ADR-0003).
+        if self.ranges.binary_search(&update.range).is_err() {
+            return Err(PsError::InvalidRange(format!(
+                "update range {} is not a registered assignment range \
+                 (ADR-0003: pushes are admitted only for assignment-layer ranges)",
+                update.range
+            )));
+        }
+        // Step-clock sequence (ADR-0006): exactly one step per accepted push.
+        // First push from an unseen worker carries clock 0; each subsequent
+        // accepted push carries prev + 1. This bounds fastest_clock growth to
+        // accepted (metered, audit-eligible) work, and subsumes both the
+        // regression check and (worker, clock) duplicates at the service
+        // level.
+        let expected = self.clock.worker_clock(update.worker).map_or(0, |c| c + 1);
+        if update.clock != expected {
+            return Err(PsError::InvalidUpdate(format!(
+                "clock step violation for worker {}: expected {}, got {} \
+                 (clocks advance exactly one per accepted push, ADR-0006)",
+                update.worker, expected, update.clock
+            )));
+        }
+        self.clock.admit(update.clock)?;
+        let record = AcceptanceRecord::for_update(&update);
+        let (worker, clock) = (update.worker, update.clock);
+        self.buffer.add(update)?;
+        self.clock.advance(worker, clock)?;
+        debug!(%worker, clock, epoch = self.epoch, "accepted push");
+        self.accepted.push(record.clone());
+        Ok(record)
+    }
+
+    /// Current shard parameters for any sub-range of the owned range.
+    pub fn pull(&self, range: ParamRange) -> Result<Vec<f32>, PsError> {
+        self.store.get_range(range)
+    }
+
+    /// The epoch barrier (ADR-0006) with the production rule:
+    /// `TrimmedMean` at the configured `trim_beta` (ADR-0003).
+    pub fn end_epoch(&mut self) -> Result<EpochOutcome, PsError> {
+        let rule = TrimmedMean::new(self.config.trim_beta)?;
+        self.end_epoch_with_rule(&rule)
+    }
+
+    /// The epoch barrier (ADR-0006) with an explicit rule — for tests and
+    /// trusted-cluster experiments; production uses [`Self::end_epoch`].
+    ///
+    /// For each buffered range: ranges with fewer than `rule.min_updates()`
+    /// updates are skipped with a warning — a deterministic no-op for that
+    /// range this epoch. Thin participation is an assignment-layer shortfall,
+    /// not worker misbehavior, so the workers' acceptance records are KEPT
+    /// (the work was done and assigned — ADR-0004); only the buffered deltas
+    /// drop at clear. Ranges at or above the minimum aggregate (updates
+    /// pre-sorted by worker for determinism) and any aggregation error still
+    /// propagates — that is a real bug, not thin participation. Then: clear
+    /// buffer, barrier the clock, open the next epoch.
+    pub fn end_epoch_with_rule(
+        &mut self,
+        rule: &dyn AggregationRule,
+    ) -> Result<EpochOutcome, PsError> {
+        let closed = self.epoch;
+        for range in self.buffer.ranges() {
+            let updates = self.buffer.updates_for(&range);
+            if updates.len() < rule.min_updates() {
+                warn!(
+                    %range,
+                    count = updates.len(),
+                    min = rule.min_updates(),
+                    epoch = closed,
+                    "thin range: below rule minimum, skipping aggregation \
+                     (no delta this epoch; acceptance records kept)"
+                );
+                continue;
+            }
+            let delta = rule.aggregate(&updates, &range)?;
+            self.store.apply_delta(range, &delta)?;
+        }
+        self.buffer.clear();
+        let _final_clocks = self.clock.barrier();
+        self.epoch += 1;
+        let accepted = std::mem::take(&mut self.accepted);
+        let params_hash = self.store.params_hash()?;
+        info!(
+            epoch = closed,
+            accepted = accepted.len(),
+            params_hash = %params_hash,
+            "epoch barrier complete"
+        );
+        Ok(EpochOutcome {
+            epoch: closed,
+            params_hash,
+            accepted,
+        })
+    }
+
+    /// Protocol constants this service runs with.
+    pub fn config(&self) -> &PsConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::StepClock;
+    use qfc_types::Address;
+
+    /// Test-only rule: coordinate-wise sum. NOT byzantine-robust — exists so
+    /// A1 service tests do not depend on `TrimmedMean` (implemented in A2).
+    struct SumRule;
+
+    impl AggregationRule for SumRule {
+        fn aggregate(
+            &self,
+            updates: &[&ParamUpdate],
+            range: &ParamRange,
+        ) -> Result<Vec<f32>, PsError> {
+            let mut out = vec![0.0f32; range.len() as usize];
+            for u in updates {
+                for (slot, v) in out.iter_mut().zip(&u.values) {
+                    *slot += v;
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    fn addr(b: u8) -> Address {
+        Address::new([b; 20])
+    }
+
+    fn range(start: u64, end: u64) -> ParamRange {
+        ParamRange::new(start, end).unwrap()
+    }
+
+    fn update(worker: u8, epoch: Epoch, clock: StepClock, r: ParamRange, val: f32) -> ParamUpdate {
+        ParamUpdate {
+            worker: addr(worker),
+            epoch,
+            clock,
+            range: r,
+            values: vec![val; r.len() as usize],
+            flops_estimated: 1000,
+        }
+    }
+
+    /// Service over `owned` with an explicit registered-range set.
+    fn service_with(owned: ParamRange, epoch: Epoch, ranges: Vec<ParamRange>) -> ShardService {
+        let store = ShardStore::open_temp(owned).unwrap();
+        ShardService::new(store, PsConfig::default(), epoch, ranges).unwrap()
+    }
+
+    /// Service over [0, 100) with the registered partition used by most
+    /// tests: [0, 10), [10, 20), [50, 60).
+    fn service(epoch: Epoch) -> ShardService {
+        service_with(
+            range(0, 100),
+            epoch,
+            vec![range(0, 10), range(10, 20), range(50, 60)],
+        )
+    }
+
+    #[test]
+    fn test_new_rejects_bad_registered_range_sets() {
+        let owned = range(0, 100);
+        // Empty set.
+        let store = ShardStore::open_temp(owned).unwrap();
+        assert!(matches!(
+            ShardService::new(store, PsConfig::default(), 0, vec![]),
+            Err(PsError::InvalidRange(_))
+        ));
+        // Overlapping ranges.
+        let store = ShardStore::open_temp(owned).unwrap();
+        assert!(matches!(
+            ShardService::new(
+                store,
+                PsConfig::default(),
+                0,
+                vec![range(0, 10), range(5, 15)]
+            ),
+            Err(PsError::InvalidRange(_))
+        ));
+        // Range outside the owned range.
+        let store = ShardStore::open_temp(owned).unwrap();
+        assert!(matches!(
+            ShardService::new(
+                store,
+                PsConfig::default(),
+                0,
+                vec![range(0, 10), range(90, 110)]
+            ),
+            Err(PsError::InvalidRange(_))
+        ));
+        // A valid partition is accepted and reported sorted.
+        let store = ShardStore::open_temp(owned).unwrap();
+        let svc = ShardService::new(
+            store,
+            PsConfig::default(),
+            0,
+            vec![range(50, 100), range(0, 50)],
+        )
+        .unwrap();
+        assert_eq!(svc.registered_ranges(), &[range(0, 50), range(50, 100)]);
+    }
+
+    #[test]
+    fn test_push_happy_path_returns_record() {
+        let mut svc = service(0);
+        let u = update(1, 0, 0, range(10, 20), 1.0);
+        let record = svc.push(u.clone()).unwrap();
+        assert_eq!(record, AcceptanceRecord::for_update(&u));
+        assert_eq!(record.worker, addr(1));
+        assert_eq!(record.epoch, 0);
+        assert_eq!(record.range, range(10, 20));
+    }
+
+    #[test]
+    fn test_epoch_mismatch_and_closed_rejection() {
+        let mut svc = service(5);
+        // Future epoch: mismatch.
+        assert!(matches!(
+            svc.push(update(1, 6, 0, range(0, 10), 1.0)),
+            Err(PsError::EpochMismatch {
+                expected: 5,
+                got: 6
+            })
+        ));
+        // Past epoch: closed.
+        assert!(matches!(
+            svc.push(update(1, 4, 0, range(0, 10), 1.0)),
+            Err(PsError::EpochClosed { epoch: 4 })
+        ));
+    }
+
+    /// Range admission (post-review hardening): a push is accepted only for
+    /// EXACTLY a registered assignment range — unregistered ranges,
+    /// attacker-chosen sub-ranges of a registered range, and ranges that
+    /// straddle two registered ranges are all refused. This is what bounds
+    /// buffer memory (workers cannot mint fresh buffer keys) and rules out
+    /// overlap double-apply.
+    #[test]
+    fn test_push_unregistered_sub_or_overlapping_range_rejected() {
+        let mut svc = service(0);
+        for bad in [
+            range(20, 30),  // inside owned, but not registered
+            range(12, 18),  // strict sub-range of registered [10, 20)
+            range(10, 15),  // shares a start with registered [10, 20)
+            range(5, 15),   // straddles [0, 10) and [10, 20)
+            range(90, 110), // outside the owned range entirely
+        ] {
+            match svc.push(update(1, 0, 0, bad, 1.0)) {
+                Err(PsError::InvalidRange(msg)) => {
+                    assert!(
+                        msg.contains(&bad.to_string()),
+                        "message must name the range: {}",
+                        msg
+                    );
+                    assert!(
+                        msg.contains("not a registered assignment range"),
+                        "message must say why: {}",
+                        msg
+                    );
+                }
+                other => panic!("expected InvalidRange for {}, got {:?}", bad, other),
+            }
+        }
+        // Nothing was buffered or recorded.
+        assert!(svc.end_epoch().unwrap().accepted.is_empty());
+    }
+
+    /// Step-clock sequence (post-review hardening, ADR-0006): the first push
+    /// from a worker must carry clock 0; every subsequent accepted push
+    /// exactly prev + 1. Jumps cannot ratchet the admission floor for free.
+    #[test]
+    fn test_clock_jump_rejected_in_order_accepted() {
+        let mut svc = service(0);
+        let r = range(0, 10);
+        // First push must be clock 0.
+        match svc.push(update(1, 0, 5, r, 1.0)) {
+            Err(PsError::InvalidUpdate(msg)) => {
+                assert!(msg.contains("expected 0"), "{}", msg);
+                assert!(msg.contains("got 5"), "{}", msg);
+            }
+            other => panic!("expected InvalidUpdate, got {:?}", other),
+        }
+        // In-order 0, 1, 2: accepted.
+        svc.push(update(1, 0, 0, r, 1.0)).unwrap();
+        svc.push(update(1, 0, 1, r, 1.0)).unwrap();
+        svc.push(update(1, 0, 2, r, 1.0)).unwrap();
+        // Jump after progress (2 -> 5): rejected, clock unchanged.
+        match svc.push(update(1, 0, 5, r, 1.0)) {
+            Err(PsError::InvalidUpdate(msg)) => {
+                assert!(msg.contains("expected 3"), "{}", msg);
+                assert!(msg.contains("got 5"), "{}", msg);
+            }
+            other => panic!("expected InvalidUpdate, got {:?}", other),
+        }
+        svc.push(update(1, 0, 3, r, 1.0)).unwrap();
+    }
+
+    /// Duplicate (worker, clock) is rejected at the step check — replaying
+    /// an already-accepted clock can never earn a second acceptance record.
+    #[test]
+    fn test_duplicate_worker_clock_rejected() {
+        let mut svc = service(0);
+        let r = range(0, 10);
+        svc.push(update(1, 0, 0, r, 1.0)).unwrap();
+        assert!(matches!(
+            svc.push(update(1, 0, 0, r, 2.0)),
+            Err(PsError::InvalidUpdate(_))
+        ));
+        // Same clock on a different registered range is still a replay.
+        assert!(matches!(
+            svc.push(update(1, 0, 0, range(10, 20), 2.0)),
+            Err(PsError::InvalidUpdate(_))
+        ));
+        let outcome = svc.end_epoch().unwrap();
+        assert_eq!(outcome.accepted.len(), 1);
+    }
+
+    #[test]
+    fn test_stale_push_rejected_after_fast_worker_advances() {
+        let mut svc = service(0);
+        let r = range(0, 10);
+        // Fast worker 9 reaches clock 10 the only way possible: 11 accepted
+        // pushes (clocks 0..=10). Staleness bound is 3 → admission floor 7.
+        for c in 0..=10 {
+            svc.push(update(9, 0, c, r, 0.0)).unwrap();
+        }
+        // Worker 1's first push must carry clock 0, which is below the floor:
+        // refused as stale (an error, never a slash — ADR-0006).
+        assert!(matches!(
+            svc.push(update(1, 0, 0, range(10, 20), 1.0)),
+            Err(PsError::StaleUpdate {
+                worker_clock: 0,
+                floor: 7,
+                bound: 3
+            })
+        ));
+    }
+
+    #[test]
+    fn test_pull_sub_range() {
+        let owned = range(0, 100);
+        let store = ShardStore::open_temp(owned).unwrap();
+        store
+            .set_range(owned, &(0..100).map(|i| i as f32).collect::<Vec<_>>())
+            .unwrap();
+        let svc = ShardService::new(store, PsConfig::default(), 0, vec![owned]).unwrap();
+
+        assert_eq!(
+            svc.pull(range(40, 44)).unwrap(),
+            vec![40.0, 41.0, 42.0, 43.0]
+        );
+        assert!(matches!(
+            svc.pull(range(90, 101)),
+            Err(PsError::InvalidRange(_))
+        ));
+    }
+
+    #[test]
+    fn test_full_epoch_cycle_and_second_epoch() {
+        let mut svc = service(0);
+        let r = range(10, 20);
+
+        // Two workers push deltas on the same range, one on another range.
+        // Each worker's first push carries clock 0 (step semantics).
+        svc.push(update(1, 0, 0, r, 1.0)).unwrap();
+        svc.push(update(2, 0, 0, r, 2.5)).unwrap();
+        svc.push(update(3, 0, 0, range(50, 60), -1.0)).unwrap();
+
+        let outcome = svc.end_epoch_with_rule(&SumRule).unwrap();
+        assert_eq!(outcome.epoch, 0);
+        assert_eq!(outcome.accepted.len(), 3);
+        assert_eq!(outcome.params_hash, svc.store().params_hash().unwrap());
+        assert_eq!(svc.epoch(), 1);
+
+        // Deltas applied coordinate-wise: 1.0 + 2.5 on [10,20), -1.0 on [50,60).
+        assert_eq!(svc.pull(r).unwrap(), vec![3.5; 10]);
+        assert_eq!(svc.pull(range(50, 60)).unwrap(), vec![-1.0; 10]);
+        assert_eq!(svc.pull(range(0, 10)).unwrap(), vec![0.0; 10]);
+
+        // Old epoch is closed; new epoch accepts (clocks were barrier-reset,
+        // so worker 1 starts again at clock 0).
+        assert!(matches!(
+            svc.push(update(1, 0, 5, r, 1.0)),
+            Err(PsError::EpochClosed { epoch: 0 })
+        ));
+        svc.push(update(1, 1, 0, r, 0.5)).unwrap();
+        let outcome2 = svc.end_epoch_with_rule(&SumRule).unwrap();
+        assert_eq!(outcome2.epoch, 1);
+        assert_eq!(outcome2.accepted.len(), 1);
+        assert_ne!(outcome2.params_hash, outcome.params_hash);
+        assert_eq!(svc.pull(r).unwrap(), vec![4.0; 10]);
+        assert_eq!(svc.epoch(), 2);
+    }
+
+    /// The production barrier: `end_epoch()` aggregates with `TrimmedMean`
+    /// at the configured `trim_beta`. Three updates on one range with
+    /// beta = 0.2 trim one per side, so the extreme is dropped and the
+    /// median's value lands in the parameters.
+    #[test]
+    fn test_end_epoch_default_rule_is_trimmed_mean() {
+        let mut svc = service(0);
+        let r = range(10, 20);
+        svc.push(update(1, 0, 0, r, 1.0)).unwrap();
+        svc.push(update(2, 0, 0, r, 2.0)).unwrap();
+        svc.push(update(3, 0, 0, r, 1000.0)).unwrap(); // outlier, trimmed
+        let outcome = svc.end_epoch().unwrap();
+        assert_eq!(outcome.accepted.len(), 3);
+        // n = 3, beta = 0.2 → trim ceil(0.6) = 1 per side, keep the median.
+        assert_eq!(svc.pull(r).unwrap(), vec![2.0; 10]);
+    }
+
+    /// Thin range (post-review hardening): a range with fewer updates than
+    /// the rule's minimum must NOT abort the barrier — it is skipped (no
+    /// delta this epoch), while other ranges aggregate and the thin range's
+    /// acceptance records are kept (the work was assigned and done,
+    /// ADR-0004; thin participation is not the worker's fault).
+    #[test]
+    fn test_thin_range_skipped_not_fatal() {
+        let mut svc = service(0);
+        let healthy = range(10, 20);
+        let thin = range(50, 60);
+        // Healthy range: 3 updates (>= TrimmedMean(0.2).min_updates() = 3).
+        svc.push(update(1, 0, 0, healthy, 1.0)).unwrap();
+        svc.push(update(2, 0, 0, healthy, 2.0)).unwrap();
+        svc.push(update(3, 0, 0, healthy, 3.0)).unwrap();
+        // Thin range: a single update — would make TrimmedMean error.
+        svc.push(update(4, 0, 0, thin, 7.0)).unwrap();
+
+        let outcome = svc.end_epoch().unwrap();
+        // All four acceptance records survive, including the thin range's.
+        assert_eq!(outcome.accepted.len(), 4);
+        assert!(outcome
+            .accepted
+            .iter()
+            .any(|rec| rec.worker == addr(4) && rec.range == thin));
+        // Healthy range aggregated (trim 1.0 and 3.0, keep 2.0); thin range
+        // untouched (deterministic no-op).
+        assert_eq!(svc.pull(healthy).unwrap(), vec![2.0; 10]);
+        assert_eq!(svc.pull(thin).unwrap(), vec![0.0; 10]);
+        // The buffered thin update dropped at the barrier: epoch 1 starts
+        // clean and a fresh end_epoch is a pure no-op.
+        let outcome2 = svc.end_epoch().unwrap();
+        assert!(outcome2.accepted.is_empty());
+        assert_eq!(outcome2.params_hash, outcome.params_hash);
+    }
+
+    /// The step clock is per worker, not per (worker, range): one worker
+    /// covering several registered ranges spends one clock step per push,
+    /// in sequence across ranges.
+    #[test]
+    fn test_one_worker_multiple_ranges_sequential_clocks() {
+        let mut svc = service(0);
+        svc.push(update(1, 0, 0, range(0, 10), 1.0)).unwrap();
+        svc.push(update(1, 0, 1, range(10, 20), 2.0)).unwrap();
+        svc.push(update(1, 0, 2, range(50, 60), 3.0)).unwrap();
+        // Reusing clock 2 on yet another range is a replay.
+        assert!(matches!(
+            svc.push(update(1, 0, 2, range(0, 10), 4.0)),
+            Err(PsError::InvalidUpdate(_))
+        ));
+        assert_eq!(svc.end_epoch().unwrap().accepted.len(), 3);
+    }
+
+    #[test]
+    fn test_records_survive_buffer_clear_and_reset_per_epoch() {
+        let mut svc = service(0);
+        svc.push(update(1, 0, 0, range(0, 10), 1.0)).unwrap();
+        let outcome = svc.end_epoch_with_rule(&SumRule).unwrap();
+        assert_eq!(outcome.accepted.len(), 1);
+
+        // Next epoch starts with an empty record set.
+        let outcome2 = svc.end_epoch_with_rule(&SumRule).unwrap();
+        assert_eq!(outcome2.epoch, 1);
+        assert!(outcome2.accepted.is_empty());
+    }
+}

--- a/crates/qfc-ps/src/service.rs
+++ b/crates/qfc-ps/src/service.rs
@@ -1,0 +1,28 @@
+//! Shard service: push/pull + epoch barrier, tying together kv / clock /
+//! aggregate (the component a PS operator runs, ADR-0002).
+//!
+//! Implemented in milestone A1. Required API:
+//!
+//! - `ShardService::new(store: ShardStore, config: PsConfig, epoch: Epoch)`.
+//! - `push(&mut self, update: ParamUpdate) -> Result<AcceptanceRecord, PsError>`
+//!   — validates epoch match + structure, SSP admission via `SspClock`,
+//!   buffers via `UpdateBuffer` (worker cap), records acceptance (ADR-0004).
+//!   Rejected-as-stale is an error, not a slash (ADR-0006).
+//! - `pull(&self, range: ParamRange) -> Result<Vec<f32>, PsError>` — current
+//!   shard parameters for any sub-range of the owned range.
+//! - `advance_clock(&mut self, worker, clock)` — worker step report.
+//! - `end_epoch(&mut self, rule: &dyn AggregationRule)
+//!      -> Result<EpochOutcome, PsError>` — the barrier (ADR-0006): for each
+//!   buffered range, aggregate (updates sorted by worker for determinism),
+//!   `apply_delta`, then clear buffer, bump epoch, and return
+//!   `EpochOutcome { epoch, params_hash, accepted: Vec<AcceptanceRecord> }`
+//!   — the inputs of the on-chain version commit (A5).
+//! - Pushes for a closed/mismatched epoch → `PsError::EpochClosed` /
+//!   `EpochMismatch`.
+
+#[allow(unused_imports)]
+use crate::{
+    aggregate::{AggregationRule, UpdateBuffer},
+    types::{AcceptanceRecord, Epoch, ParamRange, ParamUpdate},
+    PsConfig, PsError,
+};

--- a/crates/qfc-ps/src/types.rs
+++ b/crates/qfc-ps/src/types.rs
@@ -1,0 +1,220 @@
+//! Core parameter-server types.
+//!
+//! Keys are dense parameter indices (u64); a shard owns a contiguous
+//! `ParamRange` (ps-lite-style range sharding — dense tensors have key
+//! locality, unlike hashed sparse-embedding IDs; see ADR-0001 discussion
+//! and ROADMAP-AI-V3 Feature A).
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use qfc_types::{Address, Hash};
+use serde::{Deserialize, Serialize};
+
+use crate::PsError;
+
+/// Training-epoch identifier. Opaque to this crate — the coordinator owns
+/// epoch progression (ADR-0006: no dependency on qfc-consensus).
+pub type Epoch = u64;
+
+/// A worker's logical clock = its step count within the current epoch (SSP).
+pub type StepClock = u64;
+
+/// Contiguous parameter key range `[start, end)`.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    std::hash::Hash,
+    BorshSerialize,
+    BorshDeserialize,
+    Serialize,
+    Deserialize,
+)]
+pub struct ParamRange {
+    pub start: u64,
+    pub end: u64,
+}
+
+impl ParamRange {
+    pub fn new(start: u64, end: u64) -> Result<Self, PsError> {
+        if start >= end {
+            return Err(PsError::InvalidRange(format!(
+                "start {} >= end {}",
+                start, end
+            )));
+        }
+        Ok(Self { start, end })
+    }
+
+    pub fn len(&self) -> u64 {
+        self.end - self.start
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.start >= self.end
+    }
+
+    pub fn contains(&self, key: u64) -> bool {
+        key >= self.start && key < self.end
+    }
+
+    /// True if `other` lies entirely within this range.
+    pub fn covers(&self, other: &ParamRange) -> bool {
+        other.start >= self.start && other.end <= self.end
+    }
+
+    pub fn overlaps(&self, other: &ParamRange) -> bool {
+        self.start < other.end && other.start < self.end
+    }
+}
+
+impl std::fmt::Display for ParamRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}, {})", self.start, self.end)
+    }
+}
+
+/// A gradient/delta update pushed by a training worker for one range.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ParamUpdate {
+    pub worker: Address,
+    pub epoch: Epoch,
+    /// Worker's SSP clock at the step that produced this update
+    pub clock: StepClock,
+    pub range: ParamRange,
+    /// Delta values for `[range.start, range.end)`, in key order
+    pub values: Vec<f32>,
+    /// Metering claim (ADR-0004), audited by sampled re-execution (ADR-0005)
+    pub flops_estimated: u64,
+}
+
+impl ParamUpdate {
+    /// Structural validity: value count matches the range, all values finite.
+    pub fn validate(&self) -> Result<(), PsError> {
+        if self.range.is_empty() {
+            return Err(PsError::InvalidRange(format!("empty range {}", self.range)));
+        }
+        if self.values.len() as u64 != self.range.len() {
+            return Err(PsError::InvalidUpdate(format!(
+                "value count {} != range length {} for {}",
+                self.values.len(),
+                self.range.len(),
+                self.range
+            )));
+        }
+        if !self.values.iter().all(|v| v.is_finite()) {
+            return Err(PsError::InvalidUpdate(
+                "non-finite value in update".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Blake3 over a canonical encoding — this is the `update_hash` that
+    /// acceptance records carry and that verifiers recompute (ADR-0005).
+    pub fn update_hash(&self) -> Hash {
+        let mut bytes = Vec::with_capacity(20 + 8 * 4 + self.values.len() * 4);
+        bytes.extend_from_slice(self.worker.as_bytes());
+        bytes.extend_from_slice(&self.epoch.to_be_bytes());
+        bytes.extend_from_slice(&self.clock.to_be_bytes());
+        bytes.extend_from_slice(&self.range.start.to_be_bytes());
+        bytes.extend_from_slice(&self.range.end.to_be_bytes());
+        for v in &self.values {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        bytes.extend_from_slice(&self.flops_estimated.to_be_bytes());
+        qfc_crypto::blake3_hash(&bytes)
+    }
+}
+
+/// Per-epoch acceptance record (ADR-0004) — the unit reward distribution
+/// reads. A5 anchors the epoch's record-set hash on-chain.
+#[derive(
+    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct AcceptanceRecord {
+    pub worker: Address,
+    pub epoch: Epoch,
+    pub clock: StepClock,
+    pub range: ParamRange,
+    pub update_hash: Hash,
+    pub flops_estimated: u64,
+}
+
+impl AcceptanceRecord {
+    pub fn for_update(update: &ParamUpdate) -> Self {
+        Self {
+            worker: update.worker,
+            epoch: update.epoch,
+            clock: update.clock,
+            range: update.range,
+            update_hash: update.update_hash(),
+            flops_estimated: update.flops_estimated,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(b: u8) -> Address {
+        Address::new([b; 20])
+    }
+
+    fn update(worker: u8, range: ParamRange, values: Vec<f32>) -> ParamUpdate {
+        ParamUpdate {
+            worker: addr(worker),
+            epoch: 1,
+            clock: 0,
+            range,
+            values,
+            flops_estimated: 1000,
+        }
+    }
+
+    #[test]
+    fn test_range_basics() {
+        assert!(ParamRange::new(5, 5).is_err());
+        assert!(ParamRange::new(6, 5).is_err());
+        let r = ParamRange::new(10, 20).unwrap();
+        assert_eq!(r.len(), 10);
+        assert!(r.contains(10) && r.contains(19) && !r.contains(20));
+        let inner = ParamRange::new(12, 18).unwrap();
+        assert!(r.covers(&inner) && !inner.covers(&r));
+        let disjoint = ParamRange::new(20, 30).unwrap();
+        assert!(!r.overlaps(&disjoint));
+        assert!(r.overlaps(&ParamRange::new(19, 25).unwrap()));
+    }
+
+    #[test]
+    fn test_update_validation() {
+        let r = ParamRange::new(0, 4).unwrap();
+        assert!(update(1, r, vec![1.0; 4]).validate().is_ok());
+        assert!(update(1, r, vec![1.0; 3]).validate().is_err());
+        assert!(update(1, r, vec![1.0, 2.0, f32::NAN, 4.0]).validate().is_err());
+        assert!(update(1, r, vec![1.0, 2.0, f32::INFINITY, 4.0])
+            .validate()
+            .is_err());
+    }
+
+    #[test]
+    fn test_update_hash_sensitivity() {
+        let r = ParamRange::new(0, 2).unwrap();
+        let base = update(1, r, vec![1.0, 2.0]);
+        assert_eq!(base.update_hash(), base.update_hash());
+        let mut other = base.clone();
+        other.values[1] = 2.0001;
+        assert_ne!(base.update_hash(), other.update_hash());
+        let mut other = base.clone();
+        other.clock = 1;
+        assert_ne!(base.update_hash(), other.update_hash());
+        assert_ne!(
+            base.update_hash(),
+            update(2, r, vec![1.0, 2.0]).update_hash()
+        );
+    }
+}

--- a/crates/qfc-ps/src/types.rs
+++ b/crates/qfc-ps/src/types.rs
@@ -132,9 +132,7 @@ impl ParamUpdate {
 
 /// Per-epoch acceptance record (ADR-0004) — the unit reward distribution
 /// reads. A5 anchors the epoch's record-set hash on-chain.
-#[derive(
-    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct AcceptanceRecord {
     pub worker: Address,
     pub epoch: Epoch,
@@ -195,7 +193,9 @@ mod tests {
         let r = ParamRange::new(0, 4).unwrap();
         assert!(update(1, r, vec![1.0; 4]).validate().is_ok());
         assert!(update(1, r, vec![1.0; 3]).validate().is_err());
-        assert!(update(1, r, vec![1.0, 2.0, f32::NAN, 4.0]).validate().is_err());
+        assert!(update(1, r, vec![1.0, 2.0, f32::NAN, 4.0])
+            .validate()
+            .is_err());
         assert!(update(1, r, vec![1.0, 2.0, f32::INFINITY, 4.0])
             .validate()
             .is_err());

--- a/docs/adr/0002-ps-operator-role.md
+++ b/docs/adr/0002-ps-operator-role.md
@@ -1,0 +1,34 @@
+# ADR-0002: Who runs parameter-server shards
+
+**Status:** accepted · **Date:** 2026-06-12 · **Context:** ROADMAP-AI-V3 Feature A, decision 1.
+
+## Decision
+
+PS shards are run by **staked PS operators — a new, distinct role**, not by
+validators. Operators stake QFC, are assigned contiguous parameter ranges per
+training epoch (same epoch machinery validators use), and are slashable for:
+unavailability during an epoch they accepted, serving parameters that fail
+hash audit, and failing the data-pinning duty of ADR-0007.
+
+## Why not validators-double-as-operators
+
+- **Failure domains stay decoupled.** A PS shard saturating disk/network must
+  not degrade block production. (The 2026-05 VPS incidents are exactly this
+  class of coupling.)
+- **Hardware profiles differ.** Validators need low-latency consensus I/O;
+  PS shards need RAM + disk bandwidth. Separate roles let the market provision
+  each.
+- **Consensus stays clean.** PS state is relaxed-consistency by design
+  (ADR-0006) and must never be re-derivable consensus state. A separate role
+  makes the boundary structural, not conventional.
+
+Operationally, one machine MAY run both binaries on testnet (A6 pilot does);
+the protocol roles, stakes, and slash conditions remain separate.
+
+## Consequences
+
+- New on-chain role registry (stake, shard-range acceptance, liveness
+  heartbeats) lands in A5; `qfc-ps` (A1) is role-agnostic — it implements the
+  shard service an operator runs.
+- ≥2 operators per shard range (primary + replica) from day one; a single
+  operator is never trusted (roadmap non-goal #3).

--- a/docs/adr/0003-aggregation-rule.md
+++ b/docs/adr/0003-aggregation-rule.md
@@ -16,8 +16,11 @@ re-evaluate after A6 pilot data.
 
 ## Robustness bound and its preconditions
 
-Trimmed mean tolerates `f < β·n` malicious updates per shard. Two
-preconditions, without which the bound is meaningless:
+Trimmed mean tolerates `f < β·n` malicious updates per shard — and with
+ceil-trimming (`⌈β·n⌉` dropped per side, as implemented) the guarantee is in
+fact `f ≤ ⌈β·n⌉`: exactly-at-threshold attackers are always fully trimmed,
+and the empirical cliff sits at `f = ⌈β·n⌉ + 1` (demonstrated by the A2
+property tests). Two preconditions, without which the bound is meaningless:
 
 1. **Sybil resistance comes from stake, not the rule.** Updates count toward
    `n` only from miners holding the minimum training stake for the epoch's
@@ -25,9 +28,12 @@ preconditions, without which the bound is meaningless:
    must not be free.
 2. **Per-coordinate trimming needs all updates materialized.** Unlike a
    BytePS-style summation service (streaming, O(1) per update), trimmed mean
-   costs **O(n × shard_size) memory at the aggregation point**. This caps
-   workers-per-shard: `max_workers = mem_budget / shard_size_bytes`. The cap
-   is enforced at assignment (A3), and the constant lives in `qfc-ps` config.
+   costs **O(n × shard_size) memory at the aggregation point**. Pushes are
+   admitted only for registered assignment ranges (disjoint, fixed per
+   epoch), so workers cannot mint buffer keys and buffer memory is bounded
+   by `cap × owned-range size`, with `cap = max_workers_per_range =
+   mem_budget / shard_size_bytes`. The cap is enforced at push (and mirrored
+   at assignment, A3), and the constant lives in `qfc-ps` config.
 
 ## Consequences
 

--- a/docs/adr/0003-aggregation-rule.md
+++ b/docs/adr/0003-aggregation-rule.md
@@ -1,0 +1,42 @@
+# ADR-0003: Byzantine-robust aggregation rule
+
+**Status:** accepted · **Date:** 2026-06-12 · **Context:** ROADMAP-AI-V3 Feature A, decision 2.
+
+## Decision
+
+Aggregation is **coordinate-wise trimmed mean** with trim fraction
+`β = 0.2` per side (configurable per model). For each parameter coordinate,
+sort the per-worker update values, drop the top and bottom `⌈β·n⌉`, average
+the rest. Plain FedAvg is rejected permanently (roadmap non-goal #2): one
+malicious worker can move an averaged coordinate arbitrarily.
+
+Krum/Bulyan are deferred: they need O(n²) pairwise distances over full update
+vectors, and their advantage matters most for high-dimensional collusion —
+re-evaluate after A6 pilot data.
+
+## Robustness bound and its preconditions
+
+Trimmed mean tolerates `f < β·n` malicious updates per shard. Two
+preconditions, without which the bound is meaningless:
+
+1. **Sybil resistance comes from stake, not the rule.** Updates count toward
+   `n` only from miners holding the minimum training stake for the epoch's
+   job. The rule bounds what a *stake-bounded* minority can do; identities
+   must not be free.
+2. **Per-coordinate trimming needs all updates materialized.** Unlike a
+   BytePS-style summation service (streaming, O(1) per update), trimmed mean
+   costs **O(n × shard_size) memory at the aggregation point**. This caps
+   workers-per-shard: `max_workers = mem_budget / shard_size_bytes`. The cap
+   is enforced at assignment (A3), and the constant lives in `qfc-ps` config.
+
+## Consequences
+
+- `qfc-ps` aggregation buffers updates per epoch window and aggregates at the
+  SSP barrier (ADR-0006); update values are f32, aggregation accumulates in
+  f64 for determinism-friendly summation order (sorted by worker address).
+- Property tests (A2) must demonstrate: bound holds at `f < β·n` with extreme
+  adversarial values; bound *breaks* at `f ≥ β·n` (test documents the cliff,
+  so the assignment cap is load-bearing and visible).
+- Being trimmed is NOT evidence of malice (honest outliers exist); trimming
+  never triggers slashing by itself. Slashing requires failed re-execution
+  (ADR-0005).

--- a/docs/adr/0004-contribution-metering.md
+++ b/docs/adr/0004-contribution-metering.md
@@ -1,0 +1,35 @@
+# ADR-0004: Training contribution metering & rewards
+
+**Status:** accepted · **Date:** 2026-06-12 · **Context:** ROADMAP-AI-V3 Feature A, decision 3.
+
+## Decision
+
+Reward **per accepted update**, where accepted means: (a) submitted within
+the epoch's staleness bound (ADR-0006), (b) well-formed for the assigned
+(range, data-shard, step) tuple, and (c) **not failed** by sampled
+re-execution (ADR-0005). Claimed-but-unverified work earns the same as
+verified work — verification is a random audit, not a payment gate; this is
+exactly the v2.x inference model (`flops_estimated` + 5% spot-check)
+generalized to training steps.
+
+Metering unit: `flops_estimated` computed from the task descriptor
+(model params × tokens per step × steps), same estimator family as
+`task_types.rs::task_requirements`. The per-epoch training reward pool is
+split pro-rata over accepted updates' estimated FLOPs.
+
+## Explicitly rejected
+
+- **Reward-if-aggregated** (paying only untrimmed updates): honest outliers
+  get trimmed (ADR-0003); tying pay to trimming punishes honest gradient
+  noise and incentivizes update-copying toward the median.
+- **Loss-improvement bounties** ("pay for AUC delta"): unattributable per
+  worker, gameable by withholding.
+
+## Consequences
+
+- `qfc-ps` records per-epoch `(worker, range, step, update_hash, flops_estimated)`
+  acceptance records; A5 anchors the epoch's record-set hash on-chain with the
+  version commit, which is what the reward distribution reads.
+- A failed re-execution retroactively voids the miner's acceptance records
+  for that epoch and triggers slashing (ADR-0005's ratio makes the audit
+  lottery unprofitable to cheat).

--- a/docs/adr/0004-contribution-metering.md
+++ b/docs/adr/0004-contribution-metering.md
@@ -6,8 +6,13 @@
 
 Reward **per accepted update**, where accepted means: (a) submitted within
 the epoch's staleness bound (ADR-0006), (b) well-formed for the assigned
-(range, data-shard, step) tuple, and (c) **not failed** by sampled
-re-execution (ADR-0005). Claimed-but-unverified work earns the same as
+(range, data-shard, step) tuple, (c) **not failed** by sampled
+re-execution (ADR-0005), and (d) the update's range is a registered
+assignment range (workers cannot earn records on self-chosen ranges).
+Updates on a range that fails min-participation at the barrier (too few
+updates for the aggregation rule, ADR-0003) still keep their acceptance
+records: the work was done and assigned; thin participation is an
+assignment-layer shortfall, not worker misbehavior. Claimed-but-unverified work earns the same as
 verified work — verification is a random audit, not a payment gate; this is
 exactly the v2.x inference model (`flops_estimated` + 5% spot-check)
 generalized to training steps.

--- a/docs/adr/0005-training-verification.md
+++ b/docs/adr/0005-training-verification.md
@@ -1,0 +1,41 @@
+# ADR-0005: Training-step verification
+
+**Status:** accepted · **Date:** 2026-06-12 · **Context:** ROADMAP-AI-V3 Feature A, decision 4.
+
+## Decision
+
+**Sampled re-execution**, generalizing the v2.x spot-check machinery
+(`verification.rs` / `redundant.rs` / `challenge.rs`). An update commits to
+the tuple `(param_version_hash, data_shard_cid, batch_indices, seed,
+update_hash)`. A verifier replays the training step from that tuple and
+compares.
+
+Two comparison modes, staged:
+
+1. **A6 pilot: exact match, CPU-only determinism.** Pilot training jobs run
+   `SafetensorsFp32` on CPU with pinned seeds and a fixed reduction order —
+   the same determinism class the inference spot-check already relies on
+   (`CanonicalFormat` exists precisely for this). Verifier checks
+   `blake3(update) == update_hash`.
+2. **GPU tolerance-band (A4b, after pilot).** GPU kernel nondeterminism makes
+   exact gradient equality unachievable across vendors — this is the hardest
+   open problem in the roadmap and we do not pretend otherwise. Fallback:
+   verifier computes the update independently and accepts if
+   `‖Δ_claimed − Δ_replayed‖∞ / scale < ε` per range, with ε calibrated on
+   pilot data. Tolerance bands weaken the slash guarantee (a cheater can move
+   ε-far); the calibration report is a gate for enabling GPU training jobs.
+
+Sampling rate starts at **5%** (matches `SPOT_CHECK_RATE`), adaptive per
+miner reputation later. Challenge-style traps (pre-computed steps with known
+updates, indistinguishable from real assignments) reuse `challenge.rs`'s
+pattern for cheap always-on coverage.
+
+## Consequences
+
+- Verification economics are a protocol parameter, not an afterthought —
+  see ADR-0008 for the slash/reward ratio that makes 5% sampling sufficient.
+- Re-executing a step costs ≈1× the original work; at 5% sampling the
+  network-wide verification overhead is ≈5% of training compute, paid from
+  the same epoch reward pool.
+- `qfc-ps` must serve historical `(version, range)` reads for the epoch
+  being audited (snapshot retention ≥ audit window, ADR-0007).

--- a/docs/adr/0006-sync-model.md
+++ b/docs/adr/0006-sync-model.md
@@ -1,0 +1,38 @@
+# ADR-0006: Synchronization model (SSP + epoch barrier)
+
+**Status:** accepted · **Date:** 2026-06-12 · **Context:** ROADMAP-AI-V3 Feature A, decision 5.
+
+## Decision
+
+**Stale-synchronous parallel (SSP) within an epoch, hard barrier at the
+epoch boundary.**
+
+- Each worker carries a logical clock = its step count within the epoch.
+  A pull at worker clock `c` may be served parameters that lack updates from
+  workers slower than `c − s` (staleness bound `s`, default 3 — ps-lite's
+  bounded-delay consistency, configurable per job).
+- A push older than the bound is rejected as stale (still eligible for
+  acceptance records if it was assigned work — see ADR-0004 — but it does not
+  enter aggregation).
+- At epoch end: stop accepting pushes, run the aggregation rule (ADR-0003)
+  over the epoch's buffered updates, apply to the parameter set, snapshot
+  (ADR-0007), and emit the new `(version, assembled_hash)` for the on-chain
+  commit (A5). Training for epoch N+1 pulls from the committed version N.
+
+Fully-async (no barrier) is rejected: without a barrier there is no
+well-defined version to commit on-chain, and the chain anchoring *is* the
+product. BSP (barrier every step) is rejected: WAN stragglers would set the
+pace for every step; SSP tolerates them inside the epoch.
+
+## Consequences
+
+- The on-chain consensus path never sees SSP state — it sees only the
+  epoch-end `(model_id, version, hash, CID)` commit, which is deterministic
+  given the accepted-update set. Roadmap non-goal #1 holds structurally.
+- Epoch length for training jobs is minutes-scale (not the 10s consensus
+  epoch); `qfc-ps` takes the training-epoch id as an opaque u64 from the
+  coordinator rather than reading qfc-consensus — no dependency coupling.
+- Dense models make delta-sync pointless (every epoch touches every weight),
+  so version publication is full-CID, reusing the B-1 shard manifest format
+  for distribution of the new version. (Monolith-style minute-level delta
+  sync is a sparse-table optimization that does not transfer here.)

--- a/docs/adr/0006-sync-model.md
+++ b/docs/adr/0006-sync-model.md
@@ -8,12 +8,17 @@
 epoch boundary.**
 
 - Each worker carries a logical clock = its step count within the epoch.
-  A pull at worker clock `c` may be served parameters that lack updates from
-  workers slower than `c − s` (staleness bound `s`, default 3 — ps-lite's
-  bounded-delay consistency, configurable per job).
-- A push older than the bound is rejected as stale (still eligible for
-  acceptance records if it was assigned work — see ADR-0004 — but it does not
-  enter aggregation).
+  Within an epoch, pulls serve the committed version-N parameters: in-flight
+  updates are buffered and never visible before the barrier, so reads are
+  version-consistent. The staleness bound `s` (default 3 — ps-lite's
+  bounded-delay knob, configurable per job) gates PUSH admission: how far
+  behind the fastest worker a step may be and still enter aggregation.
+- Clocks advance exactly one step per accepted push — there is no
+  out-of-band clock report — which bounds clock-ratchet DoS: ratcheting the
+  admission floor costs accepted, metered, audit-eligible work.
+- A push older than the bound is rejected as stale. Stale pushes earn NO
+  acceptance record and are NOT slashable; they are simply refused
+  (consistent with ADR-0004(a)) and do not enter aggregation.
 - At epoch end: stop accepting pushes, run the aggregation rule (ADR-0003)
   over the epoch's buffered updates, apply to the parameter set, snapshot
   (ADR-0007), and emit the new `(version, assembled_hash)` for the on-chain
@@ -29,6 +34,9 @@ pace for every step; SSP tolerates them inside the epoch.
 - The on-chain consensus path never sees SSP state — it sees only the
   epoch-end `(model_id, version, hash, CID)` commit, which is deterministic
   given the accepted-update set. Roadmap non-goal #1 holds structurally.
+- The barrier as implemented is per-operator; cross-operator agreement on
+  the accepted-update set (and hence identical `params_hash` across the ≥2
+  operators of a range) is the A5 chain-integration deliverable.
 - Epoch length for training jobs is minutes-scale (not the 10s consensus
   epoch); `qfc-ps` takes the training-epoch id as an opaque u64 from the
   coordinator rather than reading qfc-consensus — no dependency coupling.

--- a/docs/adr/0007-data-availability.md
+++ b/docs/adr/0007-data-availability.md
@@ -1,0 +1,39 @@
+# ADR-0007: Data availability & disaster recovery for training
+
+**Status:** accepted · **Date:** 2026-06-12 · **Context:** Feature A review finding 1 (replay-stream availability was unowned).
+
+## Problem
+
+The recovery story "snapshot per epoch + replay the sample stream" (Monolith's
+RPO model) silently assumes someone durably stores the sample stream and the
+snapshots. In a datacenter that's Kafka + HDFS; in a decentralized network it
+must be an owned, incentivized duty or it does not exist.
+
+## Decision
+
+Three artifacts, three owners:
+
+| Artifact | Producer | Pinned by | Lifetime |
+|---|---|---|---|
+| **Data-shard manifests** (training data, sharded, CID'd — B-1 manifest format) | job submitter | submitter pays pinning deposit at job creation; assigned miners pin their shards for the job duration | job + audit window |
+| **Epoch parameter snapshots** (full params, shard-manifest format) | PS operators at the epoch barrier | the ≥2 operators of each range (staked duty, ADR-0002); CID in the on-chain commit | last `K=4` epochs + every model-version release |
+| **Accepted-update log** (per-epoch `(worker, range, step, update_hash, flops)` records, ADR-0004) | PS operators | operators; record-set hash is in the on-chain commit, so withholding is detectable | audit window |
+
+**RPO = one training epoch.** Operator failure mid-epoch loses at most the
+in-flight epoch's updates; recovery = load snapshot N−1, re-run the epoch.
+This is the deliberate, Monolith-style "RPO is a business decision": training
+re-learns a lost epoch faster than any sub-epoch durability machinery would
+pay for itself.
+
+A job whose data shards become unavailable mid-job (submitter unpinned,
+miners churned) is **failed-safe**: epoch can't start without quorum
+availability attestation from assigned miners; the job suspends rather than
+training on partial data.
+
+## Consequences
+
+- `qfc-ps` snapshot format = B-1 `ShardManifest` (split + per-shard Blake3 +
+  IPFS), so snapshots are resumable/verifiable downloads for free.
+- Slashable pinning duty needs a cheap availability challenge (operator must
+  serve a random byte-range of a pinned CID within a deadline) — lands with
+  A5; out of scope for A1/A2.

--- a/docs/adr/0008-verification-economics.md
+++ b/docs/adr/0008-verification-economics.md
@@ -1,0 +1,44 @@
+# ADR-0008: Verification economics (slash/reward ratio)
+
+**Status:** accepted · **Date:** 2026-06-12 · **Context:** Feature A review finding 2 (sampling without a stated ratio is theater).
+
+## Problem
+
+Re-executing a training step costs ≈1× the original work, so audits are
+sampled (p = 5%, ADR-0005), not universal. Sampling only deters cheating if
+the expected value of fabricating work is negative — that is a ratio we must
+pick and enforce, not an emergent property.
+
+## Decision
+
+For a per-step reward `r`, detection probability per fabricated step `p`,
+the slash `S` on detection must satisfy `p·S > (1−p)·r`, i.e. at p = 5%:
+`S > 19r`. We set:
+
+> **S = 40× the per-step reward** (safety factor ≈2 over break-even),
+> assessed against the miner's training stake; plus retroactive voiding of
+> the epoch's acceptance records (ADR-0004); plus the existing jail mechanic
+> from v2.x InvalidInference (6h).
+
+Minimum training stake per epoch must therefore cover `40r × steps_assigned`
+— this is the stake floor the assignment layer (A3) enforces, and it is the
+same number that makes ADR-0003's "stake-bounded minority" real: an attacker
+buying `β·n` worth of update slots is buying slashable stake, not identities.
+
+Challenge traps (ADR-0005) raise effective `p` above the nominal 5% for free
+on a per-miner basis; the ratio is calibrated to nominal `p` so traps are
+margin, not load-bearing.
+
+GPU tolerance-band mode (A4b) weakens detection (cheats inside ε are
+invisible) — the ε-calibration report must include a re-derivation of this
+ratio before GPU training jobs are enabled. Until then the ratio assumes
+exact-match CPU verification.
+
+## Consequences
+
+- Protocol constants in one place (`qfc-ps::config`): `p = 0.05`,
+  `slash_multiple = 40`, `staleness_bound = 3`, `trim_beta = 0.2`,
+  `snapshot_retention = 4`. A5 mirrors them on-chain as governance
+  parameters.
+- Per-epoch verifier budget = p × accepted FLOPs, paid from the epoch reward
+  pool (verification is metered work like any other).


### PR DESCRIPTION
First slice of [ROADMAP-AI-V3](docs/ROADMAP-AI-V3.md) **Feature A — decentralized training via an off-chain parameter server**. Strictly off-chain (roadmap non-goal #1 holds structurally: the chain will only ever see epoch-end version commits, landing in A5).

## A0 — ADRs 0002–0008

The roadmap's five design decisions plus two added from review: **0007 data availability** (who pins the replay stream — the decentralized version of the Monolith RPO story) and **0008 verification economics** (slash = 40× per-step reward, derived from the 5% sampling rate; sampling without a stated ratio is theater).

## A1 — `qfc-ps` crate

- `ShardStore`: contiguous `ParamRange` of dense params on a **dedicated** `qfc-storage` Database (never the chain DB); 1024-wide f32 chunk rows, BE chunk keys, atomic `WriteBatch` deltas; streaming Blake3 `params_hash` and `export_snapshot` whose byte streams coincide by construction — snapshots feed the B-1 `ShardManifest` format (ADR-0007).
- `SspClock`: bounded-staleness push admission (ps-lite's bounded-delay), clocks advance exactly one step per accepted push.
- `ShardService`: registered-range admission → SSP admit → buffer (worker cap) → acceptance records (ADR-0004); epoch barrier aggregates per range, applies deltas, returns `EpochOutcome { epoch, params_hash, accepted }` — the future on-chain commit inputs.

## A2 — Aggregation

Coordinate-wise trimmed mean (`⌈β·n⌉` per side, f64 accumulation) + a clearly-labeled poisonable `Mean` baseline. Seeded property tests (no proptest in workspace; fixed-seed `StdRng`) demonstrate ADR-0003's claims: 3 colluding ±1e30 attackers among 20 honest move the result ≤0.28σ across 300 seeds; at `f = ⌈β·n⌉+1` the result breaks by ~8e28 on 100/100 seeds — the cliff is real and the assignment-layer cap is load-bearing.

## Adversarial review pass (2 blockers fixed)

- **Range admission**: workers could previously push arbitrary sub-ranges → mint unbounded buffer keys (OOM), abort the barrier with thin ranges (liveness DoS), and double-earn on overlaps. Pushes now must exactly match a registered (disjoint, fixed) assignment range.
- **Thin ranges skip deterministically** (`AggregationRule::min_updates`) instead of failing the epoch.
- **Clock ratchet bounded**: out-of-band `advance_clock` removed; ratcheting the admission floor now costs accepted, metered, audit-eligible work.
- ADR-0004/0006 stale-push contradiction reconciled (stale = refused, no record, not slashable).

## Tests

35 passing (`qfc-ps`), workspace builds clean, fmt/clippy clean.

## Next (separate PRs)

A3 training task type in `qfc-ai-coordinator` → A4 verification path → A5 chain integration (incl. cross-operator agreement on the accepted-update set) → A6 testnet pilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)