### PR TITLE
T4.1: persist consensus checkpoints + fast restart from latest epoch

### DIFF
--- a/crates/qfc-chain/src/chain.rs
+++ b/crates/qfc-chain/src/chain.rs
@@ -13,7 +13,7 @@ use qfc_types::{
     ValidatorNode, U256,
 };
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Chain configuration
 #[derive(Clone, Debug)]
@@ -113,11 +113,14 @@ impl Chain {
                 info!("Restored state root from head block: {}", state_root);
             }
 
-            // Try to load validators from checkpoint
-            self.load_validator_checkpoint();
-
-            // Register genesis validators with consensus engine (as fallback)
-            self.register_genesis_validators();
+            // Restore consensus state (validators, epoch, finalized height)
+            // from the latest checkpoint. Only fall back to re-deriving from
+            // genesis when no usable checkpoint exists — registering genesis
+            // validators after a successful restore would clobber the
+            // checkpointed state (stake, scores, jail status, epoch).
+            if !self.load_validator_checkpoint() {
+                self.register_genesis_validators();
+            }
 
             info!("Loaded chain with genesis: {}", hash);
             return Ok(());
@@ -203,21 +206,30 @@ impl Chain {
         }
     }
 
-    /// Load validator checkpoint from storage
-    fn load_validator_checkpoint(&self) {
+    /// Load the latest validator checkpoint from storage and restore
+    /// consensus state from it. Returns `true` if a checkpoint was restored.
+    fn load_validator_checkpoint(&self) -> bool {
         match self.consensus.load_latest_checkpoint(&self.db) {
             Ok(Some(checkpoint)) => {
                 self.consensus.restore_from_checkpoint(&checkpoint);
                 info!(
-                    "Loaded validator checkpoint: epoch={}, height={}",
-                    checkpoint.epoch, checkpoint.block_height
+                    "Loaded validator checkpoint: epoch={}, height={}, validators={}",
+                    checkpoint.epoch,
+                    checkpoint.block_height,
+                    checkpoint.validators.len()
                 );
+                true
             }
             Ok(None) => {
                 debug!("No validator checkpoint found, using genesis validators");
+                false
             }
             Err(e) => {
-                debug!("Failed to load validator checkpoint: {}", e);
+                warn!(
+                    "Failed to load validator checkpoint, using genesis validators: {}",
+                    e
+                );
+                false
             }
         }
     }
@@ -238,7 +250,7 @@ impl Chain {
                 );
             }
             Err(e) => {
-                debug!("Failed to create checkpoint: {}", e);
+                warn!("Failed to create checkpoint: {}", e);
             }
         }
 
@@ -679,6 +691,11 @@ impl Chain {
         // Update in-memory head (only after the durable commit succeeded)
         *self.head.write() = Some(SealedBlock::new(block_hash, block.clone()));
 
+        // Maybe create checkpoint at epoch boundary — the producer path must
+        // checkpoint too, otherwise a block-producing node never persists
+        // consensus state and every restart re-derives from genesis.
+        let _ = self.maybe_create_checkpoint(block.number());
+
         debug!(
             "Stored produced block {} at height {}",
             block_hash,
@@ -904,5 +921,140 @@ mod tests {
             .get(cf::METADATA, qfc_storage::meta::LATEST_STATE_ROOT)
             .unwrap()
             .is_some());
+    }
+
+    // ============ Checkpoint fast restart ============
+
+    fn storage_config(path: &std::path::Path) -> qfc_storage::StorageConfig {
+        qfc_storage::StorageConfig {
+            path: path.to_path_buf(),
+            create_if_missing: true,
+            ..Default::default()
+        }
+    }
+
+    /// Produce dummy blocks up to `height` so an epoch-boundary checkpoint
+    /// (every BLOCKS_PER_EPOCH blocks) is written by the producer path.
+    fn produce_blocks(chain: &Chain, from: u64, to: u64) {
+        let mut parent_hash = chain.head().unwrap().hash;
+        for number in from..=to {
+            let mut block = Block::default();
+            block.header.number = number;
+            block.header.parent_hash = parent_hash;
+            block.header.state_root = chain.state_root();
+            chain.store_produced_block(&block, &[]).unwrap();
+            parent_hash = blake3_hash(&block.header_bytes());
+        }
+    }
+
+    fn test_validator_set() -> Vec<ValidatorNode> {
+        (1..=3u8)
+            .map(|i| {
+                let mut v = ValidatorNode::default();
+                v.address = Address::new([i; 20]);
+                v.stake = U256::from_u64(10_000 * i as u64);
+                v.contribution_score = 4242;
+                v
+            })
+            .collect()
+    }
+
+    /// Full restart path: build consensus state, write the epoch-boundary
+    /// checkpoint via block production, drop everything, reopen the same DB,
+    /// and assert epoch / validators / finalized height are restored from
+    /// the checkpoint instead of being re-derived from genesis.
+    #[test]
+    fn test_restart_restores_consensus_state_from_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+
+        {
+            let db = Database::open(storage_config(dir.path())).unwrap();
+            let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
+            let chain = Chain::new(db, ChainConfig::default(), consensus.clone()).unwrap();
+
+            // Consensus state that genesis init could never produce.
+            // (start_epoch first: it recalculates contribution scores, which
+            // would overwrite the sentinel score set below.)
+            consensus.start_epoch(7, [0xab; 32]);
+            consensus.update_validators(test_validator_set());
+            consensus.set_finalized_height(2);
+
+            // Height 3 = BLOCKS_PER_EPOCH boundary -> checkpoint written
+            produce_blocks(&chain, 1, qfc_types::BLOCKS_PER_EPOCH);
+        } // chain + db dropped, releasing the RocksDB lock
+
+        let db = Database::open(storage_config(dir.path())).unwrap();
+        let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
+        let chain = Chain::new(db, ChainConfig::default(), consensus.clone()).unwrap();
+
+        // Restored from checkpoint, not re-derived from genesis
+        assert_eq!(consensus.get_epoch().number, 7);
+        assert_eq!(consensus.get_epoch().seed, [0xab; 32]);
+        assert_eq!(consensus.finalized_height(), 2);
+
+        let validators = consensus.get_validators();
+        assert_eq!(validators.len(), 3);
+        assert_eq!(validators[0].address, Address::new([1; 20]));
+        assert_eq!(validators[0].contribution_score, 4242);
+        assert_eq!(validators[2].stake, U256::from_u64(30_000));
+
+        // Chain head itself was restored as before
+        assert_eq!(chain.block_number(), qfc_types::BLOCKS_PER_EPOCH);
+    }
+
+    /// If the newest checkpoint entry is corrupt, restart must fall back to
+    /// the previous good checkpoint instead of panicking or losing state.
+    #[test]
+    fn test_restart_falls_back_on_corrupt_latest_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+
+        {
+            let db = Database::open(storage_config(dir.path())).unwrap();
+            let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
+            let chain = Chain::new(db.clone(), ChainConfig::default(), consensus.clone()).unwrap();
+
+            consensus.start_epoch(7, [0xab; 32]);
+            consensus.update_validators(test_validator_set());
+            produce_blocks(&chain, 1, qfc_types::BLOCKS_PER_EPOCH);
+
+            // Corrupt entry at a newer epoch than the good checkpoint
+            db.put(cf::CHECKPOINTS, &8u64.to_be_bytes(), b"corrupt checkpoint")
+                .unwrap();
+        }
+
+        let db = Database::open(storage_config(dir.path())).unwrap();
+        let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
+        let _chain = Chain::new(db, ChainConfig::default(), consensus.clone()).unwrap();
+
+        // Fell back to the good epoch-7 checkpoint
+        assert_eq!(consensus.get_epoch().number, 7);
+        assert_eq!(consensus.get_validators().len(), 3);
+    }
+
+    /// Without any checkpoint, restart keeps the previous behavior: genesis
+    /// validators are registered as fallback.
+    #[test]
+    fn test_restart_without_checkpoint_uses_genesis_validators() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let genesis_validators;
+        {
+            let db = Database::open(storage_config(dir.path())).unwrap();
+            let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
+            let _chain = Chain::new(db, ChainConfig::default(), consensus.clone()).unwrap();
+            genesis_validators = consensus.get_validators();
+            // No blocks produced -> no checkpoint written
+        }
+
+        let db = Database::open(storage_config(dir.path())).unwrap();
+        let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
+        let _chain = Chain::new(db, ChainConfig::default(), consensus.clone()).unwrap();
+
+        assert_eq!(consensus.get_epoch().number, 0);
+        let restored = consensus.get_validators();
+        assert_eq!(restored.len(), genesis_validators.len());
+        for (a, b) in restored.iter().zip(genesis_validators.iter()) {
+            assert_eq!(a.address, b.address);
+        }
     }
 }

--- a/crates/qfc-consensus/src/engine.rs
+++ b/crates/qfc-consensus/src/engine.rs
@@ -14,7 +14,14 @@ use qfc_types::{
 };
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
+
+/// How many recent validator checkpoints to retain in the `checkpoints`
+/// column family. Older checkpoints are pruned when a new one is written,
+/// keeping the CF bounded (one checkpoint per epoch would otherwise grow
+/// without limit). Restart only ever needs the newest usable checkpoint;
+/// earlier ones exist purely as fallback against corruption.
+pub const CHECKPOINT_RETENTION: usize = 64;
 
 /// Consensus engine configuration
 #[derive(Clone, Debug)]
@@ -678,6 +685,11 @@ impl ConsensusEngine {
     }
 
     /// Create a validator checkpoint at epoch boundary
+    ///
+    /// The checkpoint blob, the per-validator records, and retention pruning
+    /// of old checkpoints are all written in a single atomic `WriteBatch`
+    /// (non-sync, per ADR 0001 §3 — checkpoints are derived data and are
+    /// rebuilt at the next epoch boundary if lost).
     pub fn create_checkpoint(
         &self,
         db: &qfc_storage::Database,
@@ -701,18 +713,57 @@ impl ConsensusEngine {
             finalized,
         );
 
-        // Store checkpoint
-        let key = epoch.number.to_be_bytes();
-        db.put(qfc_storage::cf::CHECKPOINTS, &key, &checkpoint.to_bytes())
+        // Big-endian epoch key: lexicographic order == numeric order, so the
+        // latest checkpoint is found by a single reverse-iterator step.
+        let key = epoch.number.to_be_bytes().to_vec();
+
+        let mut batch = qfc_storage::WriteBatch::new();
+        batch.put(
+            qfc_storage::cf::CHECKPOINTS,
+            key.clone(),
+            checkpoint.to_bytes(),
+        );
+
+        // Save individual validators in the same atomic batch
+        for validator in validators.iter() {
+            batch.put(
+                qfc_storage::cf::VALIDATORS,
+                validator.address.as_bytes().to_vec(),
+                validator.to_bytes(),
+            );
+        }
+
+        // Retention: keep only the newest CHECKPOINT_RETENTION checkpoints
+        // (including the one being written). The CF stays bounded, so this
+        // scan touches at most CHECKPOINT_RETENTION + 1 small entries.
+        match db.try_iter(qfc_storage::cf::CHECKPOINTS) {
+            Ok(iter) => {
+                let existing: Vec<Vec<u8>> = iter
+                    .filter_map(|r| r.ok())
+                    .map(|(k, _)| k.to_vec())
+                    .filter(|k| *k != key)
+                    .collect();
+                let total = existing.len() + 1;
+                if total > CHECKPOINT_RETENTION {
+                    // `existing` is in ascending key order (BE epoch), so the
+                    // front entries are the oldest.
+                    for old_key in existing.into_iter().take(total - CHECKPOINT_RETENTION) {
+                        batch.delete(qfc_storage::cf::CHECKPOINTS, old_key);
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("Failed to scan checkpoints for retention pruning: {}", e);
+            }
+        }
+
+        db.write_batch(batch)
             .map_err(|e: qfc_storage::StorageError| ConsensusError::StorageError(e.to_string()))?;
 
         info!(
             "Created checkpoint for epoch {} at height {}",
             epoch.number, block_height
         );
-
-        // Also save individual validators
-        self.save_validators(db)?;
 
         Ok(checkpoint)
     }
@@ -736,13 +787,64 @@ impl ConsensusEngine {
         }
     }
 
-    /// Load latest checkpoint from database
+    /// Load the latest checkpoint from the database.
+    ///
+    /// Iterates the `checkpoints` column family in reverse (keys are
+    /// big-endian epoch numbers, so the first entry is the newest epoch) and
+    /// returns the first checkpoint that deserializes and passes sanity
+    /// checks. Corrupt or inconsistent entries are skipped with a warning so
+    /// restart falls back to an earlier checkpoint — or to genesis if none
+    /// is usable — instead of failing.
     pub fn load_latest_checkpoint(
         &self,
-        _db: &qfc_storage::Database,
+        db: &qfc_storage::Database,
     ) -> Result<Option<ValidatorCheckpoint>> {
-        // In a full implementation, we would scan for the latest epoch
-        // For now, we return None and rely on genesis initialization
+        let iter = db
+            .try_iter_reverse(qfc_storage::cf::CHECKPOINTS)
+            .map_err(|e: qfc_storage::StorageError| ConsensusError::StorageError(e.to_string()))?;
+
+        for entry in iter {
+            let (key, value) = match entry {
+                Ok(kv) => kv,
+                Err(e) => {
+                    // Iterator-level error (e.g. corrupt SST): the iterator
+                    // is invalid past this point; fall back to genesis.
+                    warn!(
+                        "Checkpoint scan failed, falling back to genesis initialization: {}",
+                        e
+                    );
+                    break;
+                }
+            };
+
+            match ValidatorCheckpoint::from_bytes(&value) {
+                Ok(checkpoint) => {
+                    if key.as_ref() != checkpoint.epoch.to_be_bytes() {
+                        warn!(
+                            "Checkpoint key/epoch mismatch (key {:02x?}, epoch {}); trying earlier checkpoint",
+                            key, checkpoint.epoch
+                        );
+                        continue;
+                    }
+                    if checkpoint.validators.is_empty() {
+                        warn!(
+                            "Checkpoint for epoch {} has an empty validator set; trying earlier checkpoint",
+                            checkpoint.epoch
+                        );
+                        continue;
+                    }
+                    return Ok(Some(checkpoint));
+                }
+                Err(e) => {
+                    warn!(
+                        "Corrupt checkpoint entry (key {:02x?}): {}; trying earlier checkpoint",
+                        key, e
+                    );
+                    continue;
+                }
+            }
+        }
+
         Ok(None)
     }
 
@@ -1261,5 +1363,151 @@ mod tests {
         for v in updated {
             assert!(v.contribution_score > 0);
         }
+    }
+
+    // ============ Checkpoint persistence ============
+
+    #[test]
+    fn test_checkpoint_write_load_roundtrip() {
+        let db = qfc_storage::Database::open_temp().unwrap();
+        let engine = ConsensusEngine::new(ConsensusConfig::default());
+        engine.update_validators(create_test_validators(3));
+
+        engine.start_epoch(1, [0x01; 32]);
+        engine.set_finalized_height(2);
+        let cp1 = engine.create_checkpoint(&db, 3).unwrap();
+
+        engine.start_epoch(2, [0x02; 32]);
+        engine.set_finalized_height(5);
+        let cp2 = engine.create_checkpoint(&db, 6).unwrap();
+
+        // Epoch 256 exercises big-endian key ordering: with little-endian
+        // keys, epoch 256 (00 01 00 ..) would sort *before* epoch 2.
+        engine.start_epoch(256, [0x03; 32]);
+        engine.set_finalized_height(767);
+        let cp256 = engine.create_checkpoint(&db, 768).unwrap();
+
+        // Latest checkpoint is the highest epoch
+        let latest = engine.load_latest_checkpoint(&db).unwrap().unwrap();
+        assert_eq!(latest, cp256);
+        assert_eq!(latest.epoch, 256);
+        assert_eq!(latest.validators.len(), 3);
+        assert_eq!(latest.finalized_height, 767);
+        assert_eq!(latest.epoch_seed, [0x03; 32]);
+
+        // Point lookups still work
+        assert_eq!(engine.load_checkpoint(&db, 1).unwrap().unwrap(), cp1);
+        assert_eq!(engine.load_checkpoint(&db, 2).unwrap().unwrap(), cp2);
+        assert_eq!(engine.load_checkpoint(&db, 99).unwrap(), None);
+    }
+
+    #[test]
+    fn test_load_latest_checkpoint_empty_db() {
+        let db = qfc_storage::Database::open_temp().unwrap();
+        let engine = ConsensusEngine::new(ConsensusConfig::default());
+        assert_eq!(engine.load_latest_checkpoint(&db).unwrap(), None);
+    }
+
+    #[test]
+    fn test_load_latest_checkpoint_skips_corrupt_entry() {
+        let db = qfc_storage::Database::open_temp().unwrap();
+        let engine = ConsensusEngine::new(ConsensusConfig::default());
+        engine.update_validators(create_test_validators(2));
+
+        engine.start_epoch(1, [0x01; 32]);
+        let cp1 = engine.create_checkpoint(&db, 3).unwrap();
+
+        // A corrupt entry at a *newer* epoch must be skipped, falling back
+        // to the older good checkpoint.
+        db.put(
+            qfc_storage::cf::CHECKPOINTS,
+            &2u64.to_be_bytes(),
+            b"not a valid borsh checkpoint",
+        )
+        .unwrap();
+
+        let latest = engine.load_latest_checkpoint(&db).unwrap().unwrap();
+        assert_eq!(latest, cp1);
+        assert_eq!(latest.epoch, 1);
+    }
+
+    #[test]
+    fn test_load_latest_checkpoint_all_corrupt_returns_none() {
+        let db = qfc_storage::Database::open_temp().unwrap();
+        let engine = ConsensusEngine::new(ConsensusConfig::default());
+
+        db.put(qfc_storage::cf::CHECKPOINTS, &1u64.to_be_bytes(), b"junk1")
+            .unwrap();
+        db.put(qfc_storage::cf::CHECKPOINTS, &2u64.to_be_bytes(), b"junk2")
+            .unwrap();
+
+        assert_eq!(engine.load_latest_checkpoint(&db).unwrap(), None);
+    }
+
+    #[test]
+    fn test_load_latest_checkpoint_skips_empty_validator_set() {
+        let db = qfc_storage::Database::open_temp().unwrap();
+        let engine = ConsensusEngine::new(ConsensusConfig::default());
+
+        // Checkpoint with validators (epoch 1)
+        engine.update_validators(create_test_validators(2));
+        engine.start_epoch(1, [0x01; 32]);
+        let cp1 = engine.create_checkpoint(&db, 3).unwrap();
+
+        // Newer checkpoint with an empty validator set (epoch 2) — restoring
+        // it would brick producer selection, so it must be skipped.
+        engine.update_validators(Vec::new());
+        engine.start_epoch(2, [0x02; 32]);
+        engine.create_checkpoint(&db, 6).unwrap();
+
+        let latest = engine.load_latest_checkpoint(&db).unwrap().unwrap();
+        assert_eq!(latest, cp1);
+    }
+
+    #[test]
+    fn test_checkpoint_retention_prunes_old_epochs() {
+        let db = qfc_storage::Database::open_temp().unwrap();
+        let engine = ConsensusEngine::new(ConsensusConfig::default());
+        engine.update_validators(create_test_validators(1));
+
+        let extra = 5u64;
+        let total = CHECKPOINT_RETENTION as u64 + extra;
+        for epoch in 1..=total {
+            engine.start_epoch(epoch, [epoch as u8; 32]);
+            engine
+                .create_checkpoint(&db, epoch * qfc_types::BLOCKS_PER_EPOCH)
+                .unwrap();
+        }
+
+        // Only the newest CHECKPOINT_RETENTION checkpoints remain
+        let count = db.iter(qfc_storage::cf::CHECKPOINTS).unwrap().count();
+        assert_eq!(count, CHECKPOINT_RETENTION);
+
+        // Oldest epochs were pruned, newest are intact
+        assert_eq!(engine.load_checkpoint(&db, 1).unwrap(), None);
+        assert_eq!(engine.load_checkpoint(&db, extra).unwrap(), None);
+        assert!(engine.load_checkpoint(&db, extra + 1).unwrap().is_some());
+        let latest = engine.load_latest_checkpoint(&db).unwrap().unwrap();
+        assert_eq!(latest.epoch, total);
+    }
+
+    #[test]
+    fn test_restore_from_checkpoint_state() {
+        let db = qfc_storage::Database::open_temp().unwrap();
+        let engine = ConsensusEngine::new(ConsensusConfig::default());
+        engine.update_validators(create_test_validators(3));
+        engine.start_epoch(42, [0xcd; 32]);
+        engine.set_finalized_height(125);
+        engine.create_checkpoint(&db, 126).unwrap();
+
+        // Fresh engine, as after process restart
+        let restarted = ConsensusEngine::new(ConsensusConfig::default());
+        let checkpoint = restarted.load_latest_checkpoint(&db).unwrap().unwrap();
+        restarted.restore_from_checkpoint(&checkpoint);
+
+        assert_eq!(restarted.get_epoch().number, 42);
+        assert_eq!(restarted.get_epoch().seed, [0xcd; 32]);
+        assert_eq!(restarted.finalized_height(), 125);
+        assert_eq!(restarted.get_validators().len(), 3);
     }
 }


### PR DESCRIPTION
## Summary

Roadmap [T4.1](docs/ROADMAP-SRE.md) (DR automation — checkpoint + fast restart). `ConsensusEngine::load_latest_checkpoint` was a stub returning `Ok(None)`, so **every node restart re-derived consensus state from genesis**: epoch reset to 0, validator set reset to genesis defaults, all accumulated stake/score/jail/finality state lost until peers caught the node up. This PR de-stubs the load path and fixes two write-side gaps that made checkpoints either absent or immediately clobbered.

## Design choices

**Key layout — big-endian epoch keys + reverse iteration.** `create_checkpoint` already keyed the `checkpoints` CF by `epoch.to_be_bytes()`; BE keys make lexicographic order equal numeric order, so the latest checkpoint is the *first* entry of a reverse iterator (`Database::try_iter_reverse`) — O(1), no METADATA latest-pointer to keep in sync (one less thing to corrupt or forget in a crash window). Point lookups by epoch (`load_checkpoint`) are unchanged.

**Write timing — epoch boundaries, both block paths.** Checkpoints were only written from the *import* path (`import_block → maybe_create_checkpoint` every `BLOCKS_PER_EPOCH` blocks). The *producer* path (`store_produced_block`) never checkpointed, so a block-producing validator — the node whose state matters most — persisted nothing. `store_produced_block` now calls `maybe_create_checkpoint` after the durable commit.

**Atomicity — one WriteBatch per checkpoint, non-sync per ADR 0001 §3.** The checkpoint blob, the per-validator records (`validators` CF), and retention pruning are written in a single atomic `WriteBatch`. Per [ADR 0001](docs/adr/0001-block-commit-durability.md) consensus checkpoints stay non-sync: they are derived data, rebuilt at the next epoch boundary; worst case after power loss is falling back to the previous checkpoint.

**Retention — keep newest 64 (`CHECKPOINT_RETENTION`).** One checkpoint per epoch (10 s epochs ≈ 8.6 k/day, each containing the full validator set) would grow the CF without bound. Pruning happens in the same batch; the CF stays bounded so the pruning scan itself is cheap. Restart only ever needs the newest usable checkpoint; the older 63 exist purely as corruption fallback (also gives T4.2's snapshot shipping a bounded CF).

**Corruption handling — skip, warn, fall back; never panic.** `load_latest_checkpoint` skips entries that fail borsh decode, whose key doesn't match the encoded epoch, or that carry an empty validator set (restoring one would brick producer selection), and continues to the next-older checkpoint. Iterator-level errors (corrupt SST) abort the scan and fall back to genesis. All paths log `warn`.

**Restore-wins on restart.** `init_genesis` previously called `register_genesis_validators()` *unconditionally after* restoring the checkpoint, which overwrote the restored validator set with genesis defaults — making even a working load path useless. Genesis registration is now the fallback only when no usable checkpoint exists.

## What restart now skips

Before: restart at epoch N started consensus at epoch 0 with the genesis validator set — N epochs of validator-set evolution (stake changes, contribution scores, jail status, finalized height) re-derived from peers/genesis. After: one O(1) reverse-iterator read restores epoch number, epoch seed, full validator set, and finalized height as of the last epoch boundary; `maybe_advance_epoch` then time-converges the epoch number forward. Only state newer than the last epoch boundary (≤ `BLOCKS_PER_EPOCH` − 1 blocks) needs replay. RPO for consensus state = one epoch interval.

## Tests

`cargo test -p qfc-consensus -p qfc-chain` — 49 passed, 0 failed. `cargo build -p qfc-node` — clean. `cargo fmt --all` applied.

- qfc-consensus: write/load round-trip (incl. epoch 256 to catch endianness bugs — LE keys would sort 256 before 2), latest-corrupt fallback to earlier checkpoint, all-corrupt → `None`, empty-validator-set skip, retention pruning, fresh-engine restore.
- qfc-chain: full restart (build state → produce to epoch boundary → drop chain+DB → reopen → assert epoch/seed/validators/finalized height restored, not genesis), corrupt-latest restart fallback, and no-checkpoint genesis fallback (existing behavior preserved).

Scope note: per T4 split, no RocksDB file-level Checkpoint snapshots, object-storage shipping, or metrics here — that's T4.2/T4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)