### PR TITLE
T6: detection-first self-healing watchdog (qfc-watchdog)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ members = [
     "crates/qfc-bridge",
     # v3: decentralized training (off-chain parameter server)
     "crates/qfc-ps",
+    # SRE T6: out-of-process self-healing watchdog (detection-first)
+    "crates/qfc-watchdog",
 ]
 
 
@@ -143,6 +145,7 @@ qfc-ai-coordinator = { path = "crates/qfc-ai-coordinator" }
 qfc-miner = { path = "crates/qfc-miner" }
 qfc-bridge = { path = "crates/qfc-bridge" }
 qfc-ps = { path = "crates/qfc-ps" }
+qfc-watchdog = { path = "crates/qfc-watchdog" }
 
 [profile.release]
 lto = true

--- a/crates/qfc-watchdog/Cargo.toml
+++ b/crates/qfc-watchdog/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "qfc-watchdog"
+description = "Out-of-process, detection-first self-healing watchdog for a single qfc-node (SRE T6)"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "qfc-watchdog"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+parking_lot.workspace = true
+tiny_http.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/qfc-watchdog/src/detector.rs
+++ b/crates/qfc-watchdog/src/detector.rs
@@ -1,0 +1,892 @@
+//! Detector engine: turns successive metric samples into firing/cleared
+//! detector states plus a 0–100 health score.
+//!
+//! Pure state machine — the clock is injected (`now_secs`) and samples are
+//! plain structs, so every detector and transition is unit-testable with
+//! synthetic time (no sleeps). The binary feeds it real scrapes on a poll
+//! interval.
+//!
+//! Sliding windows are evaluated against an in-memory history of successful
+//! scrapes. When a scrape fails, the three node-state detectors
+//! (block-production stall, stuck sync, compaction stall) **freeze**: they
+//! keep their last firing state but their consecutive-poll counters stop
+//! advancing, so action gating cannot make progress while the watchdog is
+//! blind. Availability detectors (metrics-down, RPC-down) cover that case.
+
+use crate::prom::MetricsText;
+use std::collections::VecDeque;
+use std::fmt;
+
+/// Identity of each detector. Order in [`DetectorId::ALL`] is the priority
+/// order used when several action-eligible detectors fire at once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DetectorId {
+    BlockProductionStall,
+    StuckSync,
+    CompactionStall,
+    MetricsDown,
+    RpcDown,
+}
+
+impl DetectorId {
+    pub const ALL: [DetectorId; 5] = [
+        DetectorId::BlockProductionStall,
+        DetectorId::StuckSync,
+        DetectorId::CompactionStall,
+        DetectorId::MetricsDown,
+        DetectorId::RpcDown,
+    ];
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DetectorId::BlockProductionStall => "block_production_stall",
+            DetectorId::StuckSync => "stuck_sync",
+            DetectorId::CompactionStall => "compaction_stall",
+            DetectorId::MetricsDown => "metrics_down",
+            DetectorId::RpcDown => "rpc_down",
+        }
+    }
+
+    /// Weight subtracted from the 100-point health score while firing.
+    /// Weights sum to more than 100 on purpose; the score clamps at 0.
+    pub fn weight(&self) -> u32 {
+        match self {
+            DetectorId::BlockProductionStall => 40,
+            DetectorId::RpcDown => 30,
+            DetectorId::MetricsDown => 30,
+            DetectorId::CompactionStall => 25,
+            DetectorId::StuckSync => 15,
+        }
+    }
+}
+
+impl fmt::Display for DetectorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for DetectorId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        DetectorId::ALL
+            .iter()
+            .find(|id| id.as_str() == s)
+            .copied()
+            .ok_or_else(|| {
+                let known: Vec<&str> = DetectorId::ALL.iter().map(|d| d.as_str()).collect();
+                format!("unknown detector `{s}` (known: {})", known.join(", "))
+            })
+    }
+}
+
+/// The watchdog-relevant slice of one successful `/metrics` scrape.
+/// Every field is optional: nodes export different series depending on
+/// flags (e.g. `qfc_snapshot_*` only with `--snapshot-interval-secs`).
+#[derive(Debug, Clone, Default)]
+pub struct MetricsSnapshot {
+    pub block_height: Option<u64>,
+    pub time_since_last_block_secs: Option<f64>,
+    pub syncing: Option<bool>,
+    pub sync_lag_blocks: Option<u64>,
+    pub write_stopped: Option<bool>,
+    pub delayed_write_rate: Option<f64>,
+    /// Summed across all column families.
+    pub pending_compaction_bytes: Option<u64>,
+    pub snapshot_last_attempt_unix: Option<u64>,
+    pub snapshot_last_success_unix: Option<u64>,
+}
+
+impl MetricsSnapshot {
+    /// Parse the qfc-node exporter output (metric names per
+    /// crates/qfc-node/src/metrics.rs and docs/observability/README.md).
+    pub fn from_prometheus(text: &str) -> Self {
+        let m = MetricsText::parse(text);
+        let as_u64 = |v: f64| v.max(0.0) as u64;
+        Self {
+            block_height: m.value("qfc_block_height").map(as_u64),
+            time_since_last_block_secs: m.value("qfc_time_since_last_block_seconds"),
+            syncing: m.value("qfc_sync_syncing").map(|v| v != 0.0),
+            sync_lag_blocks: m.value("qfc_sync_lag_blocks").map(as_u64),
+            write_stopped: m.value("qfc_rocksdb_write_stopped").map(|v| v != 0.0),
+            delayed_write_rate: m.value("qfc_rocksdb_actual_delayed_write_rate"),
+            pending_compaction_bytes: m.sum("qfc_rocksdb_pending_compaction_bytes").map(as_u64),
+            snapshot_last_attempt_unix: m
+                .value("qfc_snapshot_last_attempt_timestamp_seconds")
+                .map(as_u64),
+            snapshot_last_success_unix: m
+                .value("qfc_snapshot_last_success_timestamp_seconds")
+                .map(as_u64),
+        }
+    }
+}
+
+/// Detector thresholds. All overridable from the CLI; defaults documented
+/// in docs/WATCHDOG.md.
+#[derive(Debug, Clone)]
+pub struct DetectorConfig {
+    /// Block-production stall: head age must exceed this (seconds) while the
+    /// height is unchanged over `stall_window_secs`. Default 120 — matches
+    /// the QfcBlockProductionStalled page alert.
+    pub stall_threshold_secs: f64,
+    /// Window over which the height must be unchanged. Default 120.
+    pub stall_window_secs: u64,
+    /// Stuck sync: syncing=1 at both ends of this window and lag has not
+    /// decreased. Default 300.
+    pub sync_window_secs: u64,
+    /// Compaction: delayed-write rate must be >0 continuously for this long.
+    /// Default 120.
+    pub delayed_write_sustain_secs: u64,
+    /// Compaction: total pending-compaction bytes must exceed this AND be
+    /// growing over `compaction_window_secs`. Default 8 GiB — matches the
+    /// QfcRocksdbCompactionBacklogGrowing floor.
+    pub compaction_debt_bytes: u64,
+    /// Window for the debt-growth comparison. Default 600.
+    pub compaction_window_secs: u64,
+    /// Consecutive failed `/metrics` scrapes before metrics-down fires.
+    /// Default 3.
+    pub metrics_down_consecutive: u32,
+    /// Consecutive failed RPC probes before rpc-down fires. Default 3.
+    pub rpc_down_consecutive: u32,
+}
+
+impl Default for DetectorConfig {
+    fn default() -> Self {
+        Self {
+            stall_threshold_secs: 120.0,
+            stall_window_secs: 120,
+            sync_window_secs: 300,
+            delayed_write_sustain_secs: 120,
+            compaction_debt_bytes: 8 * 1024 * 1024 * 1024,
+            compaction_window_secs: 600,
+            metrics_down_consecutive: 3,
+            rpc_down_consecutive: 3,
+        }
+    }
+}
+
+/// One detector's state after a poll.
+#[derive(Debug, Clone)]
+pub struct DetectorStatus {
+    pub id: DetectorId,
+    pub firing: bool,
+    /// Consecutive evaluated polls this detector has been firing (frozen
+    /// while the watchdog cannot scrape, for the node-state detectors).
+    pub consecutive_firing: u32,
+    pub evidence: String,
+}
+
+/// A fire→clear or clear→fire edge, for structured logging.
+#[derive(Debug, Clone)]
+pub struct Transition {
+    pub id: DetectorId,
+    pub firing: bool,
+    pub evidence: String,
+}
+
+/// Result of one poll: detector states, health score, transitions, and the
+/// node context the action gate needs.
+#[derive(Debug, Clone)]
+pub struct Evaluation {
+    pub at_secs: u64,
+    pub detectors: Vec<DetectorStatus>,
+    /// 0–100. 100 = no detector firing; each firing detector subtracts its
+    /// weight; clamped at 0.
+    pub health_score: u32,
+    pub transitions: Vec<Transition>,
+    /// Last-known syncing flag (carried across scrape failures).
+    pub syncing: Option<bool>,
+    /// Last-known snapshot-backup timestamps (carried across failures) —
+    /// the gate uses these to avoid acting while a snapshot is in flight.
+    pub snapshot_last_attempt_unix: Option<u64>,
+    pub snapshot_last_success_unix: Option<u64>,
+}
+
+impl Evaluation {
+    pub fn status(&self, id: DetectorId) -> &DetectorStatus {
+        self.detectors
+            .iter()
+            .find(|d| d.id == id)
+            .expect("all detectors present")
+    }
+
+    pub fn firing(&self, id: DetectorId) -> bool {
+        self.status(id).firing
+    }
+
+    /// One-line dump of everything firing — attached to action logs.
+    pub fn evidence_summary(&self) -> String {
+        let firing: Vec<String> = self
+            .detectors
+            .iter()
+            .filter(|d| d.firing)
+            .map(|d| format!("{}: {}", d.id, d.evidence))
+            .collect();
+        if firing.is_empty() {
+            format!("health={} (no detector firing)", self.health_score)
+        } else {
+            format!("health={} [{}]", self.health_score, firing.join("; "))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HistoryPoint {
+    at: u64,
+    height: Option<u64>,
+    syncing: Option<bool>,
+    lag: Option<u64>,
+    delayed_rate: Option<f64>,
+    pending_compaction: Option<u64>,
+}
+
+struct DetectorSlot {
+    id: DetectorId,
+    firing: bool,
+    consecutive_firing: u32,
+    evidence: String,
+}
+
+/// The detector state machine. Feed it one sample per poll via
+/// [`Engine::evaluate`].
+pub struct Engine {
+    cfg: DetectorConfig,
+    history: VecDeque<HistoryPoint>,
+    scrape_failures: u32,
+    rpc_failures: u32,
+    slots: Vec<DetectorSlot>,
+    last_syncing: Option<bool>,
+    last_snapshot_attempt: Option<u64>,
+    last_snapshot_success: Option<u64>,
+}
+
+impl Engine {
+    pub fn new(cfg: DetectorConfig) -> Self {
+        let slots = DetectorId::ALL
+            .iter()
+            .map(|id| DetectorSlot {
+                id: *id,
+                firing: false,
+                consecutive_firing: 0,
+                evidence: String::new(),
+            })
+            .collect();
+        Self {
+            cfg,
+            history: VecDeque::new(),
+            scrape_failures: 0,
+            rpc_failures: 0,
+            slots,
+            last_syncing: None,
+            last_snapshot_attempt: None,
+            last_snapshot_success: None,
+        }
+    }
+
+    /// Evaluate one poll. `scrape` is `None` when the `/metrics` endpoint
+    /// could not be scraped; `rpc_ok` reports the `eth_blockNumber` probe.
+    pub fn evaluate(
+        &mut self,
+        now_secs: u64,
+        scrape: Option<&MetricsSnapshot>,
+        rpc_ok: bool,
+    ) -> Evaluation {
+        // Availability counters.
+        if scrape.is_some() {
+            self.scrape_failures = 0;
+        } else {
+            self.scrape_failures = self.scrape_failures.saturating_add(1);
+        }
+        if rpc_ok {
+            self.rpc_failures = 0;
+        } else {
+            self.rpc_failures = self.rpc_failures.saturating_add(1);
+        }
+
+        if let Some(s) = scrape {
+            self.history.push_back(HistoryPoint {
+                at: now_secs,
+                height: s.block_height,
+                syncing: s.syncing,
+                lag: s.sync_lag_blocks,
+                delayed_rate: s.delayed_write_rate,
+                pending_compaction: s.pending_compaction_bytes,
+            });
+            self.prune(now_secs);
+            if s.syncing.is_some() {
+                self.last_syncing = s.syncing;
+            }
+            if s.snapshot_last_attempt_unix.is_some() {
+                self.last_snapshot_attempt = s.snapshot_last_attempt_unix;
+            }
+            if s.snapshot_last_success_unix.is_some() {
+                self.last_snapshot_success = s.snapshot_last_success_unix;
+            }
+        }
+
+        // Desired state per detector; `None` = freeze (no fresh data).
+        let block = scrape.map(|s| self.eval_block_stall(now_secs, s));
+        let sync = scrape.map(|s| self.eval_stuck_sync(now_secs, s));
+        let compaction = scrape.map(|s| self.eval_compaction_stall(now_secs, s));
+        let metrics_down = Some((
+            self.scrape_failures >= self.cfg.metrics_down_consecutive,
+            format!(
+                "{} consecutive /metrics scrape failures (threshold {})",
+                self.scrape_failures, self.cfg.metrics_down_consecutive
+            ),
+        ));
+        let rpc_down = Some((
+            self.rpc_failures >= self.cfg.rpc_down_consecutive,
+            format!(
+                "{} consecutive eth_blockNumber probe failures (threshold {})",
+                self.rpc_failures, self.cfg.rpc_down_consecutive
+            ),
+        ));
+
+        let desired = [block, sync, compaction, metrics_down, rpc_down];
+        let mut transitions = Vec::new();
+        for (slot, want) in self.slots.iter_mut().zip(desired) {
+            let Some((firing, evidence)) = want else {
+                continue; // frozen: keep state, do not advance counters
+            };
+            if firing != slot.firing {
+                transitions.push(Transition {
+                    id: slot.id,
+                    firing,
+                    evidence: evidence.clone(),
+                });
+            }
+            slot.consecutive_firing = if firing {
+                slot.consecutive_firing.saturating_add(1)
+            } else {
+                0
+            };
+            slot.firing = firing;
+            slot.evidence = evidence;
+        }
+
+        let penalty: u32 = self
+            .slots
+            .iter()
+            .filter(|s| s.firing)
+            .map(|s| s.id.weight())
+            .sum();
+        let health_score = 100u32.saturating_sub(penalty);
+
+        Evaluation {
+            at_secs: now_secs,
+            detectors: self
+                .slots
+                .iter()
+                .map(|s| DetectorStatus {
+                    id: s.id,
+                    firing: s.firing,
+                    consecutive_firing: s.consecutive_firing,
+                    evidence: s.evidence.clone(),
+                })
+                .collect(),
+            health_score,
+            transitions,
+            syncing: self.last_syncing,
+            snapshot_last_attempt_unix: self.last_snapshot_attempt,
+            snapshot_last_success_unix: self.last_snapshot_success,
+        }
+    }
+
+    /// Most recent history point at or before `cutoff` (the sliding-window
+    /// baseline). `None` while the window is not yet covered.
+    fn point_at_or_before(&self, cutoff: u64) -> Option<&HistoryPoint> {
+        self.history.iter().rev().find(|p| p.at <= cutoff)
+    }
+
+    fn prune(&mut self, now: u64) {
+        let retention = self
+            .cfg
+            .stall_window_secs
+            .max(self.cfg.sync_window_secs)
+            .max(self.cfg.compaction_window_secs)
+            .max(self.cfg.delayed_write_sustain_secs)
+            + 120;
+        while let Some(front) = self.history.front() {
+            if front.at + retention < now && self.history.len() > 2 {
+                self.history.pop_front();
+            } else {
+                break;
+            }
+        }
+        // Hard cap so a tiny poll interval cannot grow memory unboundedly.
+        while self.history.len() > 100_000 {
+            self.history.pop_front();
+        }
+    }
+
+    /// Block-production stall: height unchanged across the window AND head
+    /// age above threshold, while not syncing (a syncing node legitimately
+    /// has an old head).
+    fn eval_block_stall(&self, now: u64, s: &MetricsSnapshot) -> (bool, String) {
+        if s.syncing == Some(true) {
+            return (false, "node is syncing".into());
+        }
+        let (Some(height), Some(age)) = (s.block_height, s.time_since_last_block_secs) else {
+            return (false, "height/head-age series missing".into());
+        };
+        let Some(base) = self.point_at_or_before(now.saturating_sub(self.cfg.stall_window_secs))
+        else {
+            return (false, "warming up (window not covered)".into());
+        };
+        match base.height {
+            Some(base_height) if base_height == height && age > self.cfg.stall_threshold_secs => (
+                true,
+                format!(
+                    "height {height} unchanged for >={}s, head age {age:.0}s (threshold {}s), syncing=0",
+                    now.saturating_sub(base.at),
+                    self.cfg.stall_threshold_secs
+                ),
+            ),
+            _ => (
+                false,
+                format!("height {height}, head age {age:.0}s"),
+            ),
+        }
+    }
+
+    /// Stuck sync: syncing at both ends of the window and lag has not
+    /// decreased (lag > 0).
+    fn eval_stuck_sync(&self, now: u64, s: &MetricsSnapshot) -> (bool, String) {
+        if s.syncing != Some(true) {
+            return (false, "not syncing".into());
+        }
+        let Some(lag_now) = s.sync_lag_blocks else {
+            return (false, "lag series missing".into());
+        };
+        let Some(base) = self.point_at_or_before(now.saturating_sub(self.cfg.sync_window_secs))
+        else {
+            return (false, "warming up (window not covered)".into());
+        };
+        match (base.syncing, base.lag) {
+            (Some(true), Some(lag_then)) if lag_now >= lag_then && lag_now > 0 => (
+                true,
+                format!(
+                    "syncing=1 and lag not decreasing over {}s: {lag_then} -> {lag_now} blocks",
+                    now.saturating_sub(base.at)
+                ),
+            ),
+            _ => (false, format!("syncing, lag {lag_now} blocks")),
+        }
+    }
+
+    /// Compaction stall, three triggers in order of severity:
+    /// 1. hard: `qfc_rocksdb_write_stopped == 1` (immediate);
+    /// 2. soft: delayed-write rate > 0 continuously for the sustain window;
+    /// 3. debt: pending-compaction bytes above the floor AND growing over
+    ///    the compaction window.
+    fn eval_compaction_stall(&self, now: u64, s: &MetricsSnapshot) -> (bool, String) {
+        if s.write_stopped == Some(true) {
+            return (
+                true,
+                "qfc_rocksdb_write_stopped=1 (hard write stall, block import blocked)".into(),
+            );
+        }
+
+        if let Some(rate_now) = s.delayed_write_rate {
+            if rate_now > 0.0 {
+                let cutoff = now.saturating_sub(self.cfg.delayed_write_sustain_secs);
+                if let Some(base) = self.point_at_or_before(cutoff) {
+                    let sustained = base.delayed_rate.is_some_and(|r| r > 0.0)
+                        && self
+                            .history
+                            .iter()
+                            .filter(|p| p.at >= base.at)
+                            .all(|p| p.delayed_rate.is_some_and(|r| r > 0.0));
+                    if sustained {
+                        return (
+                            true,
+                            format!(
+                                "delayed write rate {rate_now:.0} B/s sustained for >={}s",
+                                self.cfg.delayed_write_sustain_secs
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+
+        if let Some(debt) = s.pending_compaction_bytes {
+            if debt > self.cfg.compaction_debt_bytes {
+                if let Some(base) =
+                    self.point_at_or_before(now.saturating_sub(self.cfg.compaction_window_secs))
+                {
+                    if let Some(debt_then) = base.pending_compaction {
+                        if debt > debt_then {
+                            return (
+                                true,
+                                format!(
+                                    "pending compaction bytes growing past threshold: \
+                                     {debt_then} -> {debt} (> {})",
+                                    self.cfg.compaction_debt_bytes
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        (false, "no write stall / compaction debt signal".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Healthy baseline snapshot; tests mutate the relevant fields.
+    fn snap() -> MetricsSnapshot {
+        MetricsSnapshot {
+            block_height: Some(100),
+            time_since_last_block_secs: Some(4.0),
+            syncing: Some(false),
+            sync_lag_blocks: Some(0),
+            write_stopped: Some(false),
+            delayed_write_rate: Some(0.0),
+            pending_compaction_bytes: Some(0),
+            snapshot_last_attempt_unix: None,
+            snapshot_last_success_unix: None,
+        }
+    }
+
+    fn engine() -> Engine {
+        Engine::new(DetectorConfig::default())
+    }
+
+    const T0: u64 = 1_000_000;
+
+    #[test]
+    fn from_prometheus_reads_node_exporter_names() {
+        let text = "\
+qfc_block_height 42
+qfc_time_since_last_block_seconds 7.500
+qfc_sync_syncing 1
+qfc_sync_lag_blocks 13
+qfc_rocksdb_write_stopped 0
+qfc_rocksdb_actual_delayed_write_rate 1048576
+qfc_rocksdb_pending_compaction_bytes{cf=\"state\"} 1000
+qfc_rocksdb_pending_compaction_bytes{cf=\"blocks\"} 500
+qfc_snapshot_last_attempt_timestamp_seconds 1765000100
+qfc_snapshot_last_success_timestamp_seconds 1765000000
+";
+        let s = MetricsSnapshot::from_prometheus(text);
+        assert_eq!(s.block_height, Some(42));
+        assert_eq!(s.time_since_last_block_secs, Some(7.5));
+        assert_eq!(s.syncing, Some(true));
+        assert_eq!(s.sync_lag_blocks, Some(13));
+        assert_eq!(s.write_stopped, Some(false));
+        assert_eq!(s.delayed_write_rate, Some(1_048_576.0));
+        assert_eq!(s.pending_compaction_bytes, Some(1500)); // summed per-CF
+        assert_eq!(s.snapshot_last_attempt_unix, Some(1_765_000_100));
+        assert_eq!(s.snapshot_last_success_unix, Some(1_765_000_000));
+    }
+
+    #[test]
+    fn from_prometheus_missing_series_are_none() {
+        let s = MetricsSnapshot::from_prometheus("qfc_block_height 1\n");
+        assert_eq!(s.block_height, Some(1));
+        assert_eq!(s.syncing, None);
+        assert_eq!(s.snapshot_last_attempt_unix, None);
+        assert_eq!(s.pending_compaction_bytes, None);
+    }
+
+    #[test]
+    fn healthy_node_scores_100_and_nothing_fires() {
+        let mut e = engine();
+        for i in 0..20 {
+            let mut s = snap();
+            s.block_height = Some(100 + i); // producing
+            let eval = e.evaluate(T0 + i * 15, Some(&s), true);
+            assert_eq!(eval.health_score, 100);
+            assert!(eval.detectors.iter().all(|d| !d.firing));
+        }
+    }
+
+    #[test]
+    fn block_stall_fires_after_window_and_clears_on_new_block() {
+        let mut e = engine();
+        // Height frozen at 100, head age growing past the threshold.
+        let mut fired_at = None;
+        for i in 0..20u64 {
+            let now = T0 + i * 15;
+            let mut s = snap();
+            s.time_since_last_block_secs = Some(4.0 + (i * 15) as f64);
+            let eval = e.evaluate(now, Some(&s), true);
+            if eval.firing(DetectorId::BlockProductionStall) && fired_at.is_none() {
+                fired_at = Some(i);
+                // fire transition is reported exactly once
+                assert!(eval
+                    .transitions
+                    .iter()
+                    .any(|t| t.id == DetectorId::BlockProductionStall && t.firing));
+                assert_eq!(eval.health_score, 60);
+            }
+        }
+        // Needs BOTH height-unchanged window (120s) and head age > 120s:
+        // age passes 120 at i=8 (4+120=124), window covered well before.
+        assert_eq!(fired_at, Some(8));
+
+        // New block arrives: height advances, head age resets -> clears.
+        let mut s = snap();
+        s.block_height = Some(101);
+        s.time_since_last_block_secs = Some(1.0);
+        let eval = e.evaluate(T0 + 20 * 15, Some(&s), true);
+        assert!(!eval.firing(DetectorId::BlockProductionStall));
+        assert!(eval
+            .transitions
+            .iter()
+            .any(|t| t.id == DetectorId::BlockProductionStall && !t.firing));
+        assert_eq!(eval.health_score, 100);
+    }
+
+    #[test]
+    fn block_stall_does_not_fire_while_syncing() {
+        let mut e = engine();
+        for i in 0..20u64 {
+            let mut s = snap();
+            s.syncing = Some(true);
+            s.sync_lag_blocks = Some(500u64.saturating_sub(i * 50)); // catching up
+            s.time_since_last_block_secs = Some(10_000.0); // old head is normal during sync
+            let eval = e.evaluate(T0 + i * 15, Some(&s), true);
+            assert!(
+                !eval.firing(DetectorId::BlockProductionStall),
+                "must not fire while syncing (poll {i})"
+            );
+        }
+    }
+
+    #[test]
+    fn block_stall_requires_covered_window() {
+        let mut e = engine();
+        let mut s = snap();
+        s.time_since_last_block_secs = Some(500.0); // way past threshold
+                                                    // First poll: no baseline yet -> warming up, must not fire.
+        let eval = e.evaluate(T0, Some(&s), true);
+        assert!(!eval.firing(DetectorId::BlockProductionStall));
+    }
+
+    #[test]
+    fn stuck_sync_fires_when_lag_flat_and_clears_when_decreasing() {
+        let mut e = engine();
+        // Lag pinned at 200 while syncing: fires once the 300s window is covered.
+        let mut fired = false;
+        for i in 0..30u64 {
+            let mut s = snap();
+            s.syncing = Some(true);
+            s.sync_lag_blocks = Some(200);
+            s.time_since_last_block_secs = Some(600.0);
+            let eval = e.evaluate(T0 + i * 15, Some(&s), true);
+            if i * 15 >= 300 {
+                assert!(eval.firing(DetectorId::StuckSync), "poll {i}");
+                fired = true;
+            } else {
+                assert!(!eval.firing(DetectorId::StuckSync), "poll {i}");
+            }
+        }
+        assert!(fired);
+
+        // Lag starts decreasing -> clears immediately.
+        let mut s = snap();
+        s.syncing = Some(true);
+        s.sync_lag_blocks = Some(150);
+        let eval = e.evaluate(T0 + 30 * 15, Some(&s), true);
+        assert!(!eval.firing(DetectorId::StuckSync));
+    }
+
+    #[test]
+    fn stuck_sync_never_fires_when_not_syncing() {
+        let mut e = engine();
+        for i in 0..30u64 {
+            let mut s = snap();
+            s.sync_lag_blocks = Some(200); // lag without syncing flag
+            let eval = e.evaluate(T0 + i * 15, Some(&s), true);
+            assert!(!eval.firing(DetectorId::StuckSync));
+        }
+    }
+
+    #[test]
+    fn compaction_stall_fires_immediately_on_write_stopped() {
+        let mut e = engine();
+        let mut s = snap();
+        s.write_stopped = Some(true);
+        // Immediate: no window needed for the hard-stop signal.
+        let eval = e.evaluate(T0, Some(&s), true);
+        assert!(eval.firing(DetectorId::CompactionStall));
+        assert!(eval
+            .status(DetectorId::CompactionStall)
+            .evidence
+            .contains("write_stopped=1"));
+    }
+
+    #[test]
+    fn compaction_stall_fires_on_sustained_delayed_writes_only() {
+        let mut e = engine();
+        // Blip: delayed for one poll, then clean -> never fires.
+        let mut s = snap();
+        s.delayed_write_rate = Some(1000.0);
+        assert!(!e
+            .evaluate(T0, Some(&s), true)
+            .firing(DetectorId::CompactionStall));
+        for i in 1..10u64 {
+            let eval = e.evaluate(T0 + i * 15, Some(&snap()), true);
+            assert!(!eval.firing(DetectorId::CompactionStall));
+        }
+
+        // Sustained: delayed continuously for >= 120s -> fires.
+        let base = T0 + 1000;
+        let mut fired_at = None;
+        for i in 0..12u64 {
+            let mut s = snap();
+            s.delayed_write_rate = Some(2_000_000.0);
+            let eval = e.evaluate(base + i * 15, Some(&s), true);
+            if eval.firing(DetectorId::CompactionStall) && fired_at.is_none() {
+                fired_at = Some(i * 15);
+            }
+        }
+        assert_eq!(
+            fired_at,
+            Some(120),
+            "fires once the sustain window is covered"
+        );
+    }
+
+    #[test]
+    fn compaction_stall_fires_on_growing_debt_past_threshold() {
+        let cfg = DetectorConfig {
+            compaction_debt_bytes: 1_000_000,
+            compaction_window_secs: 60,
+            ..Default::default()
+        };
+        let mut e = Engine::new(cfg);
+        // Debt high but flat -> no fire (steady-state big DB is fine).
+        for i in 0..10u64 {
+            let mut s = snap();
+            s.pending_compaction_bytes = Some(2_000_000);
+            let eval = e.evaluate(T0 + i * 15, Some(&s), true);
+            assert!(
+                !eval.firing(DetectorId::CompactionStall),
+                "flat debt, poll {i}"
+            );
+        }
+        // Debt growing while above threshold -> fires.
+        let mut s = snap();
+        s.pending_compaction_bytes = Some(3_000_000);
+        let eval = e.evaluate(T0 + 10 * 15, Some(&s), true);
+        assert!(eval.firing(DetectorId::CompactionStall));
+        assert!(eval
+            .status(DetectorId::CompactionStall)
+            .evidence
+            .contains("growing"));
+    }
+
+    #[test]
+    fn metrics_down_after_n_consecutive_failures_and_clears() {
+        let mut e = engine();
+        e.evaluate(T0, Some(&snap()), true);
+        let eval = e.evaluate(T0 + 15, None, true);
+        assert!(!eval.firing(DetectorId::MetricsDown), "1 failure");
+        let eval = e.evaluate(T0 + 30, None, true);
+        assert!(!eval.firing(DetectorId::MetricsDown), "2 failures");
+        let eval = e.evaluate(T0 + 45, None, true);
+        assert!(
+            eval.firing(DetectorId::MetricsDown),
+            "3rd consecutive failure"
+        );
+        assert_eq!(eval.health_score, 70);
+        // One success resets.
+        let eval = e.evaluate(T0 + 60, Some(&snap()), true);
+        assert!(!eval.firing(DetectorId::MetricsDown));
+    }
+
+    #[test]
+    fn rpc_down_after_n_consecutive_failures() {
+        let mut e = engine();
+        let mut eval = e.evaluate(T0, Some(&snap()), false);
+        for i in 1..3u64 {
+            eval = e.evaluate(T0 + i * 15, Some(&snap()), false);
+        }
+        assert!(eval.firing(DetectorId::RpcDown));
+        eval = e.evaluate(T0 + 45, Some(&snap()), true);
+        assert!(!eval.firing(DetectorId::RpcDown));
+    }
+
+    #[test]
+    fn node_state_detectors_freeze_during_scrape_failures() {
+        let mut e = engine();
+        // Drive block stall to firing with consecutive count.
+        for i in 0..10u64 {
+            let mut s = snap();
+            s.time_since_last_block_secs = Some(4.0 + (i * 30) as f64);
+            e.evaluate(T0 + i * 30, Some(&s), true);
+        }
+        let mut s = snap();
+        s.time_since_last_block_secs = Some(400.0);
+        let eval = e.evaluate(T0 + 300, Some(&s), true);
+        assert!(eval.firing(DetectorId::BlockProductionStall));
+        let consec = eval
+            .status(DetectorId::BlockProductionStall)
+            .consecutive_firing;
+        assert!(consec >= 1);
+
+        // Scrape failures: still firing, but the counter must not advance.
+        let eval = e.evaluate(T0 + 315, None, true);
+        assert!(eval.firing(DetectorId::BlockProductionStall));
+        assert_eq!(
+            eval.status(DetectorId::BlockProductionStall)
+                .consecutive_firing,
+            consec,
+            "consecutive count frozen while blind"
+        );
+        assert!(eval.transitions.is_empty(), "no transitions while frozen");
+    }
+
+    #[test]
+    fn health_score_clamps_at_zero_with_everything_firing() {
+        let mut e = engine();
+        // Stalled + write-stopped node, both probes dead after warmup.
+        for i in 0..10u64 {
+            let mut s = snap();
+            s.time_since_last_block_secs = Some(4.0 + (i * 60) as f64);
+            s.write_stopped = Some(true);
+            e.evaluate(T0 + i * 60, Some(&s), true);
+        }
+        for i in 0..3u64 {
+            e.evaluate(T0 + 600 + i * 15, None, false);
+        }
+        let eval = e.evaluate(T0 + 645, None, false);
+        assert!(eval.firing(DetectorId::BlockProductionStall)); // frozen firing
+        assert!(eval.firing(DetectorId::CompactionStall)); // frozen firing
+        assert!(eval.firing(DetectorId::MetricsDown));
+        assert!(eval.firing(DetectorId::RpcDown));
+        assert_eq!(eval.health_score, 0); // 40+25+30+30 > 100, clamped
+    }
+
+    #[test]
+    fn snapshot_and_syncing_context_carry_across_scrape_failures() {
+        let mut e = engine();
+        let mut s = snap();
+        s.snapshot_last_attempt_unix = Some(T0 - 10);
+        s.snapshot_last_success_unix = Some(T0 - 100);
+        s.syncing = Some(true);
+        e.evaluate(T0, Some(&s), true);
+        let eval = e.evaluate(T0 + 15, None, true);
+        assert_eq!(eval.snapshot_last_attempt_unix, Some(T0 - 10));
+        assert_eq!(eval.snapshot_last_success_unix, Some(T0 - 100));
+        assert_eq!(eval.syncing, Some(true));
+    }
+
+    #[test]
+    fn detector_id_round_trips_from_str() {
+        for id in DetectorId::ALL {
+            assert_eq!(id.as_str().parse::<DetectorId>().unwrap(), id);
+        }
+        assert!("bogus".parse::<DetectorId>().is_err());
+    }
+}

--- a/crates/qfc-watchdog/src/exporter.rs
+++ b/crates/qfc-watchdog/src/exporter.rs
@@ -1,0 +1,242 @@
+//! The watchdog's own Prometheus endpoint (`--watchdog-metrics-addr`).
+//!
+//! Hand-rendered text format on a tiny_http background thread, exactly like
+//! qfc-node's exporter — so the watchdog watching a node is itself watchable
+//! (and the qfc-watchdog alert group in docs/observability/alert-rules.yaml
+//! has something to scrape).
+
+use crate::detector::{DetectorId, Evaluation};
+use parking_lot::Mutex;
+use std::fmt::Write as _;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tracing::{error, info};
+
+#[derive(Default)]
+pub struct WatchdogMetrics {
+    /// 0–100 aggregate health of the watched node (100 until the first poll).
+    pub health_score: AtomicU64,
+    pub polls_total: AtomicU64,
+    pub scrape_failures_total: AtomicU64,
+    pub rpc_probe_failures_total: AtomicU64,
+    pub actions_total: AtomicU64,
+    pub action_failures_total: AtomicU64,
+    /// 1 while an action is wanted but the hourly budget is spent.
+    pub action_budget_exhausted: AtomicU64,
+    /// Unix time of the last executed action (0 = none since start).
+    pub action_last_unix: AtomicU64,
+    /// 1 when --action-cmd is configured (set once at startup).
+    pub action_mode_enabled: AtomicU64,
+    detector_firing: Mutex<Vec<(&'static str, bool)>>,
+}
+
+impl WatchdogMetrics {
+    pub fn new(action_mode_enabled: bool) -> Self {
+        Self {
+            health_score: AtomicU64::new(100),
+            action_mode_enabled: AtomicU64::new(u64::from(action_mode_enabled)),
+            detector_firing: Mutex::new(
+                DetectorId::ALL
+                    .iter()
+                    .map(|d| (d.as_str(), false))
+                    .collect(),
+            ),
+            ..Default::default()
+        }
+    }
+
+    /// Push the result of one poll into the exported gauges.
+    pub fn record_evaluation(&self, eval: &Evaluation) {
+        self.health_score
+            .store(u64::from(eval.health_score), Ordering::Relaxed);
+        let mut firing = self.detector_firing.lock();
+        firing.clear();
+        firing.extend(eval.detectors.iter().map(|d| (d.id.as_str(), d.firing)));
+    }
+
+    pub fn render(&self) -> String {
+        let mut out = String::with_capacity(2048);
+
+        let score = self.health_score.load(Ordering::Relaxed);
+        let _ = writeln!(
+            out,
+            "# HELP qfc_watchdog_health_score Aggregate health of the watched node, 0-100 (100 = no detector firing)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_watchdog_health_score gauge");
+        let _ = writeln!(out, "qfc_watchdog_health_score {score}");
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_watchdog_detector_firing Whether each watchdog detector is currently firing (0/1)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_watchdog_detector_firing gauge");
+        for (name, firing) in self.detector_firing.lock().iter() {
+            let _ = writeln!(
+                out,
+                "qfc_watchdog_detector_firing{{detector=\"{name}\"}} {}",
+                u8::from(*firing)
+            );
+        }
+
+        let counters: &[(&str, &AtomicU64, &str)] = &[
+            (
+                "qfc_watchdog_polls_total",
+                &self.polls_total,
+                "Poll cycles executed.",
+            ),
+            (
+                "qfc_watchdog_scrape_failures_total",
+                &self.scrape_failures_total,
+                "Failed scrapes of the watched node's /metrics endpoint.",
+            ),
+            (
+                "qfc_watchdog_rpc_probe_failures_total",
+                &self.rpc_probe_failures_total,
+                "Failed eth_blockNumber probes against the watched node's RPC port.",
+            ),
+            (
+                "qfc_watchdog_actions_total",
+                &self.actions_total,
+                "Remediation actions executed (action mode only; every one is also logged with evidence).",
+            ),
+            (
+                "qfc_watchdog_action_failures_total",
+                &self.action_failures_total,
+                "Remediation actions whose command exited non-zero or failed to spawn.",
+            ),
+        ];
+        for (name, v, help) in counters {
+            let _ = writeln!(out, "# HELP {name} {help}");
+            let _ = writeln!(out, "# TYPE {name} counter");
+            let _ = writeln!(out, "{name} {}", v.load(Ordering::Relaxed));
+        }
+
+        let gauges: &[(&str, &AtomicU64, &str)] = &[
+            (
+                "qfc_watchdog_action_budget_exhausted",
+                &self.action_budget_exhausted,
+                "1 while an action is wanted but --max-actions-per-hour is spent (human needed).",
+            ),
+            (
+                "qfc_watchdog_action_last_timestamp_seconds",
+                &self.action_last_unix,
+                "Unix time of the last executed action (0 = none since watchdog start).",
+            ),
+            (
+                "qfc_watchdog_action_mode_enabled",
+                &self.action_mode_enabled,
+                "1 when --action-cmd is configured, 0 in detection-only mode.",
+            ),
+        ];
+        for (name, v, help) in gauges {
+            let _ = writeln!(out, "# HELP {name} {help}");
+            let _ = writeln!(out, "# TYPE {name} gauge");
+            let _ = writeln!(out, "{name} {}", v.load(Ordering::Relaxed));
+        }
+
+        let version = env!("CARGO_PKG_VERSION");
+        let _ = writeln!(
+            out,
+            "# HELP qfc_watchdog_info Watchdog metadata as labels. Value is always 1."
+        );
+        let _ = writeln!(out, "# TYPE qfc_watchdog_info gauge");
+        let _ = writeln!(out, "qfc_watchdog_info{{version=\"{version}\"}} 1");
+
+        out
+    }
+}
+
+/// Spawn the watchdog's own metrics HTTP server on a background thread
+/// (same pattern as qfc-node's MetricsServer::start).
+pub fn serve(addr: SocketAddr, metrics: Arc<WatchdogMetrics>) {
+    std::thread::spawn(move || {
+        let server = match tiny_http::Server::http(addr) {
+            Ok(s) => s,
+            Err(e) => {
+                error!("Failed to start watchdog metrics server on {}: {}", addr, e);
+                return;
+            }
+        };
+        info!(
+            "Watchdog metrics server listening on http://{}/metrics",
+            addr
+        );
+
+        for request in server.incoming_requests() {
+            if request.url() != "/metrics" {
+                let resp = tiny_http::Response::from_string("Not Found\n")
+                    .with_status_code(404)
+                    .with_header(
+                        "Content-Type: text/plain"
+                            .parse::<tiny_http::Header>()
+                            .unwrap(),
+                    );
+                let _ = request.respond(resp);
+                continue;
+            }
+            let body = metrics.render();
+            let resp = tiny_http::Response::from_string(&body).with_header(
+                "Content-Type: text/plain; version=0.0.4; charset=utf-8"
+                    .parse::<tiny_http::Header>()
+                    .unwrap(),
+            );
+            let _ = request.respond(resp);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detector::{DetectorConfig, Engine};
+
+    /// The exporter output must contain every metric name referenced by the
+    /// qfc-watchdog group in docs/observability/alert-rules.yaml.
+    #[test]
+    fn render_includes_expected_metric_names() {
+        let m = WatchdogMetrics::new(true);
+        let out = m.render();
+        for name in [
+            "qfc_watchdog_health_score",
+            "qfc_watchdog_detector_firing",
+            "qfc_watchdog_polls_total",
+            "qfc_watchdog_scrape_failures_total",
+            "qfc_watchdog_rpc_probe_failures_total",
+            "qfc_watchdog_actions_total",
+            "qfc_watchdog_action_failures_total",
+            "qfc_watchdog_action_budget_exhausted",
+            "qfc_watchdog_action_last_timestamp_seconds",
+            "qfc_watchdog_action_mode_enabled",
+            "qfc_watchdog_info",
+        ] {
+            assert!(out.contains(name), "missing metric `{name}`:\n{out}");
+        }
+        // One firing gauge per detector, all initially 0.
+        for id in DetectorId::ALL {
+            assert!(out.contains(&format!(
+                "qfc_watchdog_detector_firing{{detector=\"{id}\"}} 0"
+            )));
+        }
+        assert!(out.contains("qfc_watchdog_health_score 100"));
+        assert!(out.contains("qfc_watchdog_action_mode_enabled 1"));
+    }
+
+    #[test]
+    fn record_evaluation_updates_score_and_detector_gauges() {
+        let m = WatchdogMetrics::new(false);
+        let mut engine = Engine::new(DetectorConfig::default());
+        // Three consecutive total failures: metrics_down + rpc_down fire.
+        engine.evaluate(1_000_000, None, false);
+        engine.evaluate(1_000_015, None, false);
+        let eval = engine.evaluate(1_000_030, None, false);
+        m.record_evaluation(&eval);
+
+        let out = m.render();
+        assert!(out.contains("qfc_watchdog_health_score 40")); // 100 - 30 - 30
+        assert!(out.contains("qfc_watchdog_detector_firing{detector=\"metrics_down\"} 1"));
+        assert!(out.contains("qfc_watchdog_detector_firing{detector=\"rpc_down\"} 1"));
+        assert!(out.contains("qfc_watchdog_detector_firing{detector=\"block_production_stall\"} 0"));
+        assert!(out.contains("qfc_watchdog_action_mode_enabled 0"));
+    }
+}

--- a/crates/qfc-watchdog/src/gate.rs
+++ b/crates/qfc-watchdog/src/gate.rs
@@ -1,0 +1,417 @@
+//! Action gating — the part of T6 that keeps "self-healing" honest.
+//!
+//! Action mode is OFF unless `--action-cmd` is set, and even then every
+//! execution must pass ALL gates, checked in this order:
+//!
+//! 1. **trigger** — an action-eligible detector (default: block-production
+//!    stall only) has been firing for `--action-after-consecutive` evaluated
+//!    polls (default 3). No trigger → `Idle`.
+//! 2. **startup grace** — never within `--startup-grace-secs` of watchdog
+//!    start (default 120): give a freshly (re)started node/watchdog pair
+//!    time to settle.
+//! 3. **snapshot in-flight** — never while a snapshot backup appears to be
+//!    running (`last_attempt > last_success` and the attempt is recent):
+//!    restarting mid-checkpoint risks a corrupt archive upload.
+//! 4. **sync progressing** — never while the node is syncing and making
+//!    progress (syncing flag set and the stuck-sync detector NOT firing):
+//!    a catching-up node looks unhealthy but is healing itself.
+//! 5. **cooldown** — at least `--action-cooldown-secs` (default 600) after
+//!    any action: give the restarted node time to come back before judging.
+//! 6. **hourly budget** — at most `--max-actions-per-hour` (default 2) over
+//!    a sliding 1h window. Exhausted budget → `BudgetExhausted`: log loudly,
+//!    keep alerting, take no action. A flapping node needs a human.
+//!
+//! The clock is injected (`now_secs`) — gate logic is unit-tested with
+//! synthetic time, never sleeps.
+
+use crate::detector::{DetectorId, Evaluation};
+use std::collections::VecDeque;
+
+const BUDGET_WINDOW_SECS: u64 = 3600;
+
+/// Gate thresholds. All overridable from the CLI; defaults documented in
+/// docs/WATCHDOG.md.
+#[derive(Debug, Clone)]
+pub struct GateConfig {
+    /// Detectors allowed to trigger an action. Default: block-production
+    /// stall only — broaden it as automation earns trust.
+    pub eligible: Vec<DetectorId>,
+    /// Trigger only after this many consecutive firing polls. Default 3.
+    pub after_consecutive: u32,
+    /// Sliding-window action budget. Default 2 per hour.
+    pub max_actions_per_hour: u32,
+    /// Quiet period after any action. Default 600 s.
+    pub cooldown_secs: u64,
+    /// Quiet period after watchdog start. Default 120 s.
+    pub startup_grace_secs: u64,
+    /// How recent a not-yet-succeeded snapshot attempt must be to count as
+    /// "in flight". Default 1800 s.
+    pub snapshot_inflight_grace_secs: u64,
+}
+
+impl Default for GateConfig {
+    fn default() -> Self {
+        Self {
+            eligible: vec![DetectorId::BlockProductionStall],
+            after_consecutive: 3,
+            max_actions_per_hour: 2,
+            cooldown_secs: 600,
+            startup_grace_secs: 120,
+            snapshot_inflight_grace_secs: 1800,
+        }
+    }
+}
+
+/// Outcome of one gate evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// No eligible detector is past its consecutive-poll threshold.
+    Idle,
+    /// A trigger exists but a safety gate vetoed the action.
+    Hold { gate: &'static str, reason: String },
+    /// A trigger exists, every safety gate passed, but the hourly budget is
+    /// spent. Caller must log loudly and keep alerting only.
+    BudgetExhausted { evidence: String },
+    /// All gates passed — caller may execute the action, then must call
+    /// [`Gate::record_action`].
+    Act {
+        detector: DetectorId,
+        evidence: String,
+    },
+}
+
+/// Sliding-window action accounting + gate evaluation.
+pub struct Gate {
+    cfg: GateConfig,
+    started_at_secs: u64,
+    /// Times of executed actions within the budget window.
+    recent_actions: VecDeque<u64>,
+    last_action_at: Option<u64>,
+}
+
+impl Gate {
+    pub fn new(cfg: GateConfig, now_secs: u64) -> Self {
+        Self {
+            cfg,
+            started_at_secs: now_secs,
+            recent_actions: VecDeque::new(),
+            last_action_at: None,
+        }
+    }
+
+    pub fn decide(&mut self, now_secs: u64, eval: &Evaluation) -> Decision {
+        // Gate 1: trigger — eligible detector firing long enough.
+        let trigger = self.cfg.eligible.iter().find_map(|id| {
+            let st = eval.status(*id);
+            (st.firing && st.consecutive_firing >= self.cfg.after_consecutive)
+                .then(|| (st.id, st.evidence.clone()))
+        });
+        let Some((detector, evidence)) = trigger else {
+            return Decision::Idle;
+        };
+        let evidence = format!("{detector}: {evidence} | {}", eval.evidence_summary());
+
+        // Gate 2: startup grace.
+        let since_start = now_secs.saturating_sub(self.started_at_secs);
+        if since_start < self.cfg.startup_grace_secs {
+            return Decision::Hold {
+                gate: "startup-grace",
+                reason: format!(
+                    "watchdog started {since_start}s ago (< {}s grace)",
+                    self.cfg.startup_grace_secs
+                ),
+            };
+        }
+
+        // Gate 3: snapshot backup in flight.
+        if let Some(attempt) = eval.snapshot_last_attempt_unix {
+            let success = eval.snapshot_last_success_unix.unwrap_or(0);
+            let attempt_age = now_secs.saturating_sub(attempt);
+            if attempt > success && attempt_age < self.cfg.snapshot_inflight_grace_secs {
+                return Decision::Hold {
+                    gate: "snapshot-in-flight",
+                    reason: format!(
+                        "snapshot attempt {attempt_age}s ago has not succeeded yet \
+                         (last_attempt {attempt} > last_success {success})"
+                    ),
+                };
+            }
+        }
+
+        // Gate 4: sync progressing (syncing and NOT detectably stuck).
+        if eval.syncing == Some(true) && !eval.firing(DetectorId::StuckSync) {
+            return Decision::Hold {
+                gate: "sync-progressing",
+                reason: "node is syncing and not stuck — let it heal itself".to_string(),
+            };
+        }
+
+        // Gate 5: cooldown after the previous action.
+        if let Some(last) = self.last_action_at {
+            let since = now_secs.saturating_sub(last);
+            if since < self.cfg.cooldown_secs {
+                return Decision::Hold {
+                    gate: "cooldown",
+                    reason: format!(
+                        "last action {since}s ago (< {}s cooldown)",
+                        self.cfg.cooldown_secs
+                    ),
+                };
+            }
+        }
+
+        // Gate 6: sliding-window hourly budget.
+        self.prune(now_secs);
+        if self.recent_actions.len() as u32 >= self.cfg.max_actions_per_hour {
+            return Decision::BudgetExhausted { evidence };
+        }
+
+        Decision::Act { detector, evidence }
+    }
+
+    /// Record an executed action (call after running the command, success or
+    /// not — a failed restart attempt still spent a budget slot).
+    pub fn record_action(&mut self, now_secs: u64) {
+        self.recent_actions.push_back(now_secs);
+        self.last_action_at = Some(now_secs);
+    }
+
+    pub fn actions_in_window(&mut self, now_secs: u64) -> u32 {
+        self.prune(now_secs);
+        self.recent_actions.len() as u32
+    }
+
+    fn prune(&mut self, now_secs: u64) {
+        while let Some(&front) = self.recent_actions.front() {
+            if now_secs.saturating_sub(front) >= BUDGET_WINDOW_SECS {
+                self.recent_actions.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detector::{DetectorStatus, Evaluation};
+
+    const T0: u64 = 1_000_000;
+
+    /// Synthetic evaluation: `firing` detectors fire with the given
+    /// consecutive count; everything else is clear.
+    fn eval_with(firing: &[(DetectorId, u32)]) -> Evaluation {
+        let detectors = DetectorId::ALL
+            .iter()
+            .map(|id| {
+                let hit = firing.iter().find(|(f, _)| f == id);
+                DetectorStatus {
+                    id: *id,
+                    firing: hit.is_some(),
+                    consecutive_firing: hit.map(|(_, c)| *c).unwrap_or(0),
+                    evidence: format!("synthetic evidence for {id}"),
+                }
+            })
+            .collect();
+        Evaluation {
+            at_secs: T0,
+            detectors,
+            health_score: 100,
+            transitions: vec![],
+            syncing: Some(false),
+            snapshot_last_attempt_unix: None,
+            snapshot_last_success_unix: None,
+        }
+    }
+
+    /// Gate whose startup grace is already over at T0.
+    fn warm_gate(cfg: GateConfig) -> Gate {
+        let grace = cfg.startup_grace_secs;
+        Gate::new(cfg, T0.saturating_sub(grace))
+    }
+
+    fn stall(consecutive: u32) -> Evaluation {
+        eval_with(&[(DetectorId::BlockProductionStall, consecutive)])
+    }
+
+    #[test]
+    fn idle_when_nothing_fires() {
+        let mut g = warm_gate(GateConfig::default());
+        assert_eq!(g.decide(T0, &eval_with(&[])), Decision::Idle);
+    }
+
+    #[test]
+    fn idle_until_consecutive_threshold() {
+        let mut g = warm_gate(GateConfig::default());
+        assert_eq!(g.decide(T0, &stall(1)), Decision::Idle);
+        assert_eq!(g.decide(T0, &stall(2)), Decision::Idle);
+        assert!(matches!(g.decide(T0, &stall(3)), Decision::Act { .. }));
+    }
+
+    #[test]
+    fn idle_when_firing_detector_is_not_eligible() {
+        // Default eligible set is block-production stall ONLY: even a hard
+        // rocksdb stop or rpc-down must not trigger an action.
+        let mut g = warm_gate(GateConfig::default());
+        let eval = eval_with(&[
+            (DetectorId::CompactionStall, 100),
+            (DetectorId::RpcDown, 100),
+            (DetectorId::MetricsDown, 100),
+            (DetectorId::StuckSync, 100),
+        ]);
+        assert_eq!(g.decide(T0, &eval), Decision::Idle);
+    }
+
+    #[test]
+    fn configurable_eligible_set() {
+        let cfg = GateConfig {
+            eligible: vec![
+                DetectorId::BlockProductionStall,
+                DetectorId::CompactionStall,
+            ],
+            ..Default::default()
+        };
+        let mut g = warm_gate(cfg);
+        let d = g.decide(T0, &eval_with(&[(DetectorId::CompactionStall, 5)]));
+        match d {
+            Decision::Act { detector, .. } => assert_eq!(detector, DetectorId::CompactionStall),
+            other => panic!("expected Act, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn startup_grace_holds() {
+        let mut g = Gate::new(GateConfig::default(), T0); // started at T0
+        match g.decide(T0 + 60, &stall(10)) {
+            Decision::Hold { gate, .. } => assert_eq!(gate, "startup-grace"),
+            other => panic!("expected Hold, got {other:?}"),
+        }
+        // Grace over -> acts.
+        assert!(matches!(
+            g.decide(T0 + 120, &stall(10)),
+            Decision::Act { .. }
+        ));
+    }
+
+    #[test]
+    fn snapshot_in_flight_holds() {
+        let mut g = warm_gate(GateConfig::default());
+        let mut eval = stall(10);
+        // Attempt newer than success and recent -> in flight.
+        eval.snapshot_last_attempt_unix = Some(T0 - 60);
+        eval.snapshot_last_success_unix = Some(T0 - 4000);
+        match g.decide(T0, &eval) {
+            Decision::Hold { gate, .. } => assert_eq!(gate, "snapshot-in-flight"),
+            other => panic!("expected Hold, got {other:?}"),
+        }
+
+        // Attempt succeeded (success >= attempt) -> not in flight.
+        eval.snapshot_last_success_unix = Some(T0 - 60);
+        assert!(matches!(g.decide(T0, &eval), Decision::Act { .. }));
+
+        // Stale failed attempt (older than the grace) -> not in flight:
+        // a snapshot that has been "running" for 30+ min is itself wedged
+        // and must not veto recovery forever.
+        eval.snapshot_last_attempt_unix = Some(T0 - 2000);
+        eval.snapshot_last_success_unix = Some(T0 - 9000);
+        assert!(matches!(g.decide(T0, &eval), Decision::Act { .. }));
+    }
+
+    #[test]
+    fn no_snapshot_metrics_means_gate_passes() {
+        // Nodes without --snapshot-interval-secs export no qfc_snapshot_*.
+        let mut g = warm_gate(GateConfig::default());
+        assert!(matches!(g.decide(T0, &stall(3)), Decision::Act { .. }));
+    }
+
+    #[test]
+    fn sync_progressing_holds_but_stuck_sync_does_not() {
+        let cfg = GateConfig {
+            eligible: vec![DetectorId::BlockProductionStall, DetectorId::StuckSync],
+            ..Default::default()
+        };
+        let mut g = warm_gate(cfg);
+
+        // Syncing and not stuck: hold even with an eligible trigger.
+        let mut eval = stall(10);
+        eval.syncing = Some(true);
+        match g.decide(T0, &eval) {
+            Decision::Hold { gate, .. } => assert_eq!(gate, "sync-progressing"),
+            other => panic!("expected Hold, got {other:?}"),
+        }
+
+        // Syncing but provably stuck: the gate does not veto.
+        let mut eval = eval_with(&[(DetectorId::StuckSync, 10)]);
+        eval.syncing = Some(true);
+        assert!(matches!(g.decide(T0, &eval), Decision::Act { .. }));
+    }
+
+    #[test]
+    fn cooldown_holds_after_action() {
+        let mut g = warm_gate(GateConfig::default());
+        assert!(matches!(g.decide(T0, &stall(5)), Decision::Act { .. }));
+        g.record_action(T0);
+
+        match g.decide(T0 + 599, &stall(5)) {
+            Decision::Hold { gate, .. } => assert_eq!(gate, "cooldown"),
+            other => panic!("expected Hold, got {other:?}"),
+        }
+        // Cooldown elapsed (and budget has one slot left) -> acts again.
+        assert!(matches!(
+            g.decide(T0 + 600, &stall(5)),
+            Decision::Act { .. }
+        ));
+    }
+
+    #[test]
+    fn budget_exhausts_and_recovers_with_sliding_window() {
+        let mut g = warm_gate(GateConfig::default());
+
+        // Two actions spend the default budget (cooldown spaced).
+        assert!(matches!(g.decide(T0, &stall(5)), Decision::Act { .. }));
+        g.record_action(T0);
+        assert!(matches!(
+            g.decide(T0 + 600, &stall(5)),
+            Decision::Act { .. }
+        ));
+        g.record_action(T0 + 600);
+        assert_eq!(g.actions_in_window(T0 + 600), 2);
+
+        // Past cooldown, still inside the hour -> budget exhausted.
+        match g.decide(T0 + 1300, &stall(5)) {
+            Decision::BudgetExhausted { evidence } => {
+                assert!(evidence.contains("block_production_stall"))
+            }
+            other => panic!("expected BudgetExhausted, got {other:?}"),
+        }
+
+        // First action slides out of the window at T0+3600 -> one slot back.
+        assert!(matches!(
+            g.decide(T0 + 3600, &stall(5)),
+            Decision::Act { .. }
+        ));
+        assert_eq!(g.actions_in_window(T0 + 3600), 1);
+    }
+
+    #[test]
+    fn act_carries_detector_and_evidence() {
+        let mut g = warm_gate(GateConfig::default());
+        match g.decide(T0, &stall(3)) {
+            Decision::Act { detector, evidence } => {
+                assert_eq!(detector, DetectorId::BlockProductionStall);
+                assert!(evidence.contains("synthetic evidence"));
+                assert!(evidence.contains("health="));
+            }
+            other => panic!("expected Act, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gate_order_trigger_before_everything() {
+        // With no trigger, even inside startup grace the decision is Idle
+        // (gates are only consulted when something wants to act).
+        let mut g = Gate::new(GateConfig::default(), T0);
+        assert_eq!(g.decide(T0 + 1, &eval_with(&[])), Decision::Idle);
+    }
+}

--- a/crates/qfc-watchdog/src/lib.rs
+++ b/crates/qfc-watchdog/src/lib.rs
@@ -1,0 +1,33 @@
+//! qfc-watchdog — out-of-process, detection-first watchdog for one qfc-node
+//! (SRE roadmap item T6, docs/ROADMAP-SRE.md).
+//!
+//! Why out-of-process: a stalled or wedged node cannot restart itself — the
+//! watcher must live outside the process (and ideally outside the container)
+//! it watches. The watchdog observes a node purely through its public
+//! surfaces: the Prometheus metrics endpoint (`--metrics-addr`, default
+//! `:6060`) and the JSON-RPC port (`eth_blockNumber` probe). It never links
+//! against node internals, so a node that is alive enough to serve metrics
+//! is observed exactly as Prometheus would see it.
+//!
+//! Detection-first philosophy (per the roadmap's non-goals): the watchdog
+//! ships with action mode **off**. It detects, scores, exports its own
+//! metrics, and logs. Automated restarts only happen when explicitly enabled
+//! with `--action-cmd`, and every execution is gated by all of the safety
+//! gates in [`gate`]. Automation earns trust incrementally — see
+//! docs/WATCHDOG.md for the trust-escalation path.
+//!
+//! Module map:
+//! - [`prom`] — minimal Prometheus text-format parsing (no metrics library).
+//! - [`probe`] — plain-std HTTP probes for `/metrics` and the RPC port.
+//! - [`detector`] — the detector state machine + health score. Pure logic,
+//!   injectable clock (`now_secs`), unit-testable without sleeping.
+//! - [`gate`] — action gating (eligible set, consecutive polls, hourly
+//!   budget, cooldown, snapshot-in-flight, sync-progress, startup grace).
+//! - [`exporter`] — the watchdog's own `/metrics` endpoint, hand-rendered
+//!   text exactly like qfc-node's exporter.
+
+pub mod detector;
+pub mod exporter;
+pub mod gate;
+pub mod probe;
+pub mod prom;

--- a/crates/qfc-watchdog/src/main.rs
+++ b/crates/qfc-watchdog/src/main.rs
@@ -1,0 +1,387 @@
+//! qfc-watchdog binary — out-of-process, detection-first watchdog for one
+//! qfc-node (SRE T6). See docs/WATCHDOG.md for the design, detector catalog,
+//! gate semantics, and deployment examples.
+//!
+//! One watchdog watches one node; run N watchdogs for N nodes.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use qfc_watchdog::detector::{DetectorConfig, DetectorId, Engine, MetricsSnapshot};
+use qfc_watchdog::exporter::{self, WatchdogMetrics};
+use qfc_watchdog::gate::{Decision, Gate, GateConfig};
+use qfc_watchdog::probe;
+use std::net::SocketAddr;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::{error, info, warn, Level};
+use tracing_subscriber::FmtSubscriber;
+
+/// Out-of-process, detection-first watchdog for one qfc-node (SRE T6).
+///
+/// Watches a node through its Prometheus /metrics endpoint and RPC port,
+/// exports a health score + per-detector gauges on its own /metrics
+/// endpoint, and — only when --action-cmd is set — may execute a single
+/// remediation command behind strict safety gates.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Metrics endpoint of the watched node (qfc-node --metrics-addr).
+    #[arg(
+        long,
+        default_value = "127.0.0.1:6060",
+        env = "QFC_WATCHDOG_NODE_METRICS_ADDR"
+    )]
+    node_metrics_addr: SocketAddr,
+
+    /// RPC endpoint of the watched node (qfc-node --rpc-addr), probed with
+    /// eth_blockNumber.
+    #[arg(
+        long,
+        default_value = "127.0.0.1:8545",
+        env = "QFC_WATCHDOG_NODE_RPC_ADDR"
+    )]
+    node_rpc_addr: SocketAddr,
+
+    /// The watchdog's OWN Prometheus listen address.
+    #[arg(
+        long,
+        default_value = "0.0.0.0:6061",
+        env = "QFC_WATCHDOG_METRICS_ADDR"
+    )]
+    watchdog_metrics_addr: SocketAddr,
+
+    /// Seconds between polls.
+    #[arg(long, default_value_t = 15, env = "QFC_WATCHDOG_POLL_INTERVAL_SECS")]
+    poll_interval_secs: u64,
+
+    /// Timeout for each scrape / RPC probe.
+    #[arg(long, default_value_t = 5, env = "QFC_WATCHDOG_PROBE_TIMEOUT_SECS")]
+    probe_timeout_secs: u64,
+
+    /// Log level (error/warn/info/debug/trace).
+    #[arg(long, default_value = "info", env = "QFC_WATCHDOG_LOG_LEVEL")]
+    log_level: String,
+
+    // --- detector thresholds (defaults documented in docs/WATCHDOG.md) ---
+    /// Block-production stall: head age (s) above which a height-frozen,
+    /// non-syncing node counts as stalled.
+    #[arg(
+        long,
+        default_value_t = 120.0,
+        env = "QFC_WATCHDOG_STALL_THRESHOLD_SECS"
+    )]
+    stall_threshold_secs: f64,
+
+    /// Block-production stall: window (s) over which the height must be
+    /// unchanged.
+    #[arg(long, default_value_t = 120, env = "QFC_WATCHDOG_STALL_WINDOW_SECS")]
+    stall_window_secs: u64,
+
+    /// Stuck sync: window (s) over which sync lag must not decrease while
+    /// syncing.
+    #[arg(long, default_value_t = 300, env = "QFC_WATCHDOG_SYNC_WINDOW_SECS")]
+    sync_window_secs: u64,
+
+    /// Compaction stall: delayed-write rate must be >0 continuously for this
+    /// many seconds.
+    #[arg(
+        long,
+        default_value_t = 120,
+        env = "QFC_WATCHDOG_DELAYED_WRITE_SUSTAIN_SECS"
+    )]
+    delayed_write_sustain_secs: u64,
+
+    /// Compaction stall: pending-compaction debt floor in bytes (default
+    /// 8 GiB); debt must exceed this AND be growing.
+    #[arg(long, default_value_t = 8 * 1024 * 1024 * 1024, env = "QFC_WATCHDOG_COMPACTION_DEBT_BYTES")]
+    compaction_debt_bytes: u64,
+
+    /// Compaction stall: window (s) for the debt-growth comparison.
+    #[arg(
+        long,
+        default_value_t = 600,
+        env = "QFC_WATCHDOG_COMPACTION_WINDOW_SECS"
+    )]
+    compaction_window_secs: u64,
+
+    /// Consecutive failed /metrics scrapes before metrics-down fires.
+    #[arg(
+        long,
+        default_value_t = 3,
+        env = "QFC_WATCHDOG_METRICS_DOWN_CONSECUTIVE"
+    )]
+    metrics_down_consecutive: u32,
+
+    /// Consecutive failed RPC probes before rpc-down fires.
+    #[arg(long, default_value_t = 3, env = "QFC_WATCHDOG_RPC_DOWN_CONSECUTIVE")]
+    rpc_down_consecutive: u32,
+
+    // --- action mode (OFF by default: pure detection) ---
+    /// Shell command to run when an action-eligible detector passes ALL
+    /// safety gates, e.g. "docker restart qfc-node-1". Unset = detection-only
+    /// mode (the default and the recommended starting point).
+    #[arg(long, env = "QFC_WATCHDOG_ACTION_CMD")]
+    action_cmd: Option<String>,
+
+    /// Detectors allowed to trigger the action (comma-separated). Known:
+    /// block_production_stall, stuck_sync, compaction_stall, metrics_down,
+    /// rpc_down. Broaden only after the default has earned trust.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        default_value = "block_production_stall",
+        env = "QFC_WATCHDOG_ACTION_ELIGIBLE"
+    )]
+    action_eligible: Vec<DetectorId>,
+
+    /// Act only after the eligible detector has been firing for this many
+    /// consecutive polls.
+    #[arg(
+        long,
+        default_value_t = 3,
+        env = "QFC_WATCHDOG_ACTION_AFTER_CONSECUTIVE"
+    )]
+    action_after_consecutive: u32,
+
+    /// Sliding-window action budget. When spent, the watchdog logs loudly
+    /// and keeps alerting only.
+    #[arg(long, default_value_t = 2, env = "QFC_WATCHDOG_MAX_ACTIONS_PER_HOUR")]
+    max_actions_per_hour: u32,
+
+    /// Quiet period (s) after any action before another may run.
+    #[arg(long, default_value_t = 600, env = "QFC_WATCHDOG_ACTION_COOLDOWN_SECS")]
+    action_cooldown_secs: u64,
+
+    /// Never act within this many seconds of watchdog start.
+    #[arg(long, default_value_t = 120, env = "QFC_WATCHDOG_STARTUP_GRACE_SECS")]
+    startup_grace_secs: u64,
+
+    /// How recent a not-yet-succeeded snapshot-backup attempt must be to
+    /// count as in-flight (and veto actions).
+    #[arg(
+        long,
+        default_value_t = 1800,
+        env = "QFC_WATCHDOG_SNAPSHOT_INFLIGHT_GRACE_SECS"
+    )]
+    snapshot_inflight_grace_secs: u64,
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let level: Level = args.log_level.parse().unwrap_or(Level::INFO);
+    let subscriber = FmtSubscriber::builder().with_max_level(level).finish();
+    tracing::subscriber::set_global_default(subscriber).context("setting tracing subscriber")?;
+
+    info!(
+        node_metrics = %args.node_metrics_addr,
+        node_rpc = %args.node_rpc_addr,
+        poll_interval_secs = args.poll_interval_secs,
+        "qfc-watchdog starting (one watchdog watches one node)"
+    );
+    match &args.action_cmd {
+        Some(cmd) => warn!(
+            action_cmd = %cmd,
+            eligible = %args
+                .action_eligible
+                .iter()
+                .map(|d| d.as_str())
+                .collect::<Vec<_>>()
+                .join(","),
+            after_consecutive = args.action_after_consecutive,
+            max_actions_per_hour = args.max_actions_per_hour,
+            cooldown_secs = args.action_cooldown_secs,
+            startup_grace_secs = args.startup_grace_secs,
+            "ACTION MODE ENABLED — remediation command will run behind safety gates"
+        ),
+        None => info!("detection-only mode (no --action-cmd): alert + health score, never acts"),
+    }
+
+    let metrics = Arc::new(WatchdogMetrics::new(args.action_cmd.is_some()));
+    exporter::serve(args.watchdog_metrics_addr, metrics.clone());
+
+    let detector_cfg = DetectorConfig {
+        stall_threshold_secs: args.stall_threshold_secs,
+        stall_window_secs: args.stall_window_secs,
+        sync_window_secs: args.sync_window_secs,
+        delayed_write_sustain_secs: args.delayed_write_sustain_secs,
+        compaction_debt_bytes: args.compaction_debt_bytes,
+        compaction_window_secs: args.compaction_window_secs,
+        metrics_down_consecutive: args.metrics_down_consecutive,
+        rpc_down_consecutive: args.rpc_down_consecutive,
+    };
+    let mut engine = Engine::new(detector_cfg);
+
+    let mut gate = args.action_cmd.as_ref().map(|_| {
+        Gate::new(
+            GateConfig {
+                eligible: args.action_eligible.clone(),
+                after_consecutive: args.action_after_consecutive,
+                max_actions_per_hour: args.max_actions_per_hour,
+                cooldown_secs: args.action_cooldown_secs,
+                startup_grace_secs: args.startup_grace_secs,
+                snapshot_inflight_grace_secs: args.snapshot_inflight_grace_secs,
+            },
+            now_unix_secs(),
+        )
+    });
+
+    let timeout = Duration::from_secs(args.probe_timeout_secs.max(1));
+    let poll_interval = Duration::from_secs(args.poll_interval_secs.max(1));
+
+    loop {
+        poll_once(&args, &mut engine, gate.as_mut(), &metrics, timeout);
+        std::thread::sleep(poll_interval);
+    }
+}
+
+fn poll_once(
+    args: &Args,
+    engine: &mut Engine,
+    gate: Option<&mut Gate>,
+    metrics: &WatchdogMetrics,
+    timeout: Duration,
+) {
+    let now = now_unix_secs();
+    metrics.polls_total.fetch_add(1, Ordering::Relaxed);
+
+    let scrape = match probe::scrape_metrics(args.node_metrics_addr, timeout) {
+        Ok(text) => Some(MetricsSnapshot::from_prometheus(&text)),
+        Err(e) => {
+            metrics
+                .scrape_failures_total
+                .fetch_add(1, Ordering::Relaxed);
+            warn!(error = %e, "failed to scrape node /metrics");
+            None
+        }
+    };
+    let rpc_ok = match probe::rpc_probe(args.node_rpc_addr, timeout) {
+        Ok(_) => true,
+        Err(e) => {
+            metrics
+                .rpc_probe_failures_total
+                .fetch_add(1, Ordering::Relaxed);
+            warn!(error = %e, "RPC probe (eth_blockNumber) failed");
+            false
+        }
+    };
+
+    let eval = engine.evaluate(now, scrape.as_ref(), rpc_ok);
+
+    // Structured log lines on every fire/clear edge.
+    for t in &eval.transitions {
+        if t.firing {
+            warn!(
+                detector = %t.id,
+                evidence = %t.evidence,
+                health_score = eval.health_score,
+                "detector FIRED"
+            );
+        } else {
+            info!(
+                detector = %t.id,
+                evidence = %t.evidence,
+                health_score = eval.health_score,
+                "detector cleared"
+            );
+        }
+    }
+
+    metrics.record_evaluation(&eval);
+
+    let Some(gate) = gate else {
+        return; // detection-only mode
+    };
+
+    match gate.decide(now, &eval) {
+        Decision::Idle => {
+            metrics.action_budget_exhausted.store(0, Ordering::Relaxed);
+        }
+        Decision::Hold {
+            gate: which,
+            reason,
+        } => {
+            metrics.action_budget_exhausted.store(0, Ordering::Relaxed);
+            info!(gate = which, reason = %reason, "action wanted but held by safety gate");
+        }
+        Decision::BudgetExhausted { evidence } => {
+            metrics.action_budget_exhausted.store(1, Ordering::Relaxed);
+            error!(
+                evidence = %evidence,
+                max_actions_per_hour = args.max_actions_per_hour,
+                "ACTION BUDGET EXHAUSTED while node is unhealthy — automation is \
+                 standing down, a human must look (qfc_watchdog_action_budget_exhausted=1)"
+            );
+        }
+        Decision::Act { detector, evidence } => {
+            metrics.action_budget_exhausted.store(0, Ordering::Relaxed);
+            let cmd = args
+                .action_cmd
+                .as_deref()
+                .expect("gate exists only with action_cmd");
+            warn!(
+                detector = %detector,
+                action_cmd = %cmd,
+                evidence = %evidence,
+                "executing remediation action"
+            );
+            gate.record_action(now); // spent even if the command fails
+            metrics.actions_total.fetch_add(1, Ordering::Relaxed);
+            metrics.action_last_unix.store(now, Ordering::Relaxed);
+            match run_action(cmd) {
+                Ok((status_ok, output)) if status_ok => {
+                    info!(output = %output, "remediation action completed");
+                }
+                Ok((_, output)) => {
+                    metrics
+                        .action_failures_total
+                        .fetch_add(1, Ordering::Relaxed);
+                    error!(output = %output, "remediation action exited non-zero");
+                }
+                Err(e) => {
+                    metrics
+                        .action_failures_total
+                        .fetch_add(1, Ordering::Relaxed);
+                    error!(error = %e, "remediation action failed to spawn");
+                }
+            }
+        }
+    }
+}
+
+/// Run the action command through `sh -c`; returns (exit-ok, trimmed output).
+fn run_action(cmd: &str) -> Result<(bool, String)> {
+    let out = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(cmd)
+        .output()
+        .context("spawning action command")?;
+    let mut text = String::new();
+    text.push_str(String::from_utf8_lossy(&out.stdout).trim());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stderr = stderr.trim();
+    if !stderr.is_empty() {
+        if !text.is_empty() {
+            text.push_str(" | stderr: ");
+        } else {
+            text.push_str("stderr: ");
+        }
+        text.push_str(stderr);
+    }
+    if text.len() > 2000 {
+        let mut end = 2000;
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        text.truncate(end);
+    }
+    Ok((out.status.success(), text))
+}

--- a/crates/qfc-watchdog/src/probe.rs
+++ b/crates/qfc-watchdog/src/probe.rs
@@ -1,0 +1,81 @@
+//! Plain-std HTTP probes — no async runtime, no HTTP client dependency.
+//!
+//! Requests are sent as `HTTP/1.0` + `Connection: close`, which forbids
+//! chunked transfer encoding, so "read to EOF, split on the blank line" is a
+//! correct response parser for both tiny_http (node metrics) and hyper
+//! (jsonrpsee RPC).
+
+use anyhow::{anyhow, Context, Result};
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::time::Duration;
+
+fn http_exchange(addr: SocketAddr, request: &str, timeout: Duration) -> Result<String> {
+    let stream =
+        TcpStream::connect_timeout(&addr, timeout).with_context(|| format!("connect to {addr}"))?;
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
+    let mut stream = stream;
+    stream
+        .write_all(request.as_bytes())
+        .with_context(|| format!("write request to {addr}"))?;
+    let mut buf = String::new();
+    stream
+        .read_to_string(&mut buf)
+        .with_context(|| format!("read response from {addr}"))?;
+    let (head, body) = buf
+        .split_once("\r\n\r\n")
+        .ok_or_else(|| anyhow!("malformed HTTP response from {addr}"))?;
+    let status = head.lines().next().unwrap_or("");
+    if !status.contains(" 200") {
+        return Err(anyhow!("non-200 response from {addr}: {status}"));
+    }
+    Ok(body.to_string())
+}
+
+/// Scrape the node's Prometheus endpoint; returns the raw exposition text.
+pub fn scrape_metrics(addr: SocketAddr, timeout: Duration) -> Result<String> {
+    let request = format!("GET /metrics HTTP/1.0\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    http_exchange(addr, &request, timeout)
+}
+
+/// Probe the node's JSON-RPC port with `eth_blockNumber`; returns the height.
+pub fn rpc_probe(addr: SocketAddr, timeout: Duration) -> Result<u64> {
+    let payload = r#"{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}"#;
+    let request = format!(
+        "POST / HTTP/1.0\r\nHost: {addr}\r\nConnection: close\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{payload}",
+        payload.len()
+    );
+    let body = http_exchange(addr, &request, timeout)?;
+    parse_block_number(&body)
+}
+
+fn parse_block_number(body: &str) -> Result<u64> {
+    const MARKER: &str = r#""result":"0x"#;
+    let idx = body
+        .find(MARKER)
+        .ok_or_else(|| anyhow!("no hex result in RPC response: {body}"))?;
+    let hex = &body[idx + MARKER.len()..];
+    let end = hex
+        .find('"')
+        .ok_or_else(|| anyhow!("malformed RPC result: {body}"))?;
+    u64::from_str_radix(&hex[..end], 16).context("parse block number hex")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_eth_block_number_response() {
+        let body = r#"{"jsonrpc":"2.0","result":"0x1a4","id":1}"#;
+        assert_eq!(parse_block_number(body).unwrap(), 0x1a4);
+    }
+
+    #[test]
+    fn rejects_error_response() {
+        let body = r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"nope"},"id":1}"#;
+        assert!(parse_block_number(body).is_err());
+    }
+}

--- a/crates/qfc-watchdog/src/prom.rs
+++ b/crates/qfc-watchdog/src/prom.rs
@@ -1,0 +1,103 @@
+//! Minimal Prometheus text-format parsing — just enough to read the
+//! qfc-node exporter output. Deliberately not a metrics library: the
+//! watchdog needs exact-name lookups and per-label sums, nothing more.
+
+/// A parsed metrics exposition: `(metric name, value)` pairs with labels
+/// stripped. Multiple samples of the same name (one per label set) are all
+/// kept, so per-CF gauges can be summed.
+#[derive(Debug, Default)]
+pub struct MetricsText {
+    samples: Vec<(String, f64)>,
+}
+
+impl MetricsText {
+    pub fn parse(text: &str) -> Self {
+        let mut samples = Vec::new();
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            // `name value`, `name{labels} value`, optional trailing timestamp.
+            let (name, rest) = match line.find('{') {
+                Some(brace) => match line[brace..].find('}') {
+                    Some(close) => (&line[..brace], &line[brace + close + 1..]),
+                    None => continue,
+                },
+                None => match line.find(char::is_whitespace) {
+                    Some(ws) => (&line[..ws], &line[ws..]),
+                    None => continue,
+                },
+            };
+            let Some(value) = rest
+                .split_whitespace()
+                .next()
+                .and_then(|v| v.parse::<f64>().ok())
+            else {
+                continue;
+            };
+            samples.push((name.to_string(), value));
+        }
+        Self { samples }
+    }
+
+    /// First sample with this exact name. Use for unlabeled gauges.
+    pub fn value(&self, name: &str) -> Option<f64> {
+        self.samples
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| *v)
+    }
+
+    /// Sum of all samples with this name (`None` when the series is absent).
+    /// Use for labeled per-CF gauges like `qfc_rocksdb_pending_compaction_bytes`.
+    pub fn sum(&self, name: &str) -> Option<f64> {
+        let mut total = 0.0;
+        let mut found = false;
+        for (n, v) in &self.samples {
+            if n == name {
+                total += v;
+                found = true;
+            }
+        }
+        found.then_some(total)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_unlabeled_labeled_and_skips_comments() {
+        let text = "\
+# HELP qfc_block_height Current block height.
+# TYPE qfc_block_height gauge
+qfc_block_height 1234
+qfc_time_since_last_block_seconds 4.250
+
+qfc_rocksdb_pending_compaction_bytes{cf=\"state\"} 100
+qfc_rocksdb_pending_compaction_bytes{cf=\"blocks\"} 250
+qfc_node_info{version=\"2.2.3\"} 1
+garbage line without value
+qfc_bad_value not_a_number
+";
+        let m = MetricsText::parse(text);
+        assert_eq!(m.value("qfc_block_height"), Some(1234.0));
+        assert_eq!(m.value("qfc_time_since_last_block_seconds"), Some(4.25));
+        // Labeled series: value() returns the first sample, sum() adds all.
+        assert_eq!(m.value("qfc_rocksdb_pending_compaction_bytes"), Some(100.0));
+        assert_eq!(m.sum("qfc_rocksdb_pending_compaction_bytes"), Some(350.0));
+        assert_eq!(m.value("qfc_node_info"), Some(1.0));
+        assert_eq!(m.value("qfc_missing"), None);
+        assert_eq!(m.sum("qfc_missing"), None);
+        assert_eq!(m.value("qfc_bad_value"), None);
+    }
+
+    #[test]
+    fn handles_timestamps_and_whitespace() {
+        let m = MetricsText::parse("qfc_x  7 1700000000000\n\tqfc_y{a=\"b\"}\t3.5\n");
+        assert_eq!(m.value("qfc_x"), Some(7.0));
+        assert_eq!(m.value("qfc_y"), Some(3.5));
+    }
+}

--- a/crates/qfc-watchdog/tests/live_node.rs
+++ b/crates/qfc-watchdog/tests/live_node.rs
@@ -1,0 +1,122 @@
+//! Optional integration test: point the watchdog engine at a live dev node.
+//!
+//! Like the qfc-node integration tests, this needs the release binary
+//! (`cargo build --release -p qfc-node`). When it is not present the test
+//! skips instead of failing, so plain `cargo test -p qfc-watchdog` stays
+//! green on a fresh checkout.
+
+use qfc_watchdog::detector::{DetectorConfig, Engine, MetricsSnapshot};
+use qfc_watchdog::probe;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const RPC_PORT: u16 = 19720;
+const METRICS_PORT: u16 = 20720;
+
+fn release_node_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent() // crates/
+        .unwrap()
+        .parent() // workspace root
+        .unwrap()
+        .join("target/release/qfc-node")
+}
+
+struct NodeGuard {
+    child: Child,
+    _datadir: tempfile::TempDir,
+}
+
+impl Drop for NodeGuard {
+    fn drop(&mut self) {
+        self.child.kill().ok();
+        self.child.wait().ok();
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+#[test]
+fn watchdog_observes_live_dev_node_as_healthy() {
+    let binary = release_node_binary();
+    if !binary.exists() {
+        eprintln!(
+            "skipping live-node integration test: {} not built \
+             (run `cargo build --release -p qfc-node`)",
+            binary.display()
+        );
+        return;
+    }
+
+    let datadir = tempfile::tempdir().unwrap();
+    let child = Command::new(&binary)
+        .args([
+            "--dev",
+            "--no-network",
+            "--datadir",
+            datadir.path().to_str().unwrap(),
+            "--rpc-addr",
+            &format!("127.0.0.1:{RPC_PORT}"),
+            "--metrics-addr",
+            &format!("127.0.0.1:{METRICS_PORT}"),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn qfc-node");
+    let _guard = NodeGuard {
+        child,
+        _datadir: datadir,
+    };
+
+    let metrics_addr: SocketAddr = format!("127.0.0.1:{METRICS_PORT}").parse().unwrap();
+    let rpc_addr: SocketAddr = format!("127.0.0.1:{RPC_PORT}").parse().unwrap();
+    let timeout = Duration::from_secs(2);
+
+    // Wait for both surfaces to come up.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let metrics_up = probe::scrape_metrics(metrics_addr, timeout).is_ok();
+        let rpc_up = probe::rpc_probe(rpc_addr, timeout).is_ok();
+        if metrics_up && rpc_up {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "node endpoints did not come up within 30s (metrics_up={metrics_up}, rpc_up={rpc_up})"
+        );
+        std::thread::sleep(Duration::from_millis(500));
+    }
+
+    // A few real polls: a freshly started dev node must score 100 with no
+    // detector firing (windows not covered + node actually healthy).
+    let mut engine = Engine::new(DetectorConfig::default());
+    let mut last = None;
+    for _ in 0..3 {
+        let text = probe::scrape_metrics(metrics_addr, timeout).expect("scrape metrics");
+        assert!(
+            text.contains("qfc_block_height"),
+            "exporter output missing qfc_block_height:\n{text}"
+        );
+        let snap = MetricsSnapshot::from_prometheus(&text);
+        assert!(snap.block_height.is_some());
+        let rpc_ok = probe::rpc_probe(rpc_addr, timeout).is_ok();
+        last = Some(engine.evaluate(now_secs(), Some(&snap), rpc_ok));
+        std::thread::sleep(Duration::from_secs(1));
+    }
+    let eval = last.unwrap();
+    assert_eq!(
+        eval.health_score,
+        100,
+        "evidence: {}",
+        eval.evidence_summary()
+    );
+    assert!(eval.detectors.iter().all(|d| !d.firing));
+}

--- a/docs/WATCHDOG.md
+++ b/docs/WATCHDOG.md
@@ -1,0 +1,197 @@
+# qfc-watchdog — out-of-process, detection-first self-healing (T6)
+
+Implements [ROADMAP-SRE.md](ROADMAP-SRE.md) item **T6**: detect
+block-production stall, stuck sync, and compaction stall from the T2
+signals; **detection-first** (alert + health score); automated restart only
+behind explicit safety gates. Crate: `crates/qfc-watchdog`.
+
+## Design
+
+### Why out-of-process
+
+A stalled node cannot restart itself: if block import is wedged on a RocksDB
+write stop, or the process is deadlocked, any in-process "self-healing" task
+is wedged with it. The watchdog is therefore a **separate binary** (ideally a
+separate container) that observes a node purely through its public surfaces:
+
+- the Prometheus exporter (`qfc-node --metrics-addr`, default `:6060`) —
+  the same T2 metrics Prometheus scrapes, so watchdog and alerting can never
+  disagree about what they saw;
+- the JSON-RPC port (`--rpc-addr`, default `:8545`), probed with
+  `eth_blockNumber` — proves the node answers real client traffic, not just
+  its metrics thread.
+
+It never links node internals. **One watchdog watches one node**; run N
+watchdog sidecars for N nodes (state like sliding windows and the action
+budget is per-node by construction).
+
+### Detection-first philosophy
+
+Per the roadmap's non-goals: *no auto-remediation without gates — T6 stays
+detection-first until trust is earned*. Concretely:
+
+- The default mode is **pure detection**: health score + per-detector gauges
+  on the watchdog's own metrics endpoint, structured log lines on every
+  detector fire/clear, and the `qfc-watchdog` alert group in
+  [observability/alert-rules.yaml](observability/alert-rules.yaml).
+- Action mode must be explicitly enabled (`--action-cmd`), starts with the
+  narrowest possible trigger (block-production stall only), and every
+  execution must pass **all** safety gates below.
+- When the action budget is spent, automation stands down loudly
+  (`qfc_watchdog_action_budget_exhausted 1` + error log) and keeps alerting.
+  It never escalates its own privileges; a flapping node gets a human.
+
+## Detector catalog
+
+Evaluated once per poll (`--poll-interval-secs`, default 15 s) over sliding
+windows of scrape history. Each detector is a firing bool + an evidence
+string (logged on transitions, attached to any action).
+
+| Detector | Fires when | Tunables (default) | Health weight |
+|---|---|---|---|
+| `block_production_stall` | height unchanged over the window AND `qfc_time_since_last_block_seconds` > threshold AND not syncing | `--stall-threshold-secs` (120), `--stall-window-secs` (120) | 40 |
+| `stuck_sync` | `qfc_sync_syncing` = 1 at both window ends AND `qfc_sync_lag_blocks` has not decreased (lag > 0) | `--sync-window-secs` (300) | 15 |
+| `compaction_stall` | `qfc_rocksdb_write_stopped` = 1 (immediate); OR `qfc_rocksdb_actual_delayed_write_rate` > 0 continuously for the sustain window; OR Σ `qfc_rocksdb_pending_compaction_bytes` above the floor AND growing over the window | `--delayed-write-sustain-secs` (120), `--compaction-debt-bytes` (8 GiB), `--compaction-window-secs` (600) | 25 |
+| `metrics_down` | N consecutive failed scrapes of the node's `/metrics` | `--metrics-down-consecutive` (3) | 30 |
+| `rpc_down` | N consecutive failed `eth_blockNumber` probes | `--rpc-down-consecutive` (3) | 30 |
+
+Notes:
+
+- **Health score** = `100 − Σ(weights of firing detectors)`, clamped at 0,
+  exported as `qfc_watchdog_health_score`. Weights deliberately sum past 100
+  — a node with several detectors firing is simply score 0.
+- A syncing node legitimately has an old head, so `block_production_stall`
+  requires `syncing = 0`; `stuck_sync` covers the syncing case.
+- While the node's `/metrics` cannot be scraped, the three node-state
+  detectors **freeze**: they keep their last firing state but their
+  consecutive-poll counters stop advancing, so action gating cannot progress
+  while the watchdog is blind. `metrics_down` covers that situation.
+- A flat-but-large compaction debt does not fire (steady-state big DBs are
+  fine); the debt trigger needs *above floor AND growing*, mirroring
+  `QfcRocksdbCompactionBacklogGrowing`.
+
+Defaults are aligned with the existing alert rules
+(`QfcBlockProductionStalled` pages at head age 120 s;
+`QfcRocksdbCompactionBacklogGrowing` uses the 8 GiB floor).
+
+## Action mode and gate semantics
+
+OFF by default. Enabled by setting `--action-cmd '<shell command>'`, e.g.
+`docker restart qfc-node-1` or `systemctl restart qfc-node`. The command
+runs via `sh -c`; every execution is logged with a full evidence dump and
+counted (`qfc_watchdog_actions_total`).
+
+All gates must pass, checked in order:
+
+| # | Gate | Rule | Tunable (default) |
+|---|---|---|---|
+| 1 | trigger | an **action-eligible** detector (default: `block_production_stall` only) has been firing for K consecutive polls | `--action-eligible` (`block_production_stall`), `--action-after-consecutive` (3) |
+| 2 | startup grace | never within T of watchdog start | `--startup-grace-secs` (120) |
+| 3 | snapshot in-flight | never while a snapshot backup appears to be running: `qfc_snapshot_last_attempt_timestamp_seconds` > `..._last_success...` AND the attempt is recent | `--snapshot-inflight-grace-secs` (1800) |
+| 4 | sync progressing | never while the node is syncing and **not** detectably stuck (`stuck_sync` not firing) — a catching-up node is healing itself | — |
+| 5 | cooldown | at least T after any previous action | `--action-cooldown-secs` (600) |
+| 6 | hourly budget | at most N actions per sliding hour; when spent: error log + `qfc_watchdog_action_budget_exhausted 1`, **no action**, alerting continues | `--max-actions-per-hour` (2) |
+
+What action mode will **not** do:
+
+- act on any detector outside the configured eligible set (no "restart on
+  RPC blip");
+- act more than the budget allows, ever — exhausted budget means humans;
+- act while a snapshot might be writing, while sync is making progress, or
+  right after its own start;
+- retry instantly: a failed action still spends a budget slot and starts the
+  cooldown (a restart command that fails is exactly when you do not want a
+  tight loop).
+
+With defaults, the worst case is: a genuinely stalled producer is restarted
+after ~45 s of confirmed stall (3 × 15 s polls) — but no earlier than 120 s
+after watchdog start — at most twice per hour, ≥10 min apart.
+
+## Configuration
+
+CLI flags with `QFC_WATCHDOG_*` env equivalents (same clap conventions as
+`qfc-node`); `qfc-watchdog --help` is the authoritative list. Endpoints:
+
+| Flag | Env | Default |
+|---|---|---|
+| `--node-metrics-addr` | `QFC_WATCHDOG_NODE_METRICS_ADDR` | `127.0.0.1:6060` |
+| `--node-rpc-addr` | `QFC_WATCHDOG_NODE_RPC_ADDR` | `127.0.0.1:8545` |
+| `--watchdog-metrics-addr` | `QFC_WATCHDOG_METRICS_ADDR` | `0.0.0.0:6061` |
+| `--poll-interval-secs` | `QFC_WATCHDOG_POLL_INTERVAL_SECS` | `15` |
+| `--probe-timeout-secs` | `QFC_WATCHDOG_PROBE_TIMEOUT_SECS` | `5` |
+
+The watchdog's own metric inventory and Prometheus scrape config live in
+[observability/README.md](observability/README.md); the alert rules are the
+`qfc-watchdog` group in
+[observability/alert-rules.yaml](observability/alert-rules.yaml)
+(health score low → ticket; action taken → ticket; budget exhausted while
+unhealthy → page).
+
+## Deployment example (docker compose sidecar)
+
+One watchdog per node, outside the node container so it can restart it. For
+the restart action it needs the docker socket (or run detection-only and
+omit it):
+
+```yaml
+services:
+  qfc-node-1:
+    image: ghcr.io/qfc-network/qfc-node:latest
+    container_name: qfc-node-1
+    command: ["--metrics-addr", "0.0.0.0:6060", "--rpc-addr", "0.0.0.0:8545"]
+    ports: ["8545:8545", "6060:6060"]
+
+  qfc-watchdog-1:
+    image: ghcr.io/qfc-network/qfc-node:latest   # ships qfc-watchdog too
+    container_name: qfc-watchdog-1
+    entrypoint: ["qfc-watchdog"]
+    environment:
+      QFC_WATCHDOG_NODE_METRICS_ADDR: "qfc-node-1:6060"
+      QFC_WATCHDOG_NODE_RPC_ADDR: "qfc-node-1:8545"
+      # Step 2 of the trust path — leave unset for detection-only:
+      # QFC_WATCHDOG_ACTION_CMD: "docker restart qfc-node-1"
+    ports: ["6061:6061"]
+    # Only needed when the action command drives docker:
+    # volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+    restart: unless-stopped     # who watches the watchdog: the supervisor
+```
+
+For N nodes, repeat the sidecar with different `QFC_WATCHDOG_NODE_*` targets
+and a distinct `--watchdog-metrics-addr` port mapping, and add each `:6061`
+target to the `qfc-watchdog` Prometheus job.
+
+## Trust-escalation path
+
+Automation earns trust incrementally. Each step runs long enough to prove
+itself (suggested: ≥2 weeks or several real incidents) before the next:
+
+1. **Detection-only** (default). Deploy with no `--action-cmd`. Compare
+   `qfc_watchdog_detector_firing` against incidents: every real stall must
+   be caught, and false positives tuned out *here*, where they are free.
+2. **Action on block-production stall** (default eligible set). Enable
+   `--action-cmd` with the conservative default gates. Review every
+   `QfcWatchdogActionTaken` ticket: was the restart justified? did it fix
+   it? Tighten `--max-actions-per-hour` to 1 if confidence is low.
+3. **Broader detector set.** Add detectors to `--action-eligible` one at a
+   time as evidence accumulates that a restart actually cures them —
+   `compaction_stall` (a hard `write_stopped` rarely resolves without
+   intervention), then possibly `rpc_down`. `metrics_down` alone is a poor
+   restart trigger (often a network/scrape problem); prefer leaving it
+   detection-only.
+
+What stays out of scope at every step (roadmap non-goals): actions other
+than the single operator-supplied command, cross-node orchestration
+(that is T7 canary territory), and any gate-bypass "emergency" mode.
+
+## Implementation notes
+
+- No async runtime, no HTTP/metrics libraries: plain-std HTTP/1.0 probes and
+  a hand-rendered exporter on `tiny_http`, mirroring `qfc-node`'s own
+  `metrics.rs`.
+- Detector and gate logic take the clock as a parameter (`now_secs`), so all
+  windows, cooldowns, budgets, and grace periods are unit-tested against
+  synthetic metrics text and synthetic time — no sleeps in tests
+  (`cargo test -p qfc-watchdog`).
+- An optional integration test boots a real dev node and asserts the engine
+  scores it 100; like the qfc-node integration tests it requires
+  `target/release/qfc-node` and skips when absent.

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -63,6 +63,12 @@ and not exported, so the shipped numbers assume the recommended 1h interval
 `qfc_snapshot_*` series only exist on nodes started with
 `--snapshot-interval-secs`, so the rules are silent (no-data) elsewhere.
 
+The `qfc-watchdog` group (T6) watches the **watchdog's** own exporter (see
+the watchdog section at the bottom of this file) — scrape it as a separate
+`job_name: qfc-watchdog`. Its rules only produce data where a `qfc-watchdog`
+sidecar runs, and the action-related alerts only matter on nodes where action
+mode is enabled (`qfc_watchdog_action_mode_enabled 1`).
+
 The `qfc-rocksdb` group (T2.1) is active. Its property-based alerts
 (`QfcRocksdbWriteStopped`, `QfcRocksdbCompactionBacklog*`) work on every node;
 the stall-rate alert (`QfcRocksdbWriteStall`) only produces data on nodes
@@ -222,3 +228,35 @@ These are only exported when backups are enabled. Alert on age (see the
 `qfc-backup-freshness` group above); `..._last_success... == 0` plus a recent
 `..._last_attempt...` means runs are happening but failing — node logs carry
 the upload command's stderr.
+
+## Self-healing watchdog (T6) and its metrics
+
+`qfc-watchdog` (crates/qfc-watchdog) is an **out-of-process** sidecar that
+observes one node through this exporter plus an `eth_blockNumber` RPC probe,
+and serves its own hand-rendered Prometheus endpoint on
+`--watchdog-metrics-addr` (default `:6061`). Full design, detector catalog,
+gate semantics, and deployment examples: [docs/WATCHDOG.md](../WATCHDOG.md).
+
+Scrape config (one target per watchdog, one watchdog per node):
+
+```yaml
+scrape_configs:
+  - job_name: qfc-watchdog     # alert rules group `qfc-watchdog`
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["node-a:6061", "node-b:6061"]
+```
+
+| Metric | Type | Labels | Source |
+|---|---|---|---|
+| `qfc_watchdog_health_score` | gauge | — | 100 minus the weights of firing detectors (clamped at 0) |
+| `qfc_watchdog_detector_firing` | gauge (0/1) | `detector` | one series per detector (`block_production_stall`, `stuck_sync`, `compaction_stall`, `metrics_down`, `rpc_down`) |
+| `qfc_watchdog_polls_total` | counter | — | poll cycles executed |
+| `qfc_watchdog_scrape_failures_total` | counter | — | failed scrapes of the node's `/metrics` |
+| `qfc_watchdog_rpc_probe_failures_total` | counter | — | failed `eth_blockNumber` probes |
+| `qfc_watchdog_actions_total` | counter | — | remediation actions executed (action mode only) |
+| `qfc_watchdog_action_failures_total` | counter | — | actions whose command exited non-zero / failed to spawn |
+| `qfc_watchdog_action_budget_exhausted` | gauge (0/1) | — | 1 while an action is wanted but `--max-actions-per-hour` is spent |
+| `qfc_watchdog_action_last_timestamp_seconds` | gauge | — | unix time of the last action (0 = none since start) |
+| `qfc_watchdog_action_mode_enabled` | gauge (0/1) | — | whether `--action-cmd` is configured |
+| `qfc_watchdog_info` | gauge | `version` | build info |

--- a/docs/observability/alert-rules.yaml
+++ b/docs/observability/alert-rules.yaml
@@ -349,6 +349,72 @@ groups:
   # qfc_snapshot_last_success_timestamp_seconds is 0 until the first success
   # after process start, so a node whose backups never succeed fires these
   # alerts too (age evaluates to ~now). The `for:` window absorbs restarts.
+  # ----------------------------------------------------------- watchdog (T6)
+  # Metric source: crates/qfc-watchdog/src/exporter.rs — the OUT-OF-PROCESS
+  # watchdog's own /metrics endpoint (default :6061), one watchdog per node.
+  # Scrape it as its own job:
+  #
+  #   - job_name: qfc-watchdog
+  #     scrape_interval: 15s
+  #     static_configs:
+  #       - targets: ["node-a:6061", "node-b:6061"]
+  #
+  # Design (docs/WATCHDOG.md): detection-first. The health score aggregates
+  # the watchdog's detectors (block-production stall, stuck sync, compaction
+  # stall, metrics-down, rpc-down); each firing detector subtracts its weight
+  # from 100. Action mode is opt-in (--action-cmd) and hard-gated; the alerts
+  # below are the human side of those gates.
+  - name: qfc-watchdog
+    rules:
+      # Sustained sub-100 health = some detector has been firing for 15m.
+      # Ticket, not page: the per-cause pages (QfcBlockProductionStalled,
+      # QfcRocksdbWriteStopped, QfcNodeDown) already cover the acute cases —
+      # this is the watchdog's own aggregated view for triage.
+      - alert: QfcWatchdogHealthScoreLow
+        expr: qfc_watchdog_health_score < 100
+        for: 15m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Watchdog health score {{ $value }} on {{ $labels.instance }} for 15m"
+          description: >-
+            One or more watchdog detectors have been firing for 15 minutes.
+            Check qfc_watchdog_detector_firing == 1 for which, and the
+            watchdog logs for the evidence lines (detector FIRED entries).
+
+      # An automated restart happened. Always worth a look even when it
+      # worked: a node that needed restarting has an underlying problem, and
+      # automation that acts silently does not earn trust.
+      - alert: QfcWatchdogActionTaken
+        expr: increase(qfc_watchdog_actions_total[1h]) > 0
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Watchdog executed a remediation action on {{ $labels.instance }}"
+          description: >-
+            The watchdog ran its --action-cmd (e.g. a node restart). Verify
+            the node recovered (qfc_watchdog_health_score back at 100) and
+            read the evidence dump in the watchdog logs. Repeated actions on
+            the same node mean the restart is treating a symptom.
+
+      # Automation is out of budget AND the node is still unhealthy: the
+      # watchdog is standing down by design — a human must take over now.
+      - alert: QfcWatchdogActionBudgetExhausted
+        expr: |
+          qfc_watchdog_action_budget_exhausted == 1
+          and
+          qfc_watchdog_health_score < 100
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: "Watchdog action budget exhausted, node still unhealthy ({{ $labels.instance }})"
+          description: >-
+            The watchdog wants to act but --max-actions-per-hour is spent
+            (restarts are not fixing it). Automation will keep alerting only.
+            Investigate the node directly; the watchdog logs carry the full
+            evidence for every action taken this hour.
+
   - name: qfc-backup-freshness
     rules:
       - alert: QfcSnapshotBackupStale


### PR DESCRIPTION
Implements ROADMAP-SRE.md **T6** — self-healing watchdog, detection-first, automation strictly behind gates (per the roadmap non-goals: *no auto-remediation without gates; automation earns trust incrementally*).

## What this is

A new standalone crate **`crates/qfc-watchdog`** (lib + small bin): an **out-of-process** sidecar that watches ONE qfc-node purely through its Prometheus endpoint (`--metrics-addr`, :6060) and RPC port (`eth_blockNumber` probe). No node code is touched — qfc-node/qfc-storage/qfc-chain are unchanged. One watchdog per node; run N sidecars for N nodes.

Default mode is **pure detection**: health score + per-detector gauges on the watchdog's own hand-rendered `/metrics` (`--watchdog-metrics-addr`, :6061), structured log lines on every detector fire/clear, and a new `qfc-watchdog` alert group.

## Detector catalog (defaults)

| Detector | Fires when | Defaults | Health weight |
|---|---|---|---|
| `block_production_stall` | height unchanged over window AND `qfc_time_since_last_block_seconds` > threshold AND not syncing | 120s threshold, 120s window | 40 |
| `stuck_sync` | syncing=1 at both window ends AND `qfc_sync_lag_blocks` not decreasing (lag>0) | 300s window | 15 |
| `compaction_stall` | `qfc_rocksdb_write_stopped=1` (immediate); OR delayed-write rate >0 sustained; OR pending-compaction debt above floor AND growing | 120s sustain, 8 GiB floor, 600s window | 25 |
| `metrics_down` | N consecutive failed `/metrics` scrapes | 3 | 30 |
| `rpc_down` | N consecutive failed `eth_blockNumber` probes | 3 | 30 |

`qfc_watchdog_health_score` = 100 − Σ(firing weights), clamped at 0. While the node's metrics are unscrapeable the node-state detectors freeze (no consecutive-count progress while blind), so gating can't advance on stale data.

## Action mode — OFF by default

Enabled only via `--action-cmd "<shell command>"` (e.g. `docker restart qfc-node-1`). Every execution must pass **ALL** gates, in order:

| # | Gate | Rule | Default |
|---|---|---|---|
| 1 | trigger | action-eligible detector firing K consecutive polls | eligible = `block_production_stall` only; K = 3 (`--action-after-consecutive`) |
| 2 | startup grace | never within T of watchdog start | 120s (`--startup-grace-secs`) |
| 3 | snapshot in-flight | never while `qfc_snapshot_last_attempt > last_success` and recent | 1800s recency (`--snapshot-inflight-grace-secs`) |
| 4 | sync progressing | never while syncing and not detectably stuck | — |
| 5 | cooldown | quiet period after any action | 600s (`--action-cooldown-secs`) |
| 6 | hourly budget | sliding-window cap; exhausted = loud error + `qfc_watchdog_action_budget_exhausted=1`, alerting only | 2/h (`--max-actions-per-hour`) |

**What action mode will NOT do:** act on detectors outside the eligible set; exceed the hourly budget under any circumstance; act during snapshots, progressing sync, or startup grace; tight-loop on a failed command (a failed action still spends a budget slot + cooldown); escalate beyond the single operator-supplied command. Every action logs a full evidence dump and increments `qfc_watchdog_actions_total`.

All flags have `QFC_WATCHDOG_*` env equivalents (same clap conventions as qfc-node).

## Observability / docs

- `docs/observability/alert-rules.yaml`: new `qfc-watchdog` group — health score <100 for 15m (**ticket**), `QfcWatchdogActionTaken` (**ticket** — a restart happened, go look), budget exhausted while still unhealthy (**page**).
- `docs/observability/README.md`: watchdog scrape config + full `qfc_watchdog_*` metric inventory.
- `docs/WATCHDOG.md`: design (why out-of-process, detection-first), detector catalog, gate semantics, docker compose sidecar example, trust-escalation path (detection-only → action on block stall → broader detector set).

## Tests

- `cargo test -p qfc-watchdog`: **36 passed, 0 failed** — 35 unit tests covering every detector (fire + clear + freeze-while-blind) and every gate (eligible set, consecutive threshold, grace, snapshot, sync, cooldown, sliding budget exhaust/recover) against synthetic metrics text and an injected clock (no sleeps), plus 1 optional live-node integration test that skips when `target/release/qfc-node` isn't built (same convention as qfc-node's integration tests).
- `cargo check --workspace` clean; `cargo clippy -p qfc-watchdog --all-targets` zero warnings; `cargo fmt --all -- --check` clean.
- Manual smoke: ran the binary against dead endpoints — `metrics_down`/`rpc_down` fired after 3 polls, health dropped to 40, exporter served all `qfc_watchdog_*` series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)