### PR TITLE
T4.3: scripted restore + game-day drill, measured RPO/RTO, DR runbook

### DIFF
--- a/docs/DR.md
+++ b/docs/DR.md
@@ -1,0 +1,204 @@
+# Disaster Recovery Runbook (T4)
+
+Scripted, rehearsed restore of a QFC node from snapshot backups, with measured
+RPO/RTO. Companion tooling:
+
+- `scripts/restore.sh` — the restore path (fetch → verify → place → restart → validate)
+- `scripts/gameday.sh` — repeatable local chaos drill that measures RPO/RTO
+- `docs/observability/alert-rules.yaml` — the backup-freshness alerts that tell
+  you this runbook is about to matter
+
+## 1. Architecture recap — what you are restoring
+
+### 1.1 What's in a snapshot (T4.2)
+
+A node started with `--snapshot-interval-secs N` periodically produces
+`<prefix>-<height>-<unix_ts>.tar.gz` (default prefix `qfc-snapshot`, default
+location `<datadir>/snapshots`, overridable with `--snapshot-dir`; optionally
+shipped off-box via `--snapshot-upload-cmd`, with `{file}` substituted).
+
+Each archive contains **one top-level directory** named like the archive stem,
+holding:
+
+- a complete, point-in-time-consistent **RocksDB database** — a file-level
+  RocksDB `Checkpoint` of the live DB (hard links of SSTs + copies of
+  MANIFEST/CURRENT/OPTIONS, memtables flushed first, so no WAL replay needed).
+  All 18 column families are captured: headers, bodies, transactions,
+  receipts, state, code, metadata, validators, **checkpoints**, etc.
+- `qfc-snapshot-manifest.json` — `{format_version: 1, created_at_unix,
+  block_height, db_version, column_families[]}`. The restore script refuses
+  archives whose manifest it does not understand.
+
+The extracted directory **is** a node database: place it at `<datadir>/db` and
+start the node. No import step.
+
+### 1.2 What the consensus checkpoint adds (T4.1)
+
+Independently of file-level snapshots, consensus writes a
+`ValidatorCheckpoint` (validator set, epoch, scores) into the `checkpoints`
+column family at every epoch boundary. On startup the node restores
+validator/epoch state from the latest checkpoint and replays **at most one
+epoch of blocks** instead of re-deriving consensus state from genesis.
+
+Because the `checkpoints` CF lives *inside* the DB, every snapshot archive
+carries the consensus checkpoints too — a restored snapshot fast-restarts the
+same way a cleanly restarted node does. Log line to confirm:
+
+```
+Loaded validator checkpoint: epoch=…, height=…, validators=…
+```
+
+### 1.3 The two recovery paths
+
+| | Path A — snapshot restore | Path B — checkpoint fast restart |
+|---|---|---|
+| When | Datadir lost/corrupt (disk loss, fat-finger `rm`, bad host) | Process died / host rebooted, datadir intact |
+| Data source | Newest snapshot archive (local dir or object storage) | The on-disk DB itself |
+| RPO | Up to one snapshot interval | 0 (RocksDB WAL recovers in-flight writes) |
+| RTO driver | Archive fetch + untar + node start | Node start only |
+| Catch-up | Blocks since the snapshot re-sync from peers | At most one epoch replayed locally |
+| Tool | `scripts/restore.sh` | just restart the service |
+
+A third path — **full peer re-sync from genesis** (no local data at all) — is
+the fallback when no usable snapshot exists. It is bounded by network sync
+throughput, grows with chain length, and is not yet timed by the game-day
+script (see §6).
+
+## 2. Measured RPO/RTO (game-day results)
+
+Measured by `scripts/gameday.sh` on **2026-06-12**, local dev Mac
+(Apple M5 Max, 36 GB RAM, macOS 26.5, release build). Drill parameters: dev
+node (`--dev --no-network`, 3 s block interval), 15 s snapshot interval,
+SIGKILL + `rm -rf` of the datadir, restore from the newest local archive via
+`scripts/restore.sh`, RTO clock from datadir destruction until RPC serves an
+*advancing* `eth_blockNumber`.
+
+| Run | Path A: RPO (blocks) | Path A: RTO | Path B: RPO | Path B: RTO |
+|-----|----------------------|-------------|-------------|-------------|
+| 1 | 1 | 13.2 s | 0 | 30.1 s |
+| 2 | 1 | 12.8 s | 0 | 12.1 s |
+| 3 | 1 | 37.6 s | 0 | 27.3 s |
+
+Reading the numbers:
+
+- **RPO**: 1 block lost out of a 15 s interval / 3 s block time (worst case 5).
+  In production RPO ≈ the snapshot interval — pick `--snapshot-interval-secs`
+  from your data-loss tolerance, and remember the freshness *alert* thresholds
+  assume a 1 h interval (§5).
+- **RTO variance is not the restore.** The mechanical restore — verify +
+  untar + place + DB open + checkpoint load + RPC up — is **≈ 1 s** end to end
+  (node boot from snapshot to serving RPC was < 15 ms in the logs). The rest
+  of the RTO, and all of its variance, is waiting for the dev node to win a
+  VRF leader slot and produce the *next* block (genesis registers 4
+  validators; 3 are offline in the drill, so ~¾ of 3 s slots are skipped).
+  On a real testnet, "serving reads" recovers in ~1 s + fetch time; "head
+  advancing" depends on the network producing blocks, not on the node.
+- Path A numbers use a **local** archive: add object-store download time for a
+  true off-site restore (archive size scales with state; drill archives were
+  ~20 KB, testnet archives will be larger — measure with
+  `restore.sh --verify-only` which times fetch+verify without touching data).
+
+Re-measure with: `scripts/gameday.sh` (~2 min, needs ports 18545/16060).
+
+## 3. Restore procedure — testnet VPS
+
+Assumptions (adapt paths/units to the host): node runs as a systemd service
+`qfc-testnet-node`, datadir `/var/lib/qfc` (DB at `/var/lib/qfc/db`), archives
+shipped by `--snapshot-upload-cmd "rclone copy {file} remote:qfc-backups/"`.
+
+**0. Decide the path.** Datadir intact and healthy disk → just
+`systemctl restart qfc-testnet-node` (Path B) and verify (§4). Datadir lost or
+RocksDB corruption errors in logs → continue (Path A).
+
+**1. Stop the node** (idempotent if already dead):
+
+```sh
+systemctl stop qfc-testnet-node
+```
+
+**2. Pick an archive.** Newest local one, if the snapshot dir survived:
+
+```sh
+ls -t /var/lib/qfc/snapshots/qfc-snapshot-*.tar.gz | head -3
+```
+
+or list remote ones: `rclone lsl remote:qfc-backups/ | sort -k2,3 | tail -3`.
+Archive names embed `<height>-<unix_ts>` — sanity-check the height against
+the explorer / a healthy peer before restoring something stale.
+
+**3. Restore.** Local archive (or directory — newest is picked):
+
+```sh
+scripts/restore.sh \
+  --datadir /var/lib/qfc --force \
+  --start-cmd 'systemctl start qfc-testnet-node' \
+  --peer-rpc-url http://<healthy-peer>:8545 \
+  /var/lib/qfc/snapshots
+```
+
+Remote archive — same command with a fetch hook instead of a path (mirrors
+the upload convention; `{file}` is the local destination):
+
+```sh
+scripts/restore.sh \
+  --fetch-cmd 'rclone copyto remote:qfc-backups/qfc-snapshot-<H>-<TS>.tar.gz {file}' \
+  --datadir /var/lib/qfc --force \
+  --start-cmd 'systemctl start qfc-testnet-node' \
+  --peer-rpc-url http://<healthy-peer>:8545
+```
+
+The script verifies tar integrity and the manifest (format version, column
+families, height/age) **before** touching the datadir, preserves any existing
+DB as `/var/lib/qfc/db.bak.<ts>` (never deletes it), starts the node, and
+polls RPC until the block number advances — comparing against the peer if
+given. Exit code 2 = DB placed but validation timed out: read the node logs
+before re-running. `--verify-only` checks an archive without restoring;
+`--help` has all flags.
+
+**4. Clean up later.** After the node has been healthy for a day, remove
+`db.bak.*` dirs to reclaim disk.
+
+## 4. Post-restore validation checklist
+
+- `restore.sh` printed `VALIDATED: block number advancing` (or do it manually:
+  two `eth_blockNumber` calls a few seconds apart must differ).
+- Startup log shows `Loaded validator checkpoint: epoch=…` — consensus
+  fast-restarted instead of falling back to genesis validators.
+- `qfc_sync_lag_blocks` (metrics, `:6060/metrics`) trending to 0; the restore
+  script warns if the peer is > 50 blocks ahead (the `QfcSyncLagHigh` alert
+  watches the same signal).
+- Backup pipeline resumed: `qfc_snapshot_last_success_timestamp_seconds`
+  advancing again — a restored node must immediately rebuild its own DR
+  coverage.
+
+## 5. Alert linkage
+
+From `docs/observability/alert-rules.yaml` (group `qfc-backup-freshness`) —
+these alerts protect the **RPO** and fire *before* a disaster:
+
+- `QfcSnapshotBackupStale` (ticket, > 2 h): one missed interval + slack — fix
+  the backup pipeline now; thresholds assume a 1 h interval, scale if yours
+  differs (ticket = 2 × interval).
+- `QfcSnapshotBackupVeryStale` (page, > 12 h): DR coverage is effectively
+  gone; a node loss now means a very stale restore or a full peer re-sync.
+
+Alerts that mean you may be *executing* this runbook shortly:
+`QfcNodeDown`, `QfcBlockProductionStalled`, `QfcRocksdbWriteStopped`.
+
+## 6. Game-day cadence & follow-ups
+
+- **Local drill (`scripts/gameday.sh`)**: run after any change to
+  `qfc-storage` snapshot/DB code, the backup task, or `restore.sh` itself —
+  it is the integration test for this runbook (~2 min). Update the table in
+  §2 when numbers move materially.
+- **Testnet game day**: quarterly, on one designated testnet validator
+  (VPS): stop it, move the datadir aside, restore from object storage with
+  `restore.sh`, record fetch time + RTO at real archive sizes, and append the
+  results to §2. The first testnet run should also validate the
+  `--snapshot-upload-cmd`/`--fetch-cmd` pair against the real object store.
+- **Follow-up (not yet measured): peer re-sync timing.** The third recovery
+  path — empty datadir, full sync from peers — needs a multi-node network to
+  time meaningfully (a 2-node local rig measures loopback sync, not reality).
+  Do it as part of the first testnet game day: wipe the drill validator's
+  datadir *without* restoring and time sync-to-head; record alongside §2 so
+  the "restore vs re-sync" decision in §1.3 has real numbers.

--- a/scripts/gameday.sh
+++ b/scripts/gameday.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# gameday.sh — repeatable local DR drill for QFC (T4.3).
+#
+# Drill, in one run:
+#   Path A (snapshot restore):
+#     start a dev node with frequent snapshots -> wait for >=N archives and
+#     blocks -> record H_snap (latest archive) and H_kill (chain head) ->
+#     SIGKILL the node and DESTROY its datadir -> restore from the latest
+#     archive via scripts/restore.sh -> restart -> measure
+#       RPO = H_kill - H_snap   (blocks lost)
+#       RTO = wall time from datadir destruction to RPC serving an
+#             advancing block number
+#   Path B (T4.1 consensus-checkpoint fast restart):
+#     clean stop of the recovered node -> restart on the intact datadir ->
+#     measure restart-to-advancing-RPC time (RPO = 0, nothing lost).
+#
+# Everything runs in a throwaway temp workdir; snapshot archives are written
+# OUTSIDE the datadir (simulating off-box object storage), so destroying the
+# datadir models a real disk loss. The only rm -rf targets are inside the
+# workdir and are guarded by an explicit path check.
+#
+# See docs/DR.md for the runbook and the measured numbers from past runs.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+gameday.sh — local QFC disaster-recovery drill with measured RPO/RTO
+
+USAGE:
+  gameday.sh [OPTIONS]
+
+OPTIONS:
+  --node-bin PATH        qfc-node binary (default: <repo>/target/release/qfc-node;
+                         built with `cargo build --release -p qfc-node` if missing).
+  --no-build             Fail instead of building when the binary is missing.
+  --snapshot-interval S  --snapshot-interval-secs for the drill node (default 15).
+  --min-snapshots N      Archives required before pulling the plug (default 2).
+  --min-blocks N         Chain height required before pulling the plug (default 12).
+  --rpc-port P           Drill node RPC port (default 18545).
+  --metrics-port P       Drill node metrics port (default 16060).
+  --keep                 Keep the workdir (logs, archives) after the drill.
+  -h, --help             This help.
+
+The drill needs ~1-2 minutes and exclusive use of the two ports.
+
+EXAMPLE:
+  scripts/gameday.sh --snapshot-interval 15 --min-blocks 12
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+NODE_BIN="$REPO_ROOT/target/release/qfc-node"
+NO_BUILD=0
+SNAP_INTERVAL=15
+MIN_SNAPSHOTS=2
+MIN_BLOCKS=12
+RPC_PORT=18545
+METRICS_PORT=16060
+KEEP=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --node-bin)          NODE_BIN="${2:?}"; shift 2 ;;
+    --no-build)          NO_BUILD=1; shift ;;
+    --snapshot-interval) SNAP_INTERVAL="${2:?}"; shift 2 ;;
+    --min-snapshots)     MIN_SNAPSHOTS="${2:?}"; shift 2 ;;
+    --min-blocks)        MIN_BLOCKS="${2:?}"; shift 2 ;;
+    --rpc-port)          RPC_PORT="${2:?}"; shift 2 ;;
+    --metrics-port)      METRICS_PORT="${2:?}"; shift 2 ;;
+    --keep)              KEEP=1; shift ;;
+    -h|--help)           usage; exit 0 ;;
+    *) printf 'unknown option: %s\n' "$1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+log()  { printf '[gameday] %s\n' "$*" >&2; }
+fail() { printf '[gameday] ERROR: %s\n' "$*" >&2; exit 1; }
+
+now_ms() {
+  if command -v perl >/dev/null; then
+    perl -MTime::HiRes=time -e 'printf "%.0f\n", time()*1000'
+  else
+    printf '%s000\n' "$(date +%s)" # 1s resolution fallback
+  fi
+}
+
+RPC_URL="http://127.0.0.1:$RPC_PORT"
+rpc_bn() { # prints decimal block number, or nothing if RPC is down
+  local hex
+  hex="$(curl -sf --max-time 3 "$RPC_URL" -X POST -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+    | sed -n 's/.*"result" *: *"0x\([0-9a-fA-F]*\)".*/\1/p' || true)"
+  if [ -n "$hex" ]; then printf '%d\n' "0x$hex"; fi
+}
+
+# Wait until the RPC block number advances at least once; echoes the
+# advancing height. $1 = timeout seconds.
+wait_advancing() {
+  local deadline first bn
+  deadline=$(( $(date +%s) + $1 ))
+  first=""
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    bn="$(rpc_bn)"
+    if [ -n "$bn" ]; then
+      if [ -z "$first" ]; then
+        first="$bn"
+      elif [ "$bn" -gt "$first" ]; then
+        printf '%s\n' "$bn"
+        return 0
+      fi
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------- workspace
+if [ ! -x "$NODE_BIN" ]; then
+  if [ "$NO_BUILD" = 1 ]; then
+    fail "node binary missing: $NODE_BIN (and --no-build given)"
+  fi
+  log "Building release node binary (cargo build --release -p qfc-node)..."
+  (cd "$REPO_ROOT" && cargo build --release -p qfc-node) || fail "build failed"
+fi
+[ -x "$NODE_BIN" ] || fail "node binary still missing: $NODE_BIN"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/qfc-gameday.XXXXXX")"
+touch "$WORKDIR/.qfc-gameday"
+DATADIR="$WORKDIR/datadir"
+BACKUPS="$WORKDIR/backups"   # outside the datadir = "off-box" object storage
+mkdir -p "$DATADIR" "$BACKUPS"
+NODE_PID=""
+
+# The ONLY rm -rf in this script. Refuses anything that is not a
+# subdirectory of a marker-carrying qfc-gameday workdir.
+guarded_rm_rf() {
+  local target="$1"
+  case "$target" in
+    "$WORKDIR"/*) : ;;
+    *) fail "guarded_rm_rf refused: '$target' is not inside workdir '$WORKDIR'" ;;
+  esac
+  case "$WORKDIR" in
+    */qfc-gameday.*) : ;;
+    *) fail "guarded_rm_rf refused: workdir '$WORKDIR' lacks the qfc-gameday name pattern" ;;
+  esac
+  [ -f "$WORKDIR/.qfc-gameday" ] || fail "guarded_rm_rf refused: marker file missing in '$WORKDIR'"
+  rm -rf "$target"
+}
+
+stop_node() {
+  if [ -n "$NODE_PID" ] && kill -0 "$NODE_PID" 2>/dev/null; then
+    kill -KILL "$NODE_PID" 2>/dev/null || true
+    wait "$NODE_PID" 2>/dev/null || true
+  fi
+  NODE_PID=""
+}
+
+cleanup() {
+  stop_node
+  if [ -f "$WORKDIR/node.pid" ]; then
+    kill -KILL "$(cat "$WORKDIR/node.pid")" 2>/dev/null || true
+  fi
+  if [ "$KEEP" = 1 ]; then
+    log "Workdir kept: $WORKDIR"
+  else
+    rm -rf "$WORKDIR"
+  fi
+}
+trap cleanup EXIT
+
+start_node() { # $1 = log file; starts the drill node in the background
+  "$NODE_BIN" --dev --no-network \
+    --datadir "$DATADIR" \
+    --rpc-addr "127.0.0.1:$RPC_PORT" \
+    --metrics-addr "127.0.0.1:$METRICS_PORT" \
+    --snapshot-interval-secs "$SNAP_INTERVAL" \
+    --snapshot-dir "$BACKUPS" \
+    --snapshot-retain 10 \
+    >>"$1" 2>&1 &
+  NODE_PID=$!
+}
+
+# restore.sh --start-cmd hook: must survive restore.sh exiting, so write a
+# tiny helper that detaches the node and records its pid.
+cat >"$WORKDIR/start-node.sh" <<EOF
+#!/bin/sh
+nohup "$NODE_BIN" --dev --no-network \\
+  --datadir "$DATADIR" \\
+  --rpc-addr "127.0.0.1:$RPC_PORT" \\
+  --metrics-addr "127.0.0.1:$METRICS_PORT" \\
+  --snapshot-interval-secs "$SNAP_INTERVAL" \\
+  --snapshot-dir "$BACKUPS" \\
+  --snapshot-retain 10 \\
+  >>"$WORKDIR/node-restored.log" 2>&1 &
+echo \$! > "$WORKDIR/node.pid"
+EOF
+chmod +x "$WORKDIR/start-node.sh"
+
+archive_count() {
+  find "$BACKUPS" -maxdepth 1 -name 'qfc-snapshot-*.tar.gz' 2>/dev/null | wc -l | tr -d ' '
+}
+
+latest_archive() {
+  # shellcheck disable=SC2012  # archive names are <prefix>-<digits>-<digits>.tar.gz, ls -t is safe
+  ls -t "$BACKUPS"/qfc-snapshot-*.tar.gz 2>/dev/null | head -1
+}
+
+# =============================================================== Path A: drill
+log "Workdir: $WORKDIR"
+log "PATH A — snapshot restore drill"
+log "Starting dev node (snapshots every ${SNAP_INTERVAL}s into $BACKUPS)..."
+start_node "$WORKDIR/node-initial.log"
+
+wait_advancing 60 >/dev/null || fail "node never started producing blocks (see $WORKDIR/node-initial.log)"
+log "Node up and producing blocks (pid $NODE_PID)"
+
+deadline=$(( $(date +%s) + MIN_SNAPSHOTS * SNAP_INTERVAL + 120 ))
+while :; do
+  count="$(archive_count)"
+  bn="$(rpc_bn)"
+  if [ "$count" -ge "$MIN_SNAPSHOTS" ] && [ -n "$bn" ] && [ "$bn" -ge "$MIN_BLOCKS" ]; then
+    break
+  fi
+  [ "$(date +%s)" -lt "$deadline" ] || fail "timed out waiting for $MIN_SNAPSHOTS snapshots + height $MIN_BLOCKS (have $count snapshots, height ${bn:-?})"
+  sleep 1
+done
+log "Preconditions met: $count snapshot archive(s), chain height $bn"
+
+ARCHIVE="$(latest_archive)"
+[ -n "$ARCHIVE" ] || fail "no snapshot archive found"
+# Name is <prefix>-<height>-<unix_ts>.tar.gz; parse from the right so a
+# prefix containing dashes cannot break the parse.
+stem="$(basename "$ARCHIVE" .tar.gz)"
+ts_part="${stem##*-}"
+H_SNAP="${stem%-*}"; H_SNAP="${H_SNAP##*-}"
+H_KILL="$(rpc_bn)"
+[ -n "$H_KILL" ] || fail "could not read chain height before the kill"
+log "Latest archive: $(basename "$ARCHIVE") (H_snap=$H_SNAP, taken at unix $ts_part)"
+log "Chain height at kill time: H_kill=$H_KILL"
+
+log "DISASTER: SIGKILL node (pid $NODE_PID) and destroy $DATADIR"
+stop_node
+T_DESTROY_MS="$(now_ms)"
+guarded_rm_rf "$DATADIR"
+
+log "Restoring via scripts/restore.sh from $BACKUPS ..."
+"$SCRIPT_DIR/restore.sh" \
+  --datadir "$DATADIR" \
+  --rpc-url "$RPC_URL" \
+  --start-cmd "$WORKDIR/start-node.sh" \
+  --validate-timeout 120 \
+  "$BACKUPS" \
+  || fail "restore.sh failed — drill aborted (workdir: $WORKDIR; rerun with --keep to inspect)"
+T_RECOVERED_MS="$(now_ms)"
+NODE_PID="$(cat "$WORKDIR/node.pid")"
+
+H_RESTORED="$(rpc_bn)"
+[ -n "$H_RESTORED" ] || fail "restored node RPC unreachable after validation (unexpected)"
+[ "$H_RESTORED" -ge "$H_SNAP" ] || fail "restored height $H_RESTORED < snapshot height $H_SNAP — restore bug"
+RTO_A_MS=$(( T_RECOVERED_MS - T_DESTROY_MS ))
+RPO_A_BLOCKS=$(( H_KILL - H_SNAP ))
+log "PATH A done: RPO=$RPO_A_BLOCKS blocks, RTO=${RTO_A_MS}ms, height now $H_RESTORED"
+
+# ====================================================== Path B: fast restart
+log "PATH B — T4.1 consensus-checkpoint fast restart (clean stop, intact datadir)"
+sleep 3   # let the restored node settle / write a checkpoint or two
+if [ -n "$NODE_PID" ] && kill -0 "$NODE_PID" 2>/dev/null; then
+  kill -TERM "$NODE_PID" 2>/dev/null || true
+  for _ in $(seq 1 20); do
+    kill -0 "$NODE_PID" 2>/dev/null || break
+    sleep 0.5
+  done
+  kill -KILL "$NODE_PID" 2>/dev/null || true
+fi
+NODE_PID=""
+
+T_RESTART_MS="$(now_ms)"
+start_node "$WORKDIR/node-fastrestart.log"
+H_AFTER_RESTART="$(wait_advancing 120)" || fail "node did not serve advancing blocks after clean restart (see $WORKDIR/node-fastrestart.log)"
+T_SERVING_MS="$(now_ms)"
+RTO_B_MS=$(( T_SERVING_MS - T_RESTART_MS ))
+
+CHECKPOINT_LINE="$(grep -m1 'Loaded validator checkpoint' "$WORKDIR/node-fastrestart.log" || true)"
+if [ -n "$CHECKPOINT_LINE" ]; then
+  log "Fast-restart confirmed: ${CHECKPOINT_LINE#*qfc_chain::chain: }"
+else
+  log "WARNING: no 'Loaded validator checkpoint' in restart log — node fell back to genesis validators + full replay"
+fi
+log "PATH B done: RPO=0 blocks, RTO=${RTO_B_MS}ms, height now $H_AFTER_RESTART"
+stop_node
+
+# ===================================================================== report
+fmt_s() { printf '%d.%01ds' $(($1 / 1000)) $((($1 % 1000) / 100)); }
+cat <<EOF
+
+================================ GAME DAY SUMMARY ================================
+  Drill node : --dev --no-network, ${SNAP_INTERVAL}s snapshot interval, 3s blocks
+  H_snap=$H_SNAP  H_kill=$H_KILL  (archive: $(basename "$ARCHIVE"))
+
+  Recovery path                       RPO (blocks)   RTO (wall)   Notes
+  ----------------------------------  -------------  -----------  -------------------------
+  A. snapshot restore (datadir lost)  $RPO_A_BLOCKS              $(fmt_s "$RTO_A_MS")        restore.sh, local archive
+  B. checkpoint fast restart          0              $(fmt_s "$RTO_B_MS")        T4.1, datadir intact
+  ----------------------------------  -------------  -----------  -------------------------
+  RPO upper bound for path A = snapshot interval (${SNAP_INTERVAL}s here;
+  production interval determines real-world RPO). Remote-fetch time is NOT
+  included in path A (local archive); add object-store download time for a
+  true off-site restore.
+==================================================================================
+EOF
+if [ "$KEEP" = 1 ]; then
+  log "Logs and archives kept in $WORKDIR"
+fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# restore.sh — restore a QFC node data directory from a snapshot archive (T4.3).
+#
+# Counterpart of the T4.2 backup pipeline (--snapshot-interval-secs /
+# --snapshot-upload-cmd in qfc-node): consumes the
+# `<prefix>-<height>-<unix_ts>.tar.gz` archives it produces.
+#
+# Flow: fetch -> verify -> place -> (re)start -> validate.
+# See docs/DR.md for the full runbook.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+restore.sh — restore a QFC node datadir from a snapshot archive
+
+USAGE:
+  restore.sh [OPTIONS] [ARCHIVE]
+
+ARCHIVE
+  Path to a local snapshot archive (<prefix>-<height>-<ts>.tar.gz), or a
+  directory containing such archives (the newest matching --prefix is used).
+  Alternatively fetch from remote storage with --fetch-cmd.
+
+OPTIONS:
+  --archive PATH        Same as the positional ARCHIVE argument.
+  --fetch-cmd CMD       Shell command that downloads the archive. `{file}`
+                        is replaced with the local destination path the
+                        command must write to (mirror of the node's
+                        --snapshot-upload-cmd convention). Env fallback:
+                        RESTORE_FETCH_CMD.
+  --datadir DIR         Node data directory to restore into (DB is placed at
+                        <datadir>/db). Default: ./data or $QFC_DATA_DIR.
+  --prefix NAME         Archive name prefix when ARCHIVE is a directory.
+                        Default: qfc-snapshot or $QFC_SNAPSHOT_PREFIX.
+  --force               Replace an existing <datadir>/db (it is preserved as
+                        <datadir>/db.bak.<timestamp>, never deleted).
+  --start-cmd CMD       Command run (via sh -c) after the DB is in place to
+                        start the node, e.g. 'systemctl start qfc-node'.
+  --rpc-url URL         Node RPC endpoint polled during validation.
+                        Default: http://127.0.0.1:8545
+  --peer-rpc-url URL    Optional healthy peer RPC; restored height is
+                        compared against it to report sync lag.
+  --validate            Poll RPC until the block number advances even when
+                        no --start-cmd is given (implied by --start-cmd).
+  --validate-timeout S  Seconds to wait for an advancing block number
+                        (default: 180).
+  --verify-only         Fetch + verify the archive, print its manifest
+                        summary, and exit without touching the datadir.
+  -h, --help            This help.
+
+EXAMPLES:
+  # Restore newest local archive into a stopped node's datadir:
+  restore.sh --datadir /var/lib/qfc --force /var/lib/qfc/snapshots
+
+  # Fetch from object storage, restore, restart via systemd, validate:
+  restore.sh \
+    --fetch-cmd 'rclone copyto remote:qfc-backups/qfc-snapshot-1200-1765432100.tar.gz {file}' \
+    --datadir /var/lib/qfc --force \
+    --start-cmd 'systemctl start qfc-node' \
+    --peer-rpc-url http://peer-b:8545
+
+  # Just check an archive is restorable (CI / backup verification):
+  restore.sh --verify-only /backups/qfc-snapshot-1200-1765432100.tar.gz
+
+EXIT CODES:
+  0 success; 1 usage/verify/place failure; 2 validation timed out (DB was
+  placed — the node may still be syncing; investigate before re-running).
+EOF
+}
+
+log()  { printf '[restore] %s\n' "$*" >&2; }
+fail() { printf '[restore] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------- arguments
+ARCHIVE="${ARCHIVE:-}"
+FETCH_CMD="${RESTORE_FETCH_CMD:-}"
+DATADIR="${QFC_DATA_DIR:-./data}"
+PREFIX="${QFC_SNAPSHOT_PREFIX:-qfc-snapshot}"
+FORCE=0
+START_CMD=""
+RPC_URL="http://127.0.0.1:8545"
+PEER_RPC_URL=""
+VALIDATE=0
+VALIDATE_TIMEOUT=180
+VERIFY_ONLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --archive)          ARCHIVE="${2:?--archive needs a value}"; shift 2 ;;
+    --fetch-cmd)        FETCH_CMD="${2:?--fetch-cmd needs a value}"; shift 2 ;;
+    --datadir)          DATADIR="${2:?--datadir needs a value}"; shift 2 ;;
+    --prefix)           PREFIX="${2:?--prefix needs a value}"; shift 2 ;;
+    --force)            FORCE=1; shift ;;
+    --start-cmd)        START_CMD="${2:?--start-cmd needs a value}"; shift 2 ;;
+    --rpc-url)          RPC_URL="${2:?--rpc-url needs a value}"; shift 2 ;;
+    --peer-rpc-url)     PEER_RPC_URL="${2:?--peer-rpc-url needs a value}"; shift 2 ;;
+    --validate)         VALIDATE=1; shift ;;
+    --validate-timeout) VALIDATE_TIMEOUT="${2:?--validate-timeout needs a value}"; shift 2 ;;
+    --verify-only)      VERIFY_ONLY=1; shift ;;
+    -h|--help)          usage; exit 0 ;;
+    -*)                 fail "unknown option: $1 (see --help)" ;;
+    *)                  [ -z "$ARCHIVE" ] || fail "multiple archives given: '$ARCHIVE' and '$1'"
+                        ARCHIVE="$1"; shift ;;
+  esac
+done
+
+if [ -n "$START_CMD" ]; then VALIDATE=1; fi
+command -v tar >/dev/null  || fail "tar not found"
+command -v curl >/dev/null || fail "curl not found (needed for validation)"
+if ! command -v jq >/dev/null; then
+  log "WARNING: jq not found — manifest verification will be degraded (grep-based)"
+fi
+
+# ---------------------------------------------------------------- workspace
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/qfc-restore.XXXXXX")"
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+# -------------------------------------------------------------------- fetch
+if [ -n "$FETCH_CMD" ]; then
+  [ -z "$ARCHIVE" ] || fail "give either an archive path or --fetch-cmd, not both"
+  ARCHIVE="$WORKDIR/fetched-snapshot.tar.gz"
+  # Mirror the node's upload-cmd convention: {file} -> single-quoted local path.
+  quoted="'$(printf '%s' "$ARCHIVE" | sed "s/'/'\\\\''/g")'"
+  case "$FETCH_CMD" in
+    *"{file}"*) cmd="${FETCH_CMD//\{file\}/$quoted}" ;;
+    *)          cmd="$FETCH_CMD $quoted" ;;
+  esac
+  log "Fetching archive: $cmd"
+  sh -c "$cmd" || fail "fetch command failed"
+  [ -s "$ARCHIVE" ] || fail "fetch command did not produce $ARCHIVE"
+fi
+
+[ -n "$ARCHIVE" ] || { usage >&2; fail "no archive given (path or --fetch-cmd)"; }
+
+# Directory given: pick the newest archive matching the prefix.
+if [ -d "$ARCHIVE" ]; then
+  newest=""
+  for f in "$ARCHIVE/$PREFIX"-*.tar.gz; do
+    [ -f "$f" ] || continue
+    if [ -z "$newest" ] || [ "$f" -nt "$newest" ]; then newest="$f"; fi
+  done
+  [ -n "$newest" ] || fail "no $PREFIX-*.tar.gz archives in $ARCHIVE"
+  log "Newest archive in directory: $newest"
+  ARCHIVE="$newest"
+fi
+[ -f "$ARCHIVE" ] || fail "archive not found: $ARCHIVE"
+
+# ------------------------------------------------------------------- verify
+log "Verifying archive integrity: $ARCHIVE"
+tar -tzf "$ARCHIVE" >"$WORKDIR/toc" || fail "archive is corrupt (tar/gzip integrity check failed)"
+
+# Exactly one top-level directory, named like the archive stem.
+roots="$(sed -e 's#^\./##' -e 's#/.*##' "$WORKDIR/toc" | sort -u)"
+[ "$(printf '%s\n' "$roots" | wc -l | tr -d ' ')" = 1 ] \
+  || fail "archive must contain exactly one top-level directory, found: $(printf '%s ' "$roots")"
+ROOT="$roots"
+grep -qx "$ROOT/qfc-snapshot-manifest.json" "$WORKDIR/toc" \
+  || fail "archive has no qfc-snapshot-manifest.json under $ROOT/ — not a QFC snapshot"
+
+STAGE="$WORKDIR/stage"
+mkdir -p "$STAGE"
+log "Extracting to staging area..."
+tar -xzf "$ARCHIVE" -C "$STAGE" || fail "extraction failed"
+SNAPDIR="$STAGE/$ROOT"
+MANIFEST="$SNAPDIR/qfc-snapshot-manifest.json"
+[ -f "$MANIFEST" ] || fail "manifest missing after extraction"
+
+if command -v jq >/dev/null; then
+  jq -e . "$MANIFEST" >/dev/null || fail "manifest is not valid JSON"
+  fmt="$(jq -r '.format_version' "$MANIFEST")"
+  [ "$fmt" = "1" ] || fail "unsupported snapshot format_version: $fmt (this script understands 1)"
+  height="$(jq -r '.block_height // "none"' "$MANIFEST")"
+  created="$(jq -r '.created_at_unix' "$MANIFEST")"
+  cf_count="$(jq -r '.column_families | length' "$MANIFEST")"
+  jq -e '.column_families | index("metadata") and index("checkpoints")' "$MANIFEST" >/dev/null \
+    || fail "manifest column_families missing 'metadata'/'checkpoints' — incompatible snapshot"
+else
+  grep -q '"format_version": *1' "$MANIFEST" || fail "unsupported or unreadable format_version"
+  height="$(sed -n 's/.*"block_height": *\([0-9]*\).*/\1/p' "$MANIFEST" | head -1)"
+  created="$(sed -n 's/.*"created_at_unix": *\([0-9]*\).*/\1/p' "$MANIFEST" | head -1)"
+  cf_count="?"
+fi
+[ -f "$SNAPDIR/CURRENT" ] || fail "snapshot has no RocksDB CURRENT file — not a database"
+
+age=$(( $(date +%s) - created ))
+log "Snapshot OK: height=${height:-none} created_at=$created (age ${age}s) column_families=$cf_count"
+if [ "$age" -gt $((24 * 3600)) ]; then
+  log "WARNING: snapshot is older than 24h — expect a long catch-up sync after restore"
+fi
+
+if [ "$VERIFY_ONLY" = 1 ]; then
+  log "--verify-only: archive is restorable, exiting."
+  exit 0
+fi
+
+# -------------------------------------------------------------------- place
+DB_DIR="$DATADIR/db"
+mkdir -p "$DATADIR"
+if [ -e "$DB_DIR" ]; then
+  if [ "$FORCE" != 1 ]; then
+    fail "$DB_DIR already exists — stop the node and re-run with --force (the old DB is kept as db.bak.<ts>)"
+  fi
+  bak="$DB_DIR.bak.$(date +%s)"
+  log "Preserving existing database as $bak"
+  mv "$DB_DIR" "$bak"
+fi
+
+# Stage inside the datadir so the final rename is atomic (same filesystem).
+PLACE_TMP="$DATADIR/.restore-incoming.$$"
+rm -rf "$PLACE_TMP"
+mv "$SNAPDIR" "$PLACE_TMP" 2>/dev/null || { cp -R "$SNAPDIR" "$PLACE_TMP"; }
+mv "$PLACE_TMP" "$DB_DIR"
+log "Database placed at $DB_DIR (height ${height:-none})"
+
+# ------------------------------------------------------------------ restart
+if [ -n "$START_CMD" ]; then
+  log "Starting node: $START_CMD"
+  sh -c "$START_CMD" || fail "start command failed"
+else
+  log "No --start-cmd given. Start the node yourself, e.g.:"
+  log "  qfc-node --datadir '$DATADIR' <your usual flags>"
+fi
+
+# ----------------------------------------------------------------- validate
+if [ "$VALIDATE" != 1 ]; then
+  log "Restore complete (validation skipped — pass --validate or --start-cmd to poll RPC)."
+  exit 0
+fi
+
+rpc_block_number() { # $1 = url; prints decimal height or nothing
+  local hex
+  hex="$(curl -sf --max-time 5 "$1" -X POST -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+    | sed -n 's/.*"result" *: *"0x\([0-9a-fA-F]*\)".*/\1/p' || true)"
+  if [ -n "$hex" ]; then printf '%d\n' "0x$hex"; fi
+}
+
+log "Validating: polling $RPC_URL for an advancing block number (timeout ${VALIDATE_TIMEOUT}s)..."
+deadline=$(( $(date +%s) + VALIDATE_TIMEOUT ))
+first_seen=""
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  bn="$(rpc_block_number "$RPC_URL")"
+  if [ -n "$bn" ]; then
+    if [ -z "$first_seen" ]; then
+      first_seen="$bn"
+      log "RPC is up, height $bn — waiting for it to advance..."
+    elif [ "$bn" -gt "$first_seen" ]; then
+      log "VALIDATED: block number advancing ($first_seen -> $bn)"
+      if [ -n "$PEER_RPC_URL" ]; then
+        peer_bn="$(rpc_block_number "$PEER_RPC_URL")"
+        if [ -n "$peer_bn" ]; then
+          log "Peer $PEER_RPC_URL is at height $peer_bn (local lag: $((peer_bn - bn)) blocks)"
+          if [ $((peer_bn - bn)) -gt 50 ]; then
+            log "NOTE: lag >50 blocks — watch qfc_sync_lag_blocks until caught up"
+          fi
+        else
+          log "WARNING: peer RPC $PEER_RPC_URL unreachable — skipping comparison"
+        fi
+      fi
+      log "Restore complete."
+      exit 0
+    fi
+  fi
+  sleep 1
+done
+log "ERROR: block number did not advance within ${VALIDATE_TIMEOUT}s (last seen: ${first_seen:-unreachable})"
+log "The database WAS placed; check node logs before re-running."
+exit 2


### PR DESCRIPTION
Closes the T4 DR-automation tier of docs/ROADMAP-SRE.md: the rehearsed restore path for the T4.1/T4.2 machinery (#108, #109), a repeatable game-day drill, and the runbook with real measured numbers.

## Measured RPO/RTO (game day, 2026-06-12, local dev Mac — Apple M5 Max / 36 GB / macOS 26.5)

Drill: dev node (3s blocks), 15s snapshot interval, SIGKILL + `rm -rf` of the datadir, restore from the newest local archive. RTO clock runs from datadir destruction until RPC serves an **advancing** `eth_blockNumber`.

| Run | Path A snapshot restore: RPO | RTO | Path B checkpoint fast restart: RPO | RTO |
|-----|------------------------------|-----|--------------------------------------|-----|
| 1 | 1 block | 13.2 s | 0 | 30.1 s |
| 2 | 1 block | 12.8 s | 0 | 12.1 s |
| 3 | 1 block | 37.6 s | 0 | 27.3 s |

Key reading: the **mechanical restore is ~1 s** (verify + untar + place + DB open + checkpoint load + RPC serving was <15 ms of node boot). All RTO variance is the dev node waiting to win a VRF leader slot for the *next* block (4 genesis validators, 3 offline in the drill → ~¾ of slots skipped). On a real network, read-availability recovers in ~1 s + archive fetch time; head advancement depends on the network, not the restored node.

## What's in the PR

- **scripts/restore.sh** — fetch (local path/dir, or remote via `--fetch-cmd`/`RESTORE_FETCH_CMD` mirroring the `--snapshot-upload-cmd` `{file}` convention) → verify (tar integrity; manifest `format_version`, column-family sanity, height/age printout) → place (atomic rename to `<datadir>/db`; refuses to clobber without `--force`; old DB preserved as `db.bak.<ts>`, never deleted) → optional `--start-cmd` → validate (polls `eth_blockNumber` until advancing, optional `--peer-rpc-url` lag comparison). `--verify-only` mode for backup verification. Non-interactive, `set -euo pipefail`, shellcheck-clean (v0.11.0), `bash -n` clean.
- **scripts/gameday.sh** — the chaos drill above, fully self-contained in a temp workdir; snapshot archives are written *outside* the datadir (simulating off-box object storage); the destructive `rm -rf` only targets the datadir and is guarded by an explicit workdir-prefix + marker-file check. Prints the summary table. Path B (T4.1 fast restart) timed in the same run, with `Loaded validator checkpoint` confirmed from the restart log.
- **docs/DR.md** — runbook: snapshot/consensus-checkpoint architecture recap, step-by-step testnet VPS restore (systemd + rclone placeholders), the measured table above, the two recovery paths compared, linkage to the `qfc-backup-freshness` alerts in docs/observability/alert-rules.yaml, and game-day cadence (local drill on every storage/backup change; quarterly testnet game day).

## Bugs found during the drill

- **In the new script itself (fixed before commit, no shipped-code bug):** first drill run failed because `curl … | sed … | { read -r hex && … }` drops the value when the HTTP response lacks a trailing newline — `read` returns non-zero at EOF even though it populated the variable, and `&&` short-circuited. Worth knowing for other scripts polling JSON-RPC.
- **No bugs found in the merged T4.1/T4.2 machinery.** Archives verified restorable, restored DB opens directly, consensus fast-restart engaged on every restart (`Loaded validator checkpoint: epoch=…, validators=4`), retention pruning behaved during the drill.
- Finding (documented in DR.md §2, not a bug): post-restart **head-advancement** latency is VRF-leader-slot bound (12–38 s observed in single-live-validator dev mode), so "RTO to advancing head" is network-dependent; "RTO to serving reads" is ~1 s.

## Test evidence

- 3 full game-day runs (table above) — RPO 1 block in all runs (worst case = interval/block-time = 5).
- restore.sh edge cases exercised: `--verify-only` OK; fresh-datadir place OK; clobber refused without `--force`; `--force` preserves `db.bak.<ts>`; `--fetch-cmd 'cp … {file}'` convention OK; truncated archive rejected at tar verify; non-QFC tarball rejected at manifest check.
- `bash -n` + shellcheck v0.11.0 clean on both scripts. No Rust touched.

Not included (documented as testnet follow-up in DR.md §6): peer re-sync timing — a 2-node loopback rig would measure localhost throughput, not real sync; scheduled for the first testnet game day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)