### PR TITLE
T5: per-tenant quotas, fair scheduling, FLOPs cost attribution + treasury hook

### DIFF
--- a/crates/qfc-ai-coordinator/Cargo.toml
+++ b/crates/qfc-ai-coordinator/Cargo.toml
@@ -13,6 +13,7 @@ qfc-crypto.workspace = true
 qfc-inference.workspace = true
 qfc-ps.workspace = true
 borsh.workspace = true
+hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/qfc-ai-coordinator/src/cost.rs
+++ b/crates/qfc-ai-coordinator/src/cost.rs
@@ -1,0 +1,343 @@
+//! T5: FLOPs cost attribution per tenant and per miner + treasury hook.
+//!
+//! Every completed public task is metered with its `estimated_flops`
+//! (from [`crate::task_types::task_requirements`] — the same per-task FLOPs
+//! estimate used for fee pricing) and its fee, attributed to **both** the
+//! tenant (submitter) that paid for it and the miner that executed it.
+//!
+//! A periodic [`CostReport`] (driven by qfc-node,
+//! `--ai-cost-report-interval-secs`) aggregates the interval since the last
+//! report plus cumulative totals, is handed to the configured
+//! [`TreasuryHook`], and stays queryable in memory
+//! (`TaskPool::last_cost_report`).
+//!
+//! The real treasury integration (charging tenants / crediting miners
+//! on-chain) is explicitly out of scope here; [`TreasuryHook`] is the
+//! contract it will implement. The default [`LoggingTreasuryHook`] only
+//! emits structured logs.
+
+use std::collections::HashMap;
+
+use qfc_types::Address;
+use serde::Serialize;
+
+/// Metered totals for one party (tenant or miner).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct CostEntry {
+    /// Completed tasks.
+    pub tasks: u64,
+    /// Sum of `estimated_flops` over those tasks.
+    pub flops: u128,
+    /// Sum of task fees (max_fee, wei).
+    pub fees_wei: u128,
+}
+
+impl CostEntry {
+    fn add(&mut self, flops: u64, fee_wei: u128) {
+        self.tasks += 1;
+        self.flops = self.flops.saturating_add(flops as u128);
+        self.fees_wei = self.fees_wei.saturating_add(fee_wei);
+    }
+}
+
+/// One line of a cost report.
+#[derive(Clone, Debug, Serialize)]
+pub struct CostReportLine {
+    /// `0x`-hex address of the tenant or miner.
+    pub address: String,
+    /// Interval (since previous report) totals.
+    pub interval: CostEntry,
+    /// Cumulative totals since process start.
+    pub cumulative: CostEntry,
+}
+
+/// Periodic per-tenant / per-miner cost attribution report.
+#[derive(Clone, Debug, Serialize)]
+pub struct CostReport {
+    /// When this report was generated (unix ms).
+    pub generated_at_ms: u64,
+    /// Start of the covered interval (previous report time or meter start).
+    pub period_start_ms: u64,
+    /// Per-tenant lines, sorted by interval FLOPs descending.
+    pub tenants: Vec<CostReportLine>,
+    /// Per-miner lines, sorted by interval FLOPs descending.
+    pub miners: Vec<CostReportLine>,
+    /// Interval totals across all tenants.
+    pub interval_total: CostEntry,
+    /// Cumulative totals since process start.
+    pub cumulative_total: CostEntry,
+}
+
+/// Treasury integration contract (T5 deliverable — the hook, not the
+/// integration). Implementations must be cheap and non-blocking: both
+/// callbacks run while the `TaskPool` lock is held.
+///
+/// - [`TreasuryHook::on_task_charged`] fires once per completed public task
+///   with the metered cost (per-task charge callback).
+/// - [`TreasuryHook::on_cost_report`] fires once per periodic report
+///   (batch settlement callback).
+///
+/// The default implementations are no-ops so an integrator can pick either
+/// granularity.
+pub trait TreasuryHook: Send + Sync {
+    /// A public task completed: `tenant` owes for `flops`/`fee_wei`,
+    /// `miner` earned it.
+    fn on_task_charged(&self, _tenant: &Address, _miner: &Address, _flops: u64, _fee_wei: u128) {}
+
+    /// A periodic cost report was generated.
+    fn on_cost_report(&self, _report: &CostReport) {}
+}
+
+/// Default hook: structured logging only (target `qfc::ai_cost`), no
+/// treasury side effects.
+pub struct LoggingTreasuryHook;
+
+impl TreasuryHook for LoggingTreasuryHook {
+    fn on_task_charged(&self, tenant: &Address, miner: &Address, flops: u64, fee_wei: u128) {
+        tracing::debug!(
+            target: "qfc::ai_cost",
+            tenant = %tenant,
+            miner = %miner,
+            flops,
+            fee_wei,
+            "AI task cost metered"
+        );
+    }
+
+    fn on_cost_report(&self, report: &CostReport) {
+        let json =
+            serde_json::to_string(report).unwrap_or_else(|e| format!("<serialize error: {e}>"));
+        tracing::info!(
+            target: "qfc::ai_cost",
+            tenants = report.tenants.len(),
+            miners = report.miners.len(),
+            interval_tasks = report.interval_total.tasks,
+            interval_flops = %report.interval_total.flops,
+            report = %json,
+            "AI cost report"
+        );
+    }
+}
+
+/// Accumulates per-tenant and per-miner cost attribution.
+#[derive(Default)]
+pub struct CostMeter {
+    interval_tenants: HashMap<Address, CostEntry>,
+    interval_miners: HashMap<Address, CostEntry>,
+    cumulative_tenants: HashMap<Address, CostEntry>,
+    cumulative_miners: HashMap<Address, CostEntry>,
+    interval_total: CostEntry,
+    cumulative_total: CostEntry,
+    period_start_ms: u64,
+    last_report: Option<CostReport>,
+}
+
+impl CostMeter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Meter one completed task.
+    pub fn record(&mut self, tenant: &Address, miner: &Address, flops: u64, fee_wei: u128) {
+        self.interval_tenants
+            .entry(*tenant)
+            .or_default()
+            .add(flops, fee_wei);
+        self.interval_miners
+            .entry(*miner)
+            .or_default()
+            .add(flops, fee_wei);
+        self.cumulative_tenants
+            .entry(*tenant)
+            .or_default()
+            .add(flops, fee_wei);
+        self.cumulative_miners
+            .entry(*miner)
+            .or_default()
+            .add(flops, fee_wei);
+        self.interval_total.add(flops, fee_wei);
+        self.cumulative_total.add(flops, fee_wei);
+    }
+
+    /// Cumulative FLOPs metered (all tenants).
+    pub fn cumulative_flops(&self) -> u128 {
+        self.cumulative_total.flops
+    }
+
+    /// Cumulative totals for one tenant.
+    pub fn tenant_total(&self, tenant: &Address) -> CostEntry {
+        self.cumulative_tenants
+            .get(tenant)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    /// Cumulative totals for one miner.
+    pub fn miner_total(&self, miner: &Address) -> CostEntry {
+        self.cumulative_miners
+            .get(miner)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    /// Generate a report covering the interval since the previous one and
+    /// reset the interval accumulators. The report is retained and
+    /// retrievable via [`CostMeter::last_report`].
+    pub fn generate_report(&mut self, now_ms: u64) -> CostReport {
+        fn lines(
+            interval: &HashMap<Address, CostEntry>,
+            cumulative: &HashMap<Address, CostEntry>,
+        ) -> Vec<CostReportLine> {
+            // Include every party seen this interval, plus cumulative-only
+            // parties are omitted (they appear in the report where they were
+            // active; cumulative state is still queryable via accessors).
+            let mut out: Vec<CostReportLine> = interval
+                .iter()
+                .map(|(addr, entry)| CostReportLine {
+                    address: format!("{addr}"),
+                    interval: *entry,
+                    cumulative: cumulative.get(addr).copied().unwrap_or_default(),
+                })
+                .collect();
+            out.sort_by_key(|line| std::cmp::Reverse(line.interval.flops));
+            out
+        }
+
+        let report = CostReport {
+            generated_at_ms: now_ms,
+            period_start_ms: self.period_start_ms,
+            tenants: lines(&self.interval_tenants, &self.cumulative_tenants),
+            miners: lines(&self.interval_miners, &self.cumulative_miners),
+            interval_total: self.interval_total,
+            cumulative_total: self.cumulative_total,
+        };
+
+        self.interval_tenants.clear();
+        self.interval_miners.clear();
+        self.interval_total = CostEntry::default();
+        self.period_start_ms = now_ms;
+        self.last_report = Some(report.clone());
+        report
+    }
+
+    /// The most recent report, if any.
+    pub fn last_report(&self) -> Option<&CostReport> {
+        self.last_report.as_ref()
+    }
+
+    /// Unix ms of the last report (0 = never). Exported as
+    /// `qfc_ai_cost_report_last_timestamp_seconds` (0 = never, matching the
+    /// T4.2 snapshot-freshness convention).
+    pub fn last_report_unix_ms(&self) -> u64 {
+        self.last_report
+            .as_ref()
+            .map(|r| r.generated_at_ms)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(b: u8) -> Address {
+        Address::new([b; 20])
+    }
+
+    #[test]
+    fn metering_accumulates_per_tenant_and_miner() {
+        let mut meter = CostMeter::new();
+        let (t1, t2, m1, m2) = (addr(1), addr(2), addr(10), addr(20));
+
+        meter.record(&t1, &m1, 1_000, 100);
+        meter.record(&t1, &m2, 2_000, 200);
+        meter.record(&t2, &m1, 5_000, 500);
+
+        assert_eq!(
+            meter.tenant_total(&t1),
+            CostEntry {
+                tasks: 2,
+                flops: 3_000,
+                fees_wei: 300
+            }
+        );
+        assert_eq!(
+            meter.tenant_total(&t2),
+            CostEntry {
+                tasks: 1,
+                flops: 5_000,
+                fees_wei: 500
+            }
+        );
+        assert_eq!(
+            meter.miner_total(&m1),
+            CostEntry {
+                tasks: 2,
+                flops: 6_000,
+                fees_wei: 600
+            }
+        );
+        assert_eq!(
+            meter.miner_total(&m2),
+            CostEntry {
+                tasks: 1,
+                flops: 2_000,
+                fees_wei: 200
+            }
+        );
+        assert_eq!(meter.cumulative_flops(), 8_000);
+    }
+
+    #[test]
+    fn report_covers_interval_and_resets() {
+        let mut meter = CostMeter::new();
+        let (t1, m1) = (addr(1), addr(10));
+
+        meter.record(&t1, &m1, 1_000, 100);
+        let r1 = meter.generate_report(5_000);
+        assert_eq!(r1.period_start_ms, 0);
+        assert_eq!(r1.generated_at_ms, 5_000);
+        assert_eq!(r1.tenants.len(), 1);
+        assert_eq!(r1.miners.len(), 1);
+        assert_eq!(r1.interval_total.flops, 1_000);
+        assert_eq!(r1.cumulative_total.flops, 1_000);
+
+        // Second interval: only new activity appears in interval lines,
+        // cumulative keeps growing.
+        meter.record(&t1, &m1, 2_000, 200);
+        let r2 = meter.generate_report(10_000);
+        assert_eq!(r2.period_start_ms, 5_000);
+        assert_eq!(r2.interval_total.flops, 2_000);
+        assert_eq!(r2.cumulative_total.flops, 3_000);
+        assert_eq!(r2.tenants[0].interval.flops, 2_000);
+        assert_eq!(r2.tenants[0].cumulative.flops, 3_000);
+
+        // Empty interval → empty lines but cumulative preserved.
+        let r3 = meter.generate_report(15_000);
+        assert!(r3.tenants.is_empty());
+        assert_eq!(r3.cumulative_total.flops, 3_000);
+
+        assert_eq!(meter.last_report_unix_ms(), 15_000);
+        assert!(meter.last_report().is_some());
+    }
+
+    #[test]
+    fn report_sorted_by_interval_flops_desc() {
+        let mut meter = CostMeter::new();
+        meter.record(&addr(1), &addr(10), 100, 0);
+        meter.record(&addr(2), &addr(10), 900, 0);
+        let r = meter.generate_report(1);
+        assert_eq!(r.tenants[0].address, format!("{}", addr(2)));
+        assert_eq!(r.tenants[1].address, format!("{}", addr(1)));
+    }
+
+    #[test]
+    fn report_serializes_to_json() {
+        let mut meter = CostMeter::new();
+        meter.record(&addr(1), &addr(10), 1_000, u128::MAX / 2);
+        let r = meter.generate_report(1);
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"tenants\""));
+        assert!(json.contains("\"miners\""));
+    }
+}

--- a/crates/qfc-ai-coordinator/src/lib.rs
+++ b/crates/qfc-ai-coordinator/src/lib.rs
@@ -12,10 +12,12 @@
 
 pub mod assignment;
 pub mod challenge;
+pub mod cost;
 pub mod governance;
 pub mod ipfs;
 pub mod param_governance;
 pub mod proof_pool;
+pub mod quota;
 pub mod redundant;
 pub mod registry;
 pub mod router;
@@ -30,12 +32,14 @@ pub use challenge::{
     ArbitrationManager, ArbitrationOutcome, ArbitrationPanel, ArbitrationVote, ChallengeGenerator,
     ChallengePenalty, ChallengeVerdict,
 };
+pub use cost::{CostEntry, CostMeter, CostReport, LoggingTreasuryHook, TreasuryHook};
 pub use governance::{GovernanceError, ModelGovernance, ModelProposal, ProposalStatus};
 pub use param_governance::{
     ParamGovernanceError, ParamProposalStatus, ParameterGovernance, ParameterKey, ParameterProposal,
 };
 pub use proof_pool::ProofPool;
-pub use task_pool::{PublicTaskFilter, TaskPool};
+pub use quota::{QuotaConfig, QuotaConfigError, QuotaError, TierQuota};
+pub use task_pool::{AiQuotaMetrics, PublicTaskFilter, TaskPool};
 pub use task_types::estimate_base_fee;
 pub use training::{
     TrainingAssignment, TrainingError, TrainingJobSpec, TrainingJobStatus, TrainingPool,

--- a/crates/qfc-ai-coordinator/src/quota.rs
+++ b/crates/qfc-ai-coordinator/src/quota.rs
@@ -1,0 +1,736 @@
+//! T5: Per-tenant quotas on the AI task pool.
+//!
+//! A **tenant** is a submitter address. Each tenant maps to a [`TierQuota`]
+//! (either an explicit per-tenant entry or the configured default tier) that
+//! bounds:
+//!
+//! - **QPS** — submissions/second via a token bucket (`max_qps` + `burst`);
+//! - **in-flight tasks** — public tasks in `Pending`/`Assigned` state;
+//! - **FLOPs budget** — `estimated_flops` admitted per fixed window
+//!   (`window_secs`), a fixed-window approximation of a rolling budget.
+//!
+//! Tenants also carry a **priority** (0..=2, 2 = highest). Under pool
+//! pressure, lower-priority tenants are shed first: priority 0 is rejected
+//! once the pending queue reaches 50% of `max_pending`, priority 1 at 75%,
+//! and priority 2 only at the hard cap. See `docs/AI-QUOTAS.md`.
+//!
+//! Configuration is JSON (`--ai-quotas <path>` on qfc-node). JSON rather than
+//! TOML because `serde_json` is already in this crate's dependency tree and
+//! the workspace has no `toml` dependency. When no config is supplied,
+//! quotas are **off**: admission always succeeds (the fee escrow on the RPC
+//! submission path remains the economic backpressure), but in-flight counts
+//! are still tracked so the exporter gauges stay meaningful.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use qfc_types::Address;
+use serde::{Deserialize, Serialize};
+
+/// Number of priority tiers (0 = lowest, shed first; 2 = highest).
+pub const PRIORITY_TIERS: usize = 3;
+
+/// Rejection reason labels, in documented degradation/checking order.
+/// These are the exact `reason` label values on
+/// `qfc_ai_tasks_rejected_total`.
+pub const REJECT_REASONS: [&str; 4] = ["pool_pressure", "qps", "in_flight", "flops_budget"];
+
+fn default_max_qps() -> f64 {
+    10.0
+}
+
+fn default_max_inflight() -> u64 {
+    100
+}
+
+fn default_priority() -> u8 {
+    1
+}
+
+fn default_window_secs() -> u64 {
+    3600
+}
+
+fn default_max_pending() -> usize {
+    10_000
+}
+
+/// Quota parameters for one tier (the default tier or a per-tenant override).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TierQuota {
+    /// Sustained submission rate in requests/second (token-bucket refill).
+    /// `0` disables QPS limiting for this tier.
+    #[serde(default = "default_max_qps")]
+    pub max_qps: f64,
+    /// Token-bucket capacity (burst size). Defaults to `ceil(max_qps)`,
+    /// minimum 1.
+    #[serde(default)]
+    pub burst: Option<u32>,
+    /// Maximum tasks in flight (`Pending` or `Assigned`). `0` = unlimited.
+    #[serde(default = "default_max_inflight")]
+    pub max_inflight: u64,
+    /// FLOPs budget (`estimated_flops` sum) admitted per `window_secs`
+    /// window. `0` = unlimited.
+    #[serde(default)]
+    pub flops_per_window: u64,
+    /// Priority tier 0..=2; values above 2 are clamped. Lowest is shed
+    /// first under pool pressure.
+    #[serde(default = "default_priority")]
+    pub priority: u8,
+}
+
+impl Default for TierQuota {
+    /// Generous defaults so an operator can enable quota *accounting*
+    /// (and pool-pressure shedding) without immediately throttling
+    /// well-behaved tenants.
+    fn default() -> Self {
+        Self {
+            max_qps: default_max_qps(),
+            burst: None,
+            max_inflight: default_max_inflight(),
+            flops_per_window: 0,
+            priority: default_priority(),
+        }
+    }
+}
+
+impl TierQuota {
+    /// Effective bucket capacity.
+    fn capacity(&self) -> f64 {
+        match self.burst {
+            Some(b) => (b as f64).max(1.0),
+            None => self.max_qps.ceil().max(1.0),
+        }
+    }
+
+    /// Priority clamped to the valid range.
+    pub fn clamped_priority(&self) -> u8 {
+        self.priority.min((PRIORITY_TIERS - 1) as u8)
+    }
+}
+
+/// Quota configuration: a default tier plus per-tenant overrides.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QuotaConfig {
+    /// FLOPs-budget window length in seconds.
+    #[serde(default = "default_window_secs")]
+    pub window_secs: u64,
+    /// Hard cap on the pending queue. Pool-pressure shedding thresholds are
+    /// derived from this: priority 0 sheds at 50%, priority 1 at 75%,
+    /// priority 2 at 100%.
+    #[serde(default = "default_max_pending")]
+    pub max_pending: usize,
+    /// Quota applied to tenants without an explicit entry.
+    #[serde(default)]
+    pub default_tier: TierQuota,
+    /// Per-tenant overrides, keyed by `0x`-prefixed hex address.
+    #[serde(default)]
+    pub tenants: HashMap<String, TierQuota>,
+    /// Parsed tenant table (built by [`QuotaConfig::finalize`]).
+    #[serde(skip)]
+    tenants_parsed: HashMap<Address, TierQuota>,
+}
+
+impl Default for QuotaConfig {
+    /// Matches the serde field defaults (an empty JSON object `{}` parses
+    /// to exactly this).
+    fn default() -> Self {
+        Self {
+            window_secs: default_window_secs(),
+            max_pending: default_max_pending(),
+            default_tier: TierQuota::default(),
+            tenants: HashMap::new(),
+            tenants_parsed: HashMap::new(),
+        }
+    }
+}
+
+/// Errors loading/parsing a quota config file.
+#[derive(Debug, thiserror::Error)]
+pub enum QuotaConfigError {
+    #[error("failed to read quota config: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("failed to parse quota config JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid tenant address in quota config: {0}")]
+    InvalidAddress(String),
+}
+
+impl QuotaConfig {
+    /// Parse a JSON config string and build the tenant lookup table.
+    pub fn from_json_str(s: &str) -> Result<Self, QuotaConfigError> {
+        let mut cfg: QuotaConfig = serde_json::from_str(s)?;
+        cfg.finalize()?;
+        Ok(cfg)
+    }
+
+    /// Load a JSON config file (`--ai-quotas <path>`).
+    pub fn from_file(path: &Path) -> Result<Self, QuotaConfigError> {
+        let raw = std::fs::read_to_string(path)?;
+        Self::from_json_str(&raw)
+    }
+
+    /// Build the parsed tenant table; validates addresses.
+    pub fn finalize(&mut self) -> Result<(), QuotaConfigError> {
+        self.tenants_parsed.clear();
+        for (key, quota) in &self.tenants {
+            let hex_part = key.strip_prefix("0x").unwrap_or(key);
+            let bytes =
+                hex::decode(hex_part).map_err(|_| QuotaConfigError::InvalidAddress(key.clone()))?;
+            let addr = Address::from_slice(&bytes)
+                .ok_or_else(|| QuotaConfigError::InvalidAddress(key.clone()))?;
+            self.tenants_parsed.insert(addr, quota.clone());
+        }
+        Ok(())
+    }
+
+    /// Quota for a tenant: explicit entry or the default tier.
+    pub fn tier_for(&self, tenant: &Address) -> &TierQuota {
+        self.tenants_parsed
+            .get(tenant)
+            .unwrap_or(&self.default_tier)
+    }
+
+    /// Pending-queue threshold above which `priority` is shed.
+    /// Degradation order: priority 0 at 50%, 1 at 75%, 2 at 100%.
+    pub fn shed_threshold(&self, priority: u8) -> usize {
+        match priority {
+            0 => self.max_pending / 2,
+            1 => self.max_pending * 3 / 4,
+            _ => self.max_pending,
+        }
+    }
+}
+
+/// Typed admission rejection. Surfaced over JSON-RPC as error code `-32029`
+/// with the limit name and a retry-after hint.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+pub enum QuotaError {
+    #[error("pool pressure: pending queue at {pending} >= shed threshold {threshold} for priority {priority}; retry after {retry_after_ms}ms")]
+    PoolPressure {
+        tenant: Address,
+        priority: u8,
+        pending: usize,
+        threshold: usize,
+        retry_after_ms: u64,
+    },
+    #[error("QPS limit exceeded for tenant {tenant}: limit {limit} req/s; retry after {retry_after_ms}ms")]
+    QpsExceeded {
+        tenant: Address,
+        limit: f64,
+        retry_after_ms: u64,
+    },
+    #[error("in-flight task limit exceeded for tenant {tenant}: {in_flight}/{limit} tasks outstanding; retry after {retry_after_ms}ms")]
+    InFlightExceeded {
+        tenant: Address,
+        limit: u64,
+        in_flight: u64,
+        retry_after_ms: u64,
+    },
+    #[error("FLOPs budget exceeded for tenant {tenant}: {used}+{requested} > {budget} per {window_secs}s window; retry after {retry_after_ms}ms")]
+    FlopsBudgetExceeded {
+        tenant: Address,
+        budget: u64,
+        used: u64,
+        requested: u64,
+        window_secs: u64,
+        retry_after_ms: u64,
+    },
+}
+
+impl QuotaError {
+    /// Stable reason label (matches [`REJECT_REASONS`] /
+    /// `qfc_ai_tasks_rejected_total{reason=...}`).
+    pub fn reason(&self) -> &'static str {
+        match self {
+            QuotaError::PoolPressure { .. } => "pool_pressure",
+            QuotaError::QpsExceeded { .. } => "qps",
+            QuotaError::InFlightExceeded { .. } => "in_flight",
+            QuotaError::FlopsBudgetExceeded { .. } => "flops_budget",
+        }
+    }
+
+    /// Hint for the client: milliseconds until a retry has a chance.
+    pub fn retry_after_ms(&self) -> u64 {
+        match self {
+            QuotaError::PoolPressure { retry_after_ms, .. }
+            | QuotaError::QpsExceeded { retry_after_ms, .. }
+            | QuotaError::InFlightExceeded { retry_after_ms, .. }
+            | QuotaError::FlopsBudgetExceeded { retry_after_ms, .. } => *retry_after_ms,
+        }
+    }
+}
+
+/// Per-tenant runtime state (token bucket + budget window + in-flight count).
+#[derive(Clone, Debug)]
+struct TenantState {
+    /// Token bucket level. Initialized to capacity on first submission.
+    tokens: f64,
+    /// Last refill timestamp (ms).
+    last_refill_ms: u64,
+    /// Public tasks in Pending/Assigned state.
+    in_flight: u64,
+    /// Start of the current FLOPs-budget window (ms).
+    window_start_ms: u64,
+    /// estimated_flops admitted in the current window.
+    flops_used: u64,
+}
+
+impl TenantState {
+    fn new(now_ms: u64, capacity: f64) -> Self {
+        Self {
+            tokens: capacity,
+            last_refill_ms: now_ms,
+            in_flight: 0,
+            window_start_ms: now_ms,
+            flops_used: 0,
+        }
+    }
+}
+
+/// Admission control + per-tenant runtime accounting.
+///
+/// Checks run in documented order: pool pressure → QPS → in-flight →
+/// FLOPs budget. State (token, budget) is only committed when every check
+/// passes, so a rejected request consumes nothing.
+pub struct QuotaEnforcer {
+    config: Option<QuotaConfig>,
+    tenants: HashMap<Address, TenantState>,
+}
+
+impl QuotaEnforcer {
+    pub fn new() -> Self {
+        Self {
+            config: None,
+            tenants: HashMap::new(),
+        }
+    }
+
+    /// Install (or clear) the quota configuration. Runtime state for known
+    /// tenants is kept; bucket capacities adjust on the next refill.
+    pub fn set_config(&mut self, config: Option<QuotaConfig>) {
+        self.config = config;
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.config.is_some()
+    }
+
+    pub fn config(&self) -> Option<&QuotaConfig> {
+        self.config.as_ref()
+    }
+
+    /// Priority tier for a tenant (default tier when quotas are off).
+    pub fn priority_for(&self, tenant: &Address) -> u8 {
+        match &self.config {
+            Some(cfg) => cfg.tier_for(tenant).clamped_priority(),
+            None => default_priority(),
+        }
+    }
+
+    /// Admission check for a submission of `estimated_flops` while the
+    /// pending queue holds `pending` tasks. Commits one QPS token and the
+    /// FLOPs charge only when admitted. Does NOT bump in-flight — call
+    /// [`QuotaEnforcer::task_started`] when the task is actually enqueued.
+    pub fn admit(
+        &mut self,
+        tenant: &Address,
+        estimated_flops: u64,
+        pending: usize,
+        now_ms: u64,
+    ) -> Result<(), QuotaError> {
+        let Some(cfg) = &self.config else {
+            return Ok(()); // quotas off
+        };
+        let quota = cfg.tier_for(tenant).clone();
+        let priority = quota.clamped_priority();
+
+        // 1. Pool pressure: shed lowest-priority tenants first.
+        let threshold = cfg.shed_threshold(priority);
+        if pending >= threshold {
+            return Err(QuotaError::PoolPressure {
+                tenant: *tenant,
+                priority,
+                pending,
+                threshold,
+                retry_after_ms: 1_000,
+            });
+        }
+
+        let window_ms = cfg.window_secs.saturating_mul(1000);
+        let capacity = quota.capacity();
+        let state = self
+            .tenants
+            .entry(*tenant)
+            .or_insert_with(|| TenantState::new(now_ms, capacity));
+
+        // Refill the token bucket.
+        if quota.max_qps > 0.0 {
+            let elapsed_ms = now_ms.saturating_sub(state.last_refill_ms);
+            state.tokens =
+                (state.tokens + elapsed_ms as f64 / 1000.0 * quota.max_qps).min(capacity);
+            state.last_refill_ms = now_ms;
+        }
+
+        // Roll the FLOPs window forward if it has elapsed.
+        if window_ms > 0 && now_ms.saturating_sub(state.window_start_ms) >= window_ms {
+            state.window_start_ms = now_ms;
+            state.flops_used = 0;
+        }
+
+        // 2. QPS (peek; consume only on full success).
+        if quota.max_qps > 0.0 && state.tokens < 1.0 {
+            let deficit = 1.0 - state.tokens;
+            let retry_after_ms = (deficit / quota.max_qps * 1000.0).ceil() as u64;
+            return Err(QuotaError::QpsExceeded {
+                tenant: *tenant,
+                limit: quota.max_qps,
+                retry_after_ms,
+            });
+        }
+
+        // 3. In-flight.
+        if quota.max_inflight > 0 && state.in_flight >= quota.max_inflight {
+            return Err(QuotaError::InFlightExceeded {
+                tenant: *tenant,
+                limit: quota.max_inflight,
+                in_flight: state.in_flight,
+                retry_after_ms: 1_000,
+            });
+        }
+
+        // 4. FLOPs budget.
+        if quota.flops_per_window > 0
+            && state.flops_used.saturating_add(estimated_flops) > quota.flops_per_window
+        {
+            let window_end = state.window_start_ms + window_ms;
+            return Err(QuotaError::FlopsBudgetExceeded {
+                tenant: *tenant,
+                budget: quota.flops_per_window,
+                used: state.flops_used,
+                requested: estimated_flops,
+                window_secs: cfg.window_secs,
+                retry_after_ms: window_end.saturating_sub(now_ms).max(1),
+            });
+        }
+
+        // Commit.
+        if quota.max_qps > 0.0 {
+            state.tokens -= 1.0;
+        }
+        state.flops_used = state.flops_used.saturating_add(estimated_flops);
+        Ok(())
+    }
+
+    /// A public task for `tenant` entered the pool (Pending).
+    pub fn task_started(&mut self, tenant: &Address, now_ms: u64) {
+        let capacity = match &self.config {
+            Some(cfg) => cfg.tier_for(tenant).capacity(),
+            None => TierQuota::default().capacity(),
+        };
+        let state = self
+            .tenants
+            .entry(*tenant)
+            .or_insert_with(|| TenantState::new(now_ms, capacity));
+        state.in_flight = state.in_flight.saturating_add(1);
+    }
+
+    /// A public task for `tenant` left Pending/Assigned (completed or
+    /// expired).
+    pub fn task_finished(&mut self, tenant: &Address) {
+        if let Some(state) = self.tenants.get_mut(tenant) {
+            state.in_flight = state.in_flight.saturating_sub(1);
+        }
+    }
+
+    /// In-flight tasks summed per priority tier (bounded-cardinality view
+    /// for the exporter: per-tenant series would be unbounded).
+    pub fn inflight_by_priority(&self) -> [u64; PRIORITY_TIERS] {
+        let mut out = [0u64; PRIORITY_TIERS];
+        for (tenant, state) in &self.tenants {
+            let p = self.priority_for(tenant) as usize;
+            out[p] = out[p].saturating_add(state.in_flight);
+        }
+        out
+    }
+
+    /// In-flight count for one tenant (test/RPC accessor).
+    pub fn inflight_for(&self, tenant: &Address) -> u64 {
+        self.tenants.get(tenant).map(|s| s.in_flight).unwrap_or(0)
+    }
+}
+
+impl Default for QuotaEnforcer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(b: u8) -> Address {
+        Address::new([b; 20])
+    }
+
+    fn cfg_with_default(tier: TierQuota) -> QuotaConfig {
+        let mut cfg = QuotaConfig {
+            default_tier: tier,
+            ..Default::default()
+        };
+        cfg.finalize().unwrap();
+        cfg
+    }
+
+    #[test]
+    fn disabled_enforcer_admits_everything() {
+        let mut e = QuotaEnforcer::new();
+        for i in 0..1000 {
+            assert!(e.admit(&addr(1), u64::MAX, 1_000_000, i).is_ok());
+        }
+    }
+
+    #[test]
+    fn token_bucket_qps_edges() {
+        let mut e = QuotaEnforcer::new();
+        e.set_config(Some(cfg_with_default(TierQuota {
+            max_qps: 2.0,
+            burst: Some(2),
+            max_inflight: 0,
+            flops_per_window: 0,
+            priority: 1,
+        })));
+        let t = addr(1);
+
+        // Burst of 2 admitted instantly.
+        assert!(e.admit(&t, 0, 0, 0).is_ok());
+        assert!(e.admit(&t, 0, 0, 0).is_ok());
+        // Third is rejected with a retry-after hint of ~500ms (1 token / 2 qps).
+        let err = e.admit(&t, 0, 0, 0).unwrap_err();
+        match &err {
+            QuotaError::QpsExceeded { retry_after_ms, .. } => {
+                assert_eq!(*retry_after_ms, 500);
+            }
+            other => panic!("expected QpsExceeded, got {other:?}"),
+        }
+        assert_eq!(err.reason(), "qps");
+
+        // 499ms later: still not enough (0.998 tokens).
+        assert!(e.admit(&t, 0, 0, 499).is_err());
+        // 500ms later: exactly one token refilled.
+        assert!(e.admit(&t, 0, 0, 500).is_ok());
+        // Bucket never exceeds burst capacity: after a long idle, only 2.
+        assert!(e.admit(&t, 0, 0, 100_000).is_ok());
+        assert!(e.admit(&t, 0, 0, 100_000).is_ok());
+        assert!(e.admit(&t, 0, 0, 100_000).is_err());
+    }
+
+    #[test]
+    fn rejected_request_consumes_nothing() {
+        // A request that fails the FLOPs check must not burn a QPS token.
+        let mut e = QuotaEnforcer::new();
+        e.set_config(Some(cfg_with_default(TierQuota {
+            max_qps: 1.0,
+            burst: Some(1),
+            max_inflight: 0,
+            flops_per_window: 100,
+            priority: 1,
+        })));
+        let t = addr(1);
+        assert!(matches!(
+            e.admit(&t, 200, 0, 0),
+            Err(QuotaError::FlopsBudgetExceeded { .. })
+        ));
+        // Token still available for an in-budget request at the same instant.
+        assert!(e.admit(&t, 50, 0, 0).is_ok());
+    }
+
+    #[test]
+    fn in_flight_limit() {
+        let mut e = QuotaEnforcer::new();
+        e.set_config(Some(cfg_with_default(TierQuota {
+            max_qps: 0.0, // unlimited QPS
+            burst: None,
+            max_inflight: 2,
+            flops_per_window: 0,
+            priority: 1,
+        })));
+        let t = addr(1);
+
+        assert!(e.admit(&t, 0, 0, 0).is_ok());
+        e.task_started(&t, 0);
+        assert!(e.admit(&t, 0, 0, 1).is_ok());
+        e.task_started(&t, 1);
+        let err = e.admit(&t, 0, 0, 2).unwrap_err();
+        assert_eq!(err.reason(), "in_flight");
+
+        // Completion frees a slot.
+        e.task_finished(&t);
+        assert!(e.admit(&t, 0, 0, 3).is_ok());
+        assert_eq!(e.inflight_for(&t), 1);
+    }
+
+    #[test]
+    fn flops_budget_window_expiry() {
+        let mut e = QuotaEnforcer::new();
+        let mut cfg = cfg_with_default(TierQuota {
+            max_qps: 0.0,
+            burst: None,
+            max_inflight: 0,
+            flops_per_window: 1_000,
+            priority: 1,
+        });
+        cfg.window_secs = 10; // 10s window
+        e.set_config(Some(cfg));
+        let t = addr(1);
+
+        assert!(e.admit(&t, 600, 0, 0).is_ok());
+        assert!(e.admit(&t, 400, 0, 1).is_ok()); // exactly at budget
+        let err = e.admit(&t, 1, 0, 2).unwrap_err();
+        match &err {
+            QuotaError::FlopsBudgetExceeded {
+                used,
+                budget,
+                retry_after_ms,
+                ..
+            } => {
+                assert_eq!(*used, 1_000);
+                assert_eq!(*budget, 1_000);
+                // Window started at t=0ms, 10s long → retry at 10_000-2.
+                assert_eq!(*retry_after_ms, 9_998);
+            }
+            other => panic!("expected FlopsBudgetExceeded, got {other:?}"),
+        }
+
+        // One ms before expiry: still rejected.
+        assert!(e.admit(&t, 1, 0, 9_999).is_err());
+        // At window boundary: budget resets.
+        assert!(e.admit(&t, 1_000, 0, 10_000).is_ok());
+    }
+
+    #[test]
+    fn pool_pressure_sheds_lowest_priority_first() {
+        let mut cfg = QuotaConfig {
+            max_pending: 100,
+            ..Default::default()
+        };
+        cfg.tenants.insert(
+            format!("0x{}", hex::encode(addr(0).as_bytes())),
+            TierQuota {
+                priority: 0,
+                max_qps: 0.0,
+                ..Default::default()
+            },
+        );
+        cfg.tenants.insert(
+            format!("0x{}", hex::encode(addr(1).as_bytes())),
+            TierQuota {
+                priority: 1,
+                max_qps: 0.0,
+                ..Default::default()
+            },
+        );
+        cfg.tenants.insert(
+            format!("0x{}", hex::encode(addr(2).as_bytes())),
+            TierQuota {
+                priority: 2,
+                max_qps: 0.0,
+                ..Default::default()
+            },
+        );
+        cfg.finalize().unwrap();
+        let mut e = QuotaEnforcer::new();
+        e.set_config(Some(cfg));
+
+        // Below 50%: everyone admitted.
+        for b in 0..3 {
+            assert!(e.admit(&addr(b), 0, 49, 0).is_ok());
+        }
+        // At 50% (pending=50): priority 0 shed, 1 and 2 admitted.
+        assert_eq!(
+            e.admit(&addr(0), 0, 50, 0).unwrap_err().reason(),
+            "pool_pressure"
+        );
+        assert!(e.admit(&addr(1), 0, 50, 0).is_ok());
+        assert!(e.admit(&addr(2), 0, 50, 0).is_ok());
+        // At 75% (pending=75): priority 1 also shed.
+        assert!(e.admit(&addr(1), 0, 75, 0).is_err());
+        assert!(e.admit(&addr(2), 0, 75, 0).is_ok());
+        // At the hard cap: everyone shed.
+        assert!(e.admit(&addr(2), 0, 100, 0).is_err());
+    }
+
+    #[test]
+    fn config_parsing_defaults_and_overrides() {
+        let json = r#"{
+            "window_secs": 600,
+            "max_pending": 500,
+            "default_tier": { "max_qps": 5.0, "max_inflight": 10 },
+            "tenants": {
+                "0x0101010101010101010101010101010101010101": {
+                    "max_qps": 50.0, "burst": 100, "priority": 2,
+                    "flops_per_window": 5000000000000
+                }
+            }
+        }"#;
+        let cfg = QuotaConfig::from_json_str(json).unwrap();
+        assert_eq!(cfg.window_secs, 600);
+        assert_eq!(cfg.max_pending, 500);
+
+        let vip = cfg.tier_for(&addr(1));
+        assert_eq!(vip.max_qps, 50.0);
+        assert_eq!(vip.clamped_priority(), 2);
+        assert_eq!(vip.flops_per_window, 5_000_000_000_000);
+
+        let other = cfg.tier_for(&addr(9));
+        assert_eq!(other.max_qps, 5.0);
+        assert_eq!(other.max_inflight, 10);
+        // Unspecified fields fall back to serde defaults.
+        assert_eq!(other.flops_per_window, 0);
+        assert_eq!(other.clamped_priority(), 1);
+    }
+
+    #[test]
+    fn config_rejects_bad_address() {
+        let json = r#"{ "tenants": { "0xnothex": {} } }"#;
+        assert!(matches!(
+            QuotaConfig::from_json_str(json),
+            Err(QuotaConfigError::InvalidAddress(_))
+        ));
+        let json = r#"{ "tenants": { "0x0102": {} } }"#; // wrong length
+        assert!(matches!(
+            QuotaConfig::from_json_str(json),
+            Err(QuotaConfigError::InvalidAddress(_))
+        ));
+    }
+
+    #[test]
+    fn priority_clamped() {
+        let q = TierQuota {
+            priority: 9,
+            ..Default::default()
+        };
+        assert_eq!(q.clamped_priority(), 2);
+    }
+
+    #[test]
+    fn inflight_by_priority_aggregates() {
+        let mut cfg = QuotaConfig::default();
+        cfg.tenants.insert(
+            format!("0x{}", hex::encode(addr(2).as_bytes())),
+            TierQuota {
+                priority: 2,
+                ..Default::default()
+            },
+        );
+        cfg.finalize().unwrap();
+        let mut e = QuotaEnforcer::new();
+        e.set_config(Some(cfg));
+
+        e.task_started(&addr(1), 0); // default tier → priority 1
+        e.task_started(&addr(1), 0);
+        e.task_started(&addr(2), 0); // priority 2
+        assert_eq!(e.inflight_by_priority(), [0, 2, 1]);
+    }
+}

--- a/crates/qfc-ai-coordinator/src/task_pool.rs
+++ b/crates/qfc-ai-coordinator/src/task_pool.rs
@@ -6,6 +6,8 @@ use borsh::BorshDeserialize;
 use qfc_inference::{GpuTier, InferenceTask};
 use qfc_types::{Address, Hash};
 
+use crate::cost::{CostMeter, CostReport, LoggingTreasuryHook, TreasuryHook};
+use crate::quota::{QuotaConfig, QuotaEnforcer, QuotaError, PRIORITY_TIERS, REJECT_REASONS};
 use crate::task_types::{synthetic_task_for_tier, task_requirements};
 
 /// How the result data is stored
@@ -95,6 +97,36 @@ pub struct TaskPool {
     redundancy_count: usize,
     /// Completed/expired/failed tasks retained for querying, with expiry timestamp (ms)
     completed_tasks: HashMap<Hash, (PublicTask, u64)>,
+    /// T5: per-tenant admission control (quotas off until configured)
+    quota: QuotaEnforcer,
+    /// T5: FLOPs/fee cost attribution per tenant and per miner
+    cost: CostMeter,
+    /// T5: treasury integration hook (default: structured logging no-op)
+    treasury_hook: Box<dyn TreasuryHook>,
+    /// T5: round-robin cursor for fair scheduling across tenants
+    rr_last_tenant: Option<Address>,
+    /// T5 metrics: public-task submissions per priority tier
+    submitted_by_tier: [u64; PRIORITY_TIERS],
+    /// T5 metrics: quota rejections per reason (indexed like REJECT_REASONS)
+    rejected_by_reason: [u64; REJECT_REASONS.len()],
+    /// T5 metrics: estimated_flops metered on completion, per priority tier
+    flops_metered_by_tier: [u128; PRIORITY_TIERS],
+}
+
+/// T5: bounded-cardinality snapshot of quota/cost activity for the
+/// Prometheus exporter. Labeled by priority **tier**, never by tenant
+/// address (tenant cardinality is unbounded); per-tenant detail lives in
+/// the cost report (structured log + `last_cost_report`).
+#[derive(Clone, Debug)]
+pub struct AiQuotaMetrics {
+    pub quotas_enabled: bool,
+    pub pending_tasks: usize,
+    pub submitted_by_tier: [u64; PRIORITY_TIERS],
+    pub rejected_by_reason: [(&'static str, u64); REJECT_REASONS.len()],
+    pub flops_metered_by_tier: [u128; PRIORITY_TIERS],
+    pub inflight_by_tier: [u64; PRIORITY_TIERS],
+    /// Unix ms of the last cost report (0 = never since start).
+    pub cost_report_unix_ms: u64,
 }
 
 impl TaskPool {
@@ -109,7 +141,29 @@ impl TaskPool {
             redundant_assignments: HashMap::new(),
             redundancy_count: 2,
             completed_tasks: HashMap::new(),
+            quota: QuotaEnforcer::new(),
+            cost: CostMeter::new(),
+            treasury_hook: Box::new(LoggingTreasuryHook),
+            rr_last_tenant: None,
+            submitted_by_tier: [0; PRIORITY_TIERS],
+            rejected_by_reason: [0; REJECT_REASONS.len()],
+            flops_metered_by_tier: [0; PRIORITY_TIERS],
         }
+    }
+
+    /// T5: install (or clear) the per-tenant quota configuration.
+    pub fn set_quota_config(&mut self, config: Option<QuotaConfig>) {
+        self.quota.set_config(config);
+    }
+
+    /// T5: whether quota enforcement is active.
+    pub fn quotas_enabled(&self) -> bool {
+        self.quota.enabled()
+    }
+
+    /// T5: replace the treasury hook (default is [`LoggingTreasuryHook`]).
+    pub fn set_treasury_hook(&mut self, hook: Box<dyn TreasuryHook>) {
+        self.treasury_hook = hook;
     }
 
     /// Set the current epoch
@@ -149,17 +203,26 @@ impl TaskPool {
     }
 
     /// Fetch a task, optionally recording the miner for redundant assignment.
-    /// Selects the highest-fee matching task (C3: priority by fee).
+    ///
+    /// T5 fair scheduling, in order:
+    /// 1. **Priority tier first** — only candidates from the highest
+    ///    priority tier present are considered (tier 2 before 1 before 0).
+    /// 2. **Round-robin across tenants** within that tier — tenants are
+    ///    ordered by address and served cyclically from a single cursor, so
+    ///    no tenant is served twice before every other tenant with matching
+    ///    pending work is served once (starvation-free).
+    /// 3. **Highest fee within a tenant** (pre-T5 C3 behavior, preserved).
+    ///
+    /// Synthetic tasks have no submitter and are attributed to
+    /// `Address::ZERO` at the default tier's priority.
     pub fn fetch_task_for(
         &mut self,
         tier: GpuTier,
         available_memory_mb: u64,
         miner: Option<Address>,
     ) -> Option<InferenceTask> {
-        // Find all matching candidates, pick the one with highest fee (C3)
-        let mut best_idx: Option<usize> = None;
-        let mut best_fee: u128 = 0;
-
+        // Collect matching candidates: (index, tenant, priority, fee).
+        let mut candidates: Vec<(usize, Address, u8, u128)> = Vec::new();
         for (i, task) in self.pending.iter().enumerate() {
             let reqs = task_requirements(&task.task_type);
             if !tier_can_run(tier, reqs.min_tier) || available_memory_mb < reqs.min_memory_mb {
@@ -173,19 +236,45 @@ impl TaskPool {
                     }
                 }
             }
-            // Check fee from public_tasks; synthetic tasks have fee=0
-            let fee = self
+            // Tenant + fee from public_tasks; synthetic tasks are the
+            // zero-address tenant with fee 0.
+            let (tenant, fee) = self
                 .public_tasks
                 .get(&task.task_id)
-                .map(|pt| pt.max_fee)
-                .unwrap_or(0);
-            if best_idx.is_none() || fee > best_fee {
-                best_idx = Some(i);
-                best_fee = fee;
-            }
+                .map(|pt| (pt.submitter, pt.max_fee))
+                .unwrap_or((Address::ZERO, 0));
+            let priority = self.quota.priority_for(&tenant);
+            candidates.push((i, tenant, priority, fee));
+        }
+        if candidates.is_empty() {
+            return None;
         }
 
-        let idx = best_idx?;
+        // 1. Highest priority tier only.
+        let max_priority = candidates.iter().map(|c| c.2).max().unwrap_or(0);
+        candidates.retain(|c| c.2 == max_priority);
+
+        // 2. Round-robin across tenants: pick the smallest tenant address
+        //    strictly greater than the cursor, wrapping to the smallest.
+        let mut tenants: Vec<Address> = candidates.iter().map(|c| c.1).collect();
+        tenants.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        tenants.dedup();
+        let chosen_tenant = match self.rr_last_tenant {
+            Some(last) => tenants
+                .iter()
+                .find(|t| t.as_bytes() > last.as_bytes())
+                .copied()
+                .unwrap_or(tenants[0]),
+            None => tenants[0],
+        };
+        self.rr_last_tenant = Some(chosen_tenant);
+
+        // 3. Highest fee within the chosen tenant.
+        let idx = candidates
+            .iter()
+            .filter(|c| c.1 == chosen_tenant)
+            .max_by_key(|c| c.3)
+            .map(|c| c.0)?;
         let task = self.pending[idx].clone();
         let task_id = task.task_id;
 
@@ -239,7 +328,35 @@ impl TaskPool {
         self.pending.retain(|t| t.deadline > now);
     }
 
-    /// Submit a public inference task
+    /// T5: submit a public inference task with per-tenant quota admission.
+    ///
+    /// Checks (in order): pool-pressure shedding (lowest priority first),
+    /// QPS token bucket, in-flight limit, FLOPs budget (charged with the
+    /// task's `estimated_flops`). With no quota config installed every
+    /// submission is admitted. On rejection the pool is unchanged and the
+    /// typed [`QuotaError`] carries the violated limit + retry-after hint.
+    pub fn try_submit_public_task(
+        &mut self,
+        submitter: Address,
+        task: InferenceTask,
+        max_fee: u128,
+        now_ms: u64,
+    ) -> Result<Hash, QuotaError> {
+        let estimated_flops = task_requirements(&task.task_type).estimated_flops;
+        if let Err(err) = self
+            .quota
+            .admit(&submitter, estimated_flops, self.pending.len(), now_ms)
+        {
+            if let Some(i) = REJECT_REASONS.iter().position(|r| *r == err.reason()) {
+                self.rejected_by_reason[i] += 1;
+            }
+            return Err(err);
+        }
+        Ok(self.submit_public_task(submitter, task, max_fee))
+    }
+
+    /// Submit a public inference task (no quota admission — prefer
+    /// [`TaskPool::try_submit_public_task`] on externally driven paths).
     pub fn submit_public_task(
         &mut self,
         submitter: Address,
@@ -249,6 +366,10 @@ impl TaskPool {
         let task_id = task.task_id;
         let input_hash = task.task_type.input_hash();
         let now = now_ms();
+        // T5: in-flight + submission accounting.
+        self.quota.task_started(&submitter, now);
+        let tier = self.quota.priority_for(&submitter) as usize;
+        self.submitted_by_tier[tier] += 1;
         let public = PublicTask {
             task_id,
             submitter,
@@ -321,6 +442,19 @@ impl TaskPool {
     ) -> bool {
         self.assigned.remove(task_id);
         if let Some(mut task) = self.public_tasks.remove(task_id) {
+            // T5: meter the completed task — estimated_flops attributed to
+            // both the tenant (submitter) and the executing miner — and
+            // notify the treasury hook.
+            let flops = task_requirements(&task.inner_task.task_type).estimated_flops;
+            let tier = self.quota.priority_for(&task.submitter) as usize;
+            self.quota.task_finished(&task.submitter);
+            self.cost
+                .record(&task.submitter, &miner, flops, task.max_fee);
+            self.flops_metered_by_tier[tier] =
+                self.flops_metered_by_tier[tier].saturating_add(flops as u128);
+            self.treasury_hook
+                .on_task_charged(&task.submitter, &miner, flops, task.max_fee);
+
             task.status = PublicTaskStatus::Completed {
                 result,
                 miner,
@@ -400,6 +534,9 @@ impl TaskPool {
                 let input_hash = task.inner_task.task_type.input_hash();
                 self.input_hash_index.remove(&input_hash);
                 self.assigned.remove(&id);
+                // T5: expired tasks leave the tenant's in-flight count
+                // (no cost metering — the task was never executed).
+                self.quota.task_finished(&task.submitter);
                 task.status = PublicTaskStatus::Expired;
                 // Retain for querying before returning for refund
                 let retain_until = now + COMPLETED_RETENTION_MS;
@@ -429,6 +566,43 @@ impl TaskPool {
             }
         }
         pruned
+    }
+
+    /// T5: generate a periodic cost report (per-tenant + per-miner FLOPs and
+    /// fees over the interval since the previous report), notify the
+    /// treasury hook, and retain it for querying.
+    pub fn generate_cost_report(&mut self, now_ms: u64) -> CostReport {
+        let report = self.cost.generate_report(now_ms);
+        self.treasury_hook.on_cost_report(&report);
+        report
+    }
+
+    /// T5: the most recent cost report (queryable accessor for RPC/exporter).
+    pub fn last_cost_report(&self) -> Option<&CostReport> {
+        self.cost.last_report()
+    }
+
+    /// T5: read access to the cost meter (cumulative per-tenant/per-miner
+    /// totals).
+    pub fn cost_meter(&self) -> &CostMeter {
+        &self.cost
+    }
+
+    /// T5: bounded-cardinality metrics snapshot for the Prometheus exporter.
+    pub fn quota_metrics(&self) -> AiQuotaMetrics {
+        let mut rejected = [("", 0u64); REJECT_REASONS.len()];
+        for (i, reason) in REJECT_REASONS.iter().enumerate() {
+            rejected[i] = (*reason, self.rejected_by_reason[i]);
+        }
+        AiQuotaMetrics {
+            quotas_enabled: self.quota.enabled(),
+            pending_tasks: self.pending.len(),
+            submitted_by_tier: self.submitted_by_tier,
+            rejected_by_reason: rejected,
+            flops_metered_by_tier: self.flops_metered_by_tier,
+            inflight_by_tier: self.quota.inflight_by_priority(),
+            cost_report_unix_ms: self.cost.last_report_unix_ms(),
+        }
     }
 
     /// Serialize a PublicTask to bytes for storage
@@ -844,5 +1018,313 @@ mod tests {
 
         // Task should no longer be in memory
         assert!(pool.get_public_task(&task_id).is_none());
+    }
+
+    // ---------- T5: quotas, fairness, metering, treasury hook ----------
+
+    fn make_public_task(pool: &mut TaskPool, submitter: Address, seed: &[u8], fee: u128) -> Hash {
+        let input_hash = qfc_crypto::blake3_hash(seed);
+        let task_type = qfc_inference::task::ComputeTaskType::Embedding {
+            model_id: qfc_inference::task::ModelId::new("test", "v1"),
+            input_hash,
+        };
+        let task_id = qfc_crypto::blake3_hash(&[seed, b"id"].concat());
+        let task = InferenceTask::new(task_id, 1, task_type, vec![], now_ms(), u64::MAX);
+        pool.submit_public_task(submitter, task, fee);
+        task_id
+    }
+
+    fn try_submit(
+        pool: &mut TaskPool,
+        submitter: Address,
+        seed: &[u8],
+        now: u64,
+    ) -> Result<Hash, crate::quota::QuotaError> {
+        let input_hash = qfc_crypto::blake3_hash(seed);
+        let task_type = qfc_inference::task::ComputeTaskType::Embedding {
+            model_id: qfc_inference::task::ModelId::new("test", "v1"),
+            input_hash,
+        };
+        let task_id = qfc_crypto::blake3_hash(&[seed, b"id"].concat());
+        let task = InferenceTask::new(task_id, 1, task_type, vec![], now, u64::MAX);
+        pool.try_submit_public_task(submitter, task, 1_000, now)
+    }
+
+    fn quota_cfg(json: &str) -> crate::quota::QuotaConfig {
+        crate::quota::QuotaConfig::from_json_str(json).unwrap()
+    }
+
+    #[test]
+    fn test_try_submit_quota_rejection_and_counters() {
+        let mut pool = TaskPool::new();
+        pool.set_quota_config(Some(quota_cfg(
+            r#"{ "default_tier": { "max_qps": 1.0, "burst": 1 } }"#,
+        )));
+
+        assert!(try_submit(&mut pool, Address::new([1; 20]), b"a", 0).is_ok());
+        let err = try_submit(&mut pool, Address::new([1; 20]), b"b", 0).unwrap_err();
+        assert_eq!(err.reason(), "qps");
+        assert!(err.retry_after_ms() > 0);
+
+        let m = pool.quota_metrics();
+        assert!(m.quotas_enabled);
+        assert_eq!(m.pending_tasks, 1);
+        assert_eq!(m.submitted_by_tier[1], 1); // default tier priority = 1
+        assert_eq!(
+            m.rejected_by_reason
+                .iter()
+                .find(|(r, _)| *r == "qps")
+                .unwrap()
+                .1,
+            1
+        );
+    }
+
+    #[test]
+    fn test_quotas_off_admits_everything() {
+        let mut pool = TaskPool::new();
+        for i in 0..50u64 {
+            assert!(try_submit(&mut pool, Address::new([1; 20]), &i.to_le_bytes(), 0).is_ok());
+        }
+        assert!(!pool.quotas_enabled());
+        assert_eq!(pool.quota_metrics().submitted_by_tier[1], 50);
+    }
+
+    #[test]
+    fn test_fair_scheduling_two_tenants_starvation_free() {
+        let mut pool = TaskPool::new();
+        let (a, b) = (Address::new([0xAA; 20]), Address::new([0xBB; 20]));
+
+        // Tenant A floods the pool with high-fee tasks; B submits cheap ones.
+        for i in 0..4u8 {
+            make_public_task(&mut pool, a, &[b'a', i], 1_000_000);
+        }
+        for i in 0..4u8 {
+            make_public_task(&mut pool, b, &[b'b', i], 1);
+        }
+
+        // Round-robin must alternate tenants despite the fee gap.
+        let mut order = Vec::new();
+        for _ in 0..8 {
+            let task = pool.fetch_task(GpuTier::Hot, 100_000).unwrap();
+            let tenant = pool.get_public_task(&task.task_id).unwrap().submitter;
+            order.push(tenant);
+        }
+        let a_count_first_half = order[..4].iter().filter(|t| **t == a).count();
+        let b_count_first_half = order[..4].iter().filter(|t| **t == b).count();
+        assert_eq!(
+            a_count_first_half, 2,
+            "tenant A must not starve B: {order:?}"
+        );
+        assert_eq!(
+            b_count_first_half, 2,
+            "tenant B must be served fairly: {order:?}"
+        );
+        // No two consecutive fetches serve the same tenant while both have work.
+        for w in order[..7].windows(2) {
+            assert_ne!(w[0], w[1], "round-robin must alternate: {order:?}");
+        }
+    }
+
+    #[test]
+    fn test_priority_tier_served_before_lower() {
+        let mut pool = TaskPool::new();
+        let (lo, hi) = (Address::new([0x01; 20]), Address::new([0x02; 20]));
+        pool.set_quota_config(Some(quota_cfg(&format!(
+            r#"{{
+                "default_tier": {{ "max_qps": 0.0 }},
+                "tenants": {{
+                    "0x{}": {{ "max_qps": 0.0, "priority": 0 }},
+                    "0x{}": {{ "max_qps": 0.0, "priority": 2 }}
+                }}
+            }}"#,
+            hex::encode(lo.as_bytes()),
+            hex::encode(hi.as_bytes()),
+        ))));
+
+        // Low-priority task submitted first and with a far higher fee.
+        make_public_task(&mut pool, lo, b"low-prio", 1_000_000);
+        make_public_task(&mut pool, hi, b"high-prio", 1);
+
+        let first = pool.fetch_task(GpuTier::Hot, 100_000).unwrap();
+        assert_eq!(
+            pool.get_public_task(&first.task_id).unwrap().submitter,
+            hi,
+            "highest priority tier must be served first"
+        );
+        let second = pool.fetch_task(GpuTier::Hot, 100_000).unwrap();
+        assert_eq!(pool.get_public_task(&second.task_id).unwrap().submitter, lo);
+    }
+
+    #[test]
+    fn test_degradation_order_under_pool_pressure() {
+        let mut pool = TaskPool::new();
+        let (t0, t1, t2) = (
+            Address::new([0x10; 20]),
+            Address::new([0x11; 20]),
+            Address::new([0x12; 20]),
+        );
+        pool.set_quota_config(Some(quota_cfg(&format!(
+            r#"{{
+                "max_pending": 8,
+                "default_tier": {{ "max_qps": 0.0 }},
+                "tenants": {{
+                    "0x{}": {{ "max_qps": 0.0, "priority": 0 }},
+                    "0x{}": {{ "max_qps": 0.0, "priority": 1 }},
+                    "0x{}": {{ "max_qps": 0.0, "priority": 2 }}
+                }}
+            }}"#,
+            hex::encode(t0.as_bytes()),
+            hex::encode(t1.as_bytes()),
+            hex::encode(t2.as_bytes()),
+        ))));
+
+        // Fill the pool to 4 pending (50% of 8): tier 0 sheds first.
+        for i in 0..4u8 {
+            assert!(try_submit(&mut pool, t2, &[b'f', i], 0).is_ok());
+        }
+        assert_eq!(pool.pending_count(), 4);
+        assert_eq!(
+            try_submit(&mut pool, t0, b"shed0", 0).unwrap_err().reason(),
+            "pool_pressure"
+        );
+        assert!(try_submit(&mut pool, t1, b"ok1", 0).is_ok());
+        assert!(try_submit(&mut pool, t2, b"ok2", 0).is_ok());
+
+        // At 6 pending (75%): tier 1 sheds too; tier 2 still admitted.
+        assert_eq!(pool.pending_count(), 6);
+        assert_eq!(
+            try_submit(&mut pool, t1, b"shed1", 0).unwrap_err().reason(),
+            "pool_pressure"
+        );
+        assert!(try_submit(&mut pool, t2, b"ok3", 0).is_ok());
+        assert!(try_submit(&mut pool, t2, b"ok4", 0).is_ok());
+
+        // At the hard cap (8): even tier 2 sheds.
+        assert_eq!(pool.pending_count(), 8);
+        assert_eq!(
+            try_submit(&mut pool, t2, b"shed2", 0).unwrap_err().reason(),
+            "pool_pressure"
+        );
+    }
+
+    #[test]
+    fn test_metering_per_tenant_and_miner_and_inflight() {
+        let mut pool = TaskPool::new();
+        let (tenant_a, tenant_b) = (Address::new([0xA1; 20]), Address::new([0xB1; 20]));
+        let (miner_x, miner_y) = (Address::new([0x71; 20]), Address::new([0x72; 20]));
+
+        let id1 = make_public_task(&mut pool, tenant_a, b"m1", 500);
+        let id2 = make_public_task(&mut pool, tenant_a, b"m2", 700);
+        let id3 = make_public_task(&mut pool, tenant_b, b"m3", 900);
+
+        // In-flight is tracked per tenant (default tier = priority 1).
+        assert_eq!(pool.quota_metrics().inflight_by_tier, [0, 3, 0]);
+
+        // Embedding tasks meter 1 GFLOP each (task_requirements).
+        pool.complete_public_task(&id1, ResultStorage::Inline(vec![]), miner_x, 10);
+        pool.complete_public_task(&id2, ResultStorage::Inline(vec![]), miner_y, 10);
+        pool.complete_public_task(&id3, ResultStorage::Inline(vec![]), miner_x, 10);
+
+        let meter = pool.cost_meter();
+        let a = meter.tenant_total(&tenant_a);
+        assert_eq!(a.tasks, 2);
+        assert_eq!(a.flops, 2_000_000_000);
+        assert_eq!(a.fees_wei, 1_200);
+        let b = meter.tenant_total(&tenant_b);
+        assert_eq!(b.tasks, 1);
+        assert_eq!(b.flops, 1_000_000_000);
+        let x = meter.miner_total(&miner_x);
+        assert_eq!(x.tasks, 2);
+        assert_eq!(x.flops, 2_000_000_000);
+        assert_eq!(x.fees_wei, 1_400);
+        let y = meter.miner_total(&miner_y);
+        assert_eq!(y.tasks, 1);
+
+        let m = pool.quota_metrics();
+        assert_eq!(m.inflight_by_tier, [0, 0, 0]);
+        assert_eq!(m.flops_metered_by_tier[1], 3_000_000_000);
+
+        // Cost report: queryable, sorted, freshness timestamp set.
+        let report = pool.generate_cost_report(123_456);
+        assert_eq!(report.tenants.len(), 2);
+        assert_eq!(report.miners.len(), 2);
+        assert_eq!(report.interval_total.tasks, 3);
+        assert_eq!(pool.last_cost_report().unwrap().generated_at_ms, 123_456);
+        assert_eq!(pool.quota_metrics().cost_report_unix_ms, 123_456);
+    }
+
+    #[test]
+    fn test_expired_task_frees_inflight_without_metering() {
+        let mut pool = TaskPool::new();
+        let tenant = Address::new([0xC1; 20]);
+        let input_hash = qfc_crypto::blake3_hash(b"exp");
+        let task_type = qfc_inference::task::ComputeTaskType::Embedding {
+            model_id: qfc_inference::task::ModelId::new("test", "v1"),
+            input_hash,
+        };
+        let task_id = qfc_crypto::blake3_hash(b"exp-id");
+        let now = now_ms();
+        let task = InferenceTask::new(task_id, 1, task_type, vec![], now, now + 10);
+        pool.submit_public_task(tenant, task, 100);
+        assert_eq!(pool.quota_metrics().inflight_by_tier[1], 1);
+
+        let expired = pool.prune_expired_public(now + 1_000);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(pool.quota_metrics().inflight_by_tier[1], 0);
+        // Never executed → nothing metered.
+        assert_eq!(pool.cost_meter().cumulative_flops(), 0);
+    }
+
+    #[test]
+    fn test_treasury_hook_invoked() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::sync::Arc;
+
+        #[derive(Default)]
+        struct RecordingHook {
+            charges: AtomicU64,
+            charged_flops: AtomicU64,
+            reports: AtomicU64,
+        }
+        impl crate::cost::TreasuryHook for RecordingHook {
+            fn on_task_charged(
+                &self,
+                _tenant: &Address,
+                _miner: &Address,
+                flops: u64,
+                _fee_wei: u128,
+            ) {
+                self.charges.fetch_add(1, Ordering::Relaxed);
+                self.charged_flops.fetch_add(flops, Ordering::Relaxed);
+            }
+            fn on_cost_report(&self, _report: &crate::cost::CostReport) {
+                self.reports.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        struct SharedHook(Arc<RecordingHook>);
+        impl crate::cost::TreasuryHook for SharedHook {
+            fn on_task_charged(&self, t: &Address, m: &Address, f: u64, w: u128) {
+                self.0.on_task_charged(t, m, f, w)
+            }
+            fn on_cost_report(&self, r: &crate::cost::CostReport) {
+                self.0.on_cost_report(r)
+            }
+        }
+
+        let hook = Arc::new(RecordingHook::default());
+        let mut pool = TaskPool::new();
+        pool.set_treasury_hook(Box::new(SharedHook(hook.clone())));
+
+        let tenant = Address::new([0xD1; 20]);
+        let miner = Address::new([0xD2; 20]);
+        let id = make_public_task(&mut pool, tenant, b"hook", 500);
+        pool.complete_public_task(&id, ResultStorage::Inline(vec![]), miner, 5);
+        pool.generate_cost_report(1);
+
+        assert_eq!(hook.charges.load(Ordering::Relaxed), 1);
+        assert_eq!(hook.charged_flops.load(Ordering::Relaxed), 1_000_000_000);
+        assert_eq!(hook.reports.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/qfc-node/src/main.rs
+++ b/crates/qfc-node/src/main.rs
@@ -147,6 +147,19 @@ struct Args {
     /// Snapshot archive name prefix.
     #[arg(long, default_value = "qfc-snapshot", env = "QFC_SNAPSHOT_PREFIX")]
     snapshot_prefix: String,
+
+    /// T5: per-tenant AI task-pool quota config (JSON; see docs/AI-QUOTAS.md).
+    /// Unset = quotas off (admission always succeeds). The file is
+    /// hot-reloaded: changes are picked up within ~30s (mtime check); a
+    /// parse error keeps the previous config and logs the failure.
+    #[arg(long, env = "QFC_AI_QUOTAS")]
+    ai_quotas: Option<PathBuf>,
+
+    /// T5: interval in seconds between AI cost reports (per-tenant/per-miner
+    /// FLOPs + fees, emitted as a structured log and handed to the treasury
+    /// hook). 0 = disabled.
+    #[arg(long, default_value_t = 600, env = "QFC_AI_COST_REPORT_INTERVAL_SECS")]
+    ai_cost_report_interval_secs: u64,
 }
 
 #[tokio::main]
@@ -258,6 +271,27 @@ async fn main() -> Result<()> {
     // v2.0: Shared proof pool and task pool for RPC, sync, and block producer
     let proof_pool = Arc::new(RwLock::new(ProofPool::new()));
     let task_pool = Arc::new(RwLock::new(TaskPool::new()));
+
+    // T5: per-tenant quotas (--ai-quotas) + periodic cost reports.
+    if let Some(ref quota_path) = args.ai_quotas {
+        let cfg = qfc_ai_coordinator::QuotaConfig::from_file(quota_path)
+            .map_err(|e| anyhow::anyhow!("Invalid --ai-quotas file {:?}: {}", quota_path, e))?;
+        info!(
+            "AI quotas enabled from {:?} ({} tenant overrides, default tier: {} qps / {} in-flight, window {}s, max pending {})",
+            quota_path,
+            cfg.tenants.len(),
+            cfg.default_tier.max_qps,
+            cfg.default_tier.max_inflight,
+            cfg.window_secs,
+            cfg.max_pending
+        );
+        task_pool.write().set_quota_config(Some(cfg));
+    }
+    spawn_ai_quota_task(
+        task_pool.clone(),
+        args.ai_quotas.clone(),
+        args.ai_cost_report_interval_secs,
+    );
 
     // v2.0 P2: Shared challenge generator, redundant verifier, task router
     let challenge_generator = Arc::new(RwLock::new(
@@ -532,7 +566,8 @@ async fn main() -> Result<()> {
         args.chain_id,
     )
     .with_rpc_metrics(rpc_metrics.clone())
-    .with_storage(db.clone());
+    .with_storage(db.clone())
+    .with_task_pool(task_pool.clone());
     if let Some(ref sync) = _sync_manager {
         metrics_server =
             metrics_server.with_sync_status(sync.clone() as Arc<dyn qfc_rpc::SyncStatusProvider>);
@@ -568,4 +603,70 @@ async fn main() -> Result<()> {
     info!("Shutting down...");
 
     Ok(())
+}
+
+/// T5: background task driving (a) periodic AI cost reports
+/// (`--ai-cost-report-interval-secs`, 0 = disabled) and (b) hot reload of
+/// the `--ai-quotas` config file (mtime check every tick; a file that fails
+/// to parse keeps the previous config). No-op when both are disabled.
+fn spawn_ai_quota_task(
+    task_pool: Arc<RwLock<TaskPool>>,
+    quota_path: Option<PathBuf>,
+    report_interval_secs: u64,
+) {
+    if quota_path.is_none() && report_interval_secs == 0 {
+        return;
+    }
+
+    const TICK_SECS: u64 = 30;
+    tokio::spawn(async move {
+        let mut last_mtime: Option<std::time::SystemTime> = quota_path
+            .as_ref()
+            .and_then(|p| std::fs::metadata(p).and_then(|m| m.modified()).ok());
+        let mut secs_since_report = 0u64;
+
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(TICK_SECS)).await;
+
+            // Hot reload on mtime change.
+            if let Some(ref path) = quota_path {
+                let mtime = std::fs::metadata(path).and_then(|m| m.modified()).ok();
+                if mtime.is_some() && mtime != last_mtime {
+                    last_mtime = mtime;
+                    match qfc_ai_coordinator::QuotaConfig::from_file(path) {
+                        Ok(cfg) => {
+                            info!(
+                                "AI quota config reloaded from {:?} ({} tenant overrides)",
+                                path,
+                                cfg.tenants.len()
+                            );
+                            task_pool.write().set_quota_config(Some(cfg));
+                        }
+                        Err(e) => {
+                            warn!(
+                                "AI quota config reload failed, keeping previous config: {}",
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Periodic cost report.
+            if report_interval_secs > 0 {
+                secs_since_report += TICK_SECS;
+                if secs_since_report >= report_interval_secs {
+                    secs_since_report = 0;
+                    let now_ms = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0);
+                    // generate_cost_report logs via the treasury hook
+                    // (target qfc::ai_cost) and retains the report for
+                    // the exporter/RPC.
+                    let _ = task_pool.write().generate_cost_report(now_ms);
+                }
+            }
+        }
+    });
 }

--- a/crates/qfc-node/src/metrics.rs
+++ b/crates/qfc-node/src/metrics.rs
@@ -46,6 +46,8 @@ pub struct MetricsServer {
     /// T4.2: backup-freshness metrics, shared with the snapshot backup task.
     /// Only present when backups are enabled (--snapshot-interval-secs).
     snapshot_backup: Option<Arc<SnapshotBackupMetrics>>,
+    /// T5: AI task pool, for quota/cost-attribution metrics.
+    task_pool: Option<Arc<RwLock<qfc_ai_coordinator::TaskPool>>>,
 }
 
 impl MetricsServer {
@@ -74,6 +76,7 @@ impl MetricsServer {
             reorgs_detected: AtomicU64::new(0),
             storage: None,
             snapshot_backup: None,
+            task_pool: None,
         }
     }
 
@@ -102,6 +105,13 @@ impl MetricsServer {
     /// instead of firing on age 0).
     pub fn with_snapshot_backup(mut self, metrics: Arc<SnapshotBackupMetrics>) -> Self {
         self.snapshot_backup = Some(metrics);
+        self
+    }
+
+    /// Attach the shared AI task pool for quota/cost-attribution metrics
+    /// (T5). Cheap `Arc` clone of the pool shared with RPC and the producer.
+    pub fn with_task_pool(mut self, task_pool: Arc<RwLock<qfc_ai_coordinator::TaskPool>>) -> Self {
+        self.task_pool = Some(task_pool);
         self
     }
 
@@ -410,7 +420,93 @@ impl MetricsServer {
             Self::render_snapshot_backup_metrics(snap, &mut out);
         }
 
+        // --- AI task pool quotas + cost attribution (T5) ---
+        if let Some(pool) = &self.task_pool {
+            let snapshot = pool.read().quota_metrics();
+            Self::render_ai_quota_metrics(&snapshot, &mut out);
+        }
+
         out
+    }
+
+    /// T5: quota/cost-attribution metrics. Labeled by priority **tier**
+    /// (`tenant_tier` ∈ 0/1/2) rather than tenant address — tenant
+    /// cardinality is unbounded, tiers are fixed at three. Per-tenant
+    /// detail is in the periodic cost report (structured log, target
+    /// `qfc::ai_cost`) and the `TaskPool::last_cost_report` accessor.
+    /// `qfc_ai_cost_report_last_timestamp_seconds` follows the T4.2
+    /// freshness convention: 0 = never since start, alert on age in PromQL.
+    fn render_ai_quota_metrics(snapshot: &qfc_ai_coordinator::AiQuotaMetrics, out: &mut String) {
+        let enabled: u8 = if snapshot.quotas_enabled { 1 } else { 0 };
+        let _ = writeln!(
+            out,
+            "# HELP qfc_ai_quotas_enabled Whether per-tenant AI task quotas are enforced (--ai-quotas). Accounting metrics below are exported regardless."
+        );
+        let _ = writeln!(out, "# TYPE qfc_ai_quotas_enabled gauge");
+        let _ = writeln!(out, "qfc_ai_quotas_enabled {enabled}");
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_ai_pending_tasks Tasks waiting in the AI task pool (pool-pressure shedding input)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_ai_pending_tasks gauge");
+        let _ = writeln!(out, "qfc_ai_pending_tasks {}", snapshot.pending_tasks);
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_ai_tasks_submitted_total Public AI tasks admitted to the pool, by tenant priority tier (0=lowest/shed first, 2=highest)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_ai_tasks_submitted_total counter");
+        for (tier, v) in snapshot.submitted_by_tier.iter().enumerate() {
+            let _ = writeln!(
+                out,
+                "qfc_ai_tasks_submitted_total{{tenant_tier=\"{tier}\"}} {v}"
+            );
+        }
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_ai_tasks_rejected_total AI task submissions rejected by quota admission, by violated limit."
+        );
+        let _ = writeln!(out, "# TYPE qfc_ai_tasks_rejected_total counter");
+        for (reason, v) in snapshot.rejected_by_reason.iter() {
+            let _ = writeln!(
+                out,
+                "qfc_ai_tasks_rejected_total{{reason=\"{reason}\"}} {v}"
+            );
+        }
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_ai_flops_metered_total estimated_flops metered on completed public tasks, by tenant priority tier."
+        );
+        let _ = writeln!(out, "# TYPE qfc_ai_flops_metered_total counter");
+        for (tier, v) in snapshot.flops_metered_by_tier.iter().enumerate() {
+            let _ = writeln!(
+                out,
+                "qfc_ai_flops_metered_total{{tenant_tier=\"{tier}\"}} {v}"
+            );
+        }
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_ai_tenant_inflight Public tasks currently Pending/Assigned, summed per tenant priority tier."
+        );
+        let _ = writeln!(out, "# TYPE qfc_ai_tenant_inflight gauge");
+        for (tier, v) in snapshot.inflight_by_tier.iter().enumerate() {
+            let _ = writeln!(out, "qfc_ai_tenant_inflight{{tenant_tier=\"{tier}\"}} {v}");
+        }
+
+        let ts_secs = snapshot.cost_report_unix_ms / 1000;
+        let _ = writeln!(
+            out,
+            "# HELP qfc_ai_cost_report_last_timestamp_seconds Unix time of the last AI cost report. 0 = never since start; alert on age."
+        );
+        let _ = writeln!(
+            out,
+            "# TYPE qfc_ai_cost_report_last_timestamp_seconds gauge"
+        );
+        let _ = writeln!(out, "qfc_ai_cost_report_last_timestamp_seconds {ts_secs}");
     }
 
     /// T4.2: backup-freshness metrics. Only rendered when the snapshot
@@ -783,6 +879,47 @@ mod tests {
         rpc_metrics.request_started();
         rpc_metrics.request_finished("eth_blockNumber", std::time::Duration::from_millis(5), None);
 
+        // T5: task pool with quota/cost activity (one submission admitted,
+        // one rejected by QPS, one completion metered, one cost report).
+        let task_pool = {
+            let mut pool = qfc_ai_coordinator::TaskPool::new();
+            let cfg = qfc_ai_coordinator::QuotaConfig::from_json_str(
+                r#"{ "default_tier": { "max_qps": 1.0, "burst": 1 } }"#,
+            )
+            .unwrap();
+            pool.set_quota_config(Some(cfg));
+            let make_task = |seed: &[u8]| {
+                let input_hash = qfc_crypto::blake3_hash(seed);
+                qfc_inference::InferenceTask::new(
+                    qfc_crypto::blake3_hash(&[seed, b"id"].concat()),
+                    1,
+                    qfc_inference::task::ComputeTaskType::Embedding {
+                        model_id: qfc_inference::task::ModelId::new("test", "v1"),
+                        input_hash,
+                    },
+                    vec![],
+                    0,
+                    u64::MAX,
+                )
+            };
+            let tenant = qfc_types::Address::new([0xAB; 20]);
+            let task = make_task(b"metrics-t5");
+            let task_id = task.task_id;
+            pool.try_submit_public_task(tenant, task, 1_000, 0).unwrap();
+            // Second submission at the same instant exceeds the 1-token burst.
+            assert!(pool
+                .try_submit_public_task(tenant, make_task(b"metrics-t5-b"), 1_000, 0)
+                .is_err());
+            pool.complete_public_task(
+                &task_id,
+                qfc_ai_coordinator::task_pool::ResultStorage::Inline(vec![]),
+                qfc_types::Address::new([0xCD; 20]),
+                7,
+            );
+            pool.generate_cost_report(1_765_000_000_000);
+            Arc::new(RwLock::new(pool))
+        };
+
         // T4.2: backup-freshness metrics as the backup task would update them.
         let snapshot_metrics = Arc::new(SnapshotBackupMetrics::default());
         snapshot_metrics
@@ -807,7 +944,8 @@ mod tests {
         .with_sync_status(Arc::new(FakeSync))
         .with_rpc_metrics(rpc_metrics)
         .with_storage(db)
-        .with_snapshot_backup(snapshot_metrics);
+        .with_snapshot_backup(snapshot_metrics)
+        .with_task_pool(task_pool);
         (server, tmp)
     }
 
@@ -869,6 +1007,14 @@ mod tests {
             "qfc_snapshot_failures_total",
             "qfc_snapshot_duration_seconds",
             "qfc_snapshot_size_bytes",
+            // AI task pool quotas + cost attribution (T5)
+            "qfc_ai_quotas_enabled",
+            "qfc_ai_pending_tasks",
+            "qfc_ai_tasks_submitted_total",
+            "qfc_ai_tasks_rejected_total",
+            "qfc_ai_flops_metered_total",
+            "qfc_ai_tenant_inflight",
+            "qfc_ai_cost_report_last_timestamp_seconds",
         ] {
             assert!(
                 out.contains(name),
@@ -881,6 +1027,19 @@ mod tests {
         assert!(out.contains("qfc_snapshot_last_success_timestamp_seconds 1765000000"));
         assert!(out.contains("qfc_snapshot_failures_total 0"));
         assert!(out.contains("qfc_snapshot_size_bytes 4096"));
+        // T5: tier/reason labels carry the quota activity seeded above
+        // (default tier = priority 1; one QPS rejection; one completed
+        // Embedding task = 1 GFLOP metered; report at 1_765_000_000_000 ms).
+        assert!(out.contains("qfc_ai_quotas_enabled 1"));
+        assert!(out.contains("qfc_ai_tasks_submitted_total{tenant_tier=\"1\"} 1"));
+        assert!(out.contains("qfc_ai_tasks_submitted_total{tenant_tier=\"0\"} 0"));
+        assert!(out.contains("qfc_ai_tasks_rejected_total{reason=\"qps\"} 1"));
+        assert!(out.contains("qfc_ai_tasks_rejected_total{reason=\"pool_pressure\"} 0"));
+        assert!(out.contains("qfc_ai_tasks_rejected_total{reason=\"in_flight\"} 0"));
+        assert!(out.contains("qfc_ai_tasks_rejected_total{reason=\"flops_budget\"} 0"));
+        assert!(out.contains("qfc_ai_flops_metered_total{tenant_tier=\"1\"} 1000000000"));
+        assert!(out.contains("qfc_ai_tenant_inflight{tenant_tier=\"1\"} 0"));
+        assert!(out.contains("qfc_ai_cost_report_last_timestamp_seconds 1765000000"));
         // Per-CF metrics carry a {cf="..."} label for every CF in cf::ALL.
         for cf_name in cf::ALL {
             assert!(

--- a/crates/qfc-rpc/src/error.rs
+++ b/crates/qfc-rpc/src/error.rs
@@ -22,6 +22,27 @@ pub enum RpcError {
 
     #[error("Internal error: {0}")]
     Internal(String),
+
+    /// T5: AI task-pool quota rejection. Carries the violated limit
+    /// (`reason` ∈ pool_pressure | qps | in_flight | flops_budget) and a
+    /// retry-after hint; surfaced as JSON-RPC code -32029 with structured
+    /// `data`.
+    #[error("Quota exceeded ({reason}): {message}")]
+    QuotaExceeded {
+        reason: &'static str,
+        message: String,
+        retry_after_ms: u64,
+    },
+}
+
+impl From<qfc_ai_coordinator::QuotaError> for RpcError {
+    fn from(e: qfc_ai_coordinator::QuotaError) -> Self {
+        RpcError::QuotaExceeded {
+            reason: e.reason(),
+            message: e.to_string(),
+            retry_after_ms: e.retry_after_ms(),
+        }
+    }
 }
 
 impl From<RpcError> for ErrorObjectOwned {
@@ -39,8 +60,42 @@ impl From<RpcError> for ErrorObjectOwned {
             }
             RpcError::Execution(msg) => ErrorObjectOwned::owned(-32000, msg, None::<()>),
             RpcError::Internal(msg) => ErrorObjectOwned::owned(-32603, msg, None::<()>),
+            RpcError::QuotaExceeded {
+                reason,
+                message,
+                retry_after_ms,
+            } => ErrorObjectOwned::owned(
+                -32029,
+                format!("Quota exceeded ({reason}): {message}"),
+                Some(serde_json::json!({
+                    "reason": reason,
+                    "retryAfterMs": retry_after_ms,
+                })),
+            ),
         }
     }
 }
 
 pub type Result<T> = std::result::Result<T, RpcError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quota_error_maps_to_distinct_code_with_retry_hint() {
+        let quota_err = qfc_ai_coordinator::QuotaError::QpsExceeded {
+            tenant: qfc_types::Address::new([1; 20]),
+            limit: 5.0,
+            retry_after_ms: 200,
+        };
+        let rpc_err: RpcError = quota_err.into();
+        let obj: ErrorObjectOwned = rpc_err.into();
+        assert_eq!(obj.code(), -32029);
+        assert!(obj.message().contains("qps"), "message: {}", obj.message());
+        assert!(obj.message().contains("retry after 200ms"));
+        let data = obj.data().expect("structured data").to_string();
+        assert!(data.contains("\"retryAfterMs\":200"));
+        assert!(data.contains("\"reason\":\"qps\""));
+    }
+}

--- a/crates/qfc-rpc/src/qfc.rs
+++ b/crates/qfc-rpc/src/qfc.rs
@@ -226,7 +226,12 @@ pub trait QfcApi {
 
     // ---- v2.0: Public Inference API endpoints ----
 
-    /// Submit a public inference task (paid)
+    /// Submit a public inference task (paid).
+    ///
+    /// T5: may fail with JSON-RPC error `-32029` when the submitter's quota
+    /// is exceeded (QPS / in-flight / FLOPs budget) or the pool is shedding
+    /// low-priority tenants under pressure; the error `data` carries
+    /// `{reason, retryAfterMs}`. See docs/AI-QUOTAS.md.
     #[method(name = "submitPublicTask")]
     async fn submit_public_task(&self, request: RpcSubmitPublicTask) -> RpcResult<String>;
 

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -3459,7 +3459,26 @@ impl QfcApiServer for RpcServer {
             now + 60_000, // 60s deadline
         );
 
-        let public_task_id = pool.submit_public_task(submitter, task, max_fee);
+        // T5: per-tenant quota admission (QPS / in-flight / FLOPs budget /
+        // pool-pressure shedding). The fee was already escrowed above, so a
+        // rejection refunds it before surfacing the typed error (-32029).
+        let public_task_id = match pool.try_submit_public_task(submitter, task, max_fee, now) {
+            Ok(id) => id,
+            Err(quota_err) => {
+                drop(pool);
+                if let Err(e) = state.add_balance(&submitter, fee_u256) {
+                    warn!(
+                        "Failed to refund escrowed fee after quota rejection for {}: {}",
+                        submitter, e
+                    );
+                }
+                info!(
+                    "Public task rejected by quota for {}: {}",
+                    submitter, quota_err
+                );
+                return Err(RpcError::from(quota_err).into());
+            }
+        };
         info!(
             "Public task submitted by {}: {} (fee: {})",
             submitter,

--- a/docs/AI-QUOTAS.md
+++ b/docs/AI-QUOTAS.md
@@ -1,0 +1,199 @@
+# AI Task Pool: Multi-Tenant Quotas & Cost Attribution (T5)
+
+Per-submitter quotas on the AI task pool (QPS, in-flight, FLOPs budget) with
+fair scheduling, FLOPs cost attribution per tenant and per miner, and a
+treasury hook. Implements roadmap item T5 of
+[ROADMAP-SRE.md](ROADMAP-SRE.md).
+
+Code: `crates/qfc-ai-coordinator/src/quota.rs` (admission),
+`crates/qfc-ai-coordinator/src/cost.rs` (metering + treasury hook),
+`crates/qfc-ai-coordinator/src/task_pool.rs` (integration),
+`crates/qfc-rpc/src/error.rs` (RPC error surface),
+`crates/qfc-node/src/{main,metrics}.rs` (config + exporter).
+
+## Tenant model
+
+A **tenant is a submitter address** — the `submitter` of a public inference
+task (`qfc_submitPublicTask`). Each tenant resolves to a quota: an explicit
+per-tenant entry in the config, or the configured **default tier**.
+
+Per-tenant limits:
+
+| Limit | Mechanism | Config field | Disabled by |
+|---|---|---|---|
+| QPS | token bucket: refill `max_qps` tokens/s, capacity `burst` (default `ceil(max_qps)`) | `max_qps`, `burst` | `max_qps: 0` |
+| In-flight tasks | count of the tenant's public tasks in `Pending`/`Assigned` | `max_inflight` | `max_inflight: 0` |
+| FLOPs budget | sum of admitted `estimated_flops` per fixed window of `window_secs` (fixed-window approximation of a rolling budget; resets at window boundary) | `flops_per_window` | `flops_per_window: 0` |
+| Priority | tier 0–2; **2 = highest, 0 = shed first** | `priority` | — |
+
+`estimated_flops` comes from
+`task_types::task_requirements(task_type).estimated_flops` — the same
+per-task FLOPs estimate the fee pricing uses, so budget and billing agree.
+
+## Configuration
+
+`qfc-node --ai-quotas <path>` (env `QFC_AI_QUOTAS`). The file is **JSON**
+(not TOML: `serde_json` is already in the dependency tree; the workspace has
+no TOML dependency). Example:
+
+```json
+{
+  "window_secs": 3600,
+  "max_pending": 10000,
+  "default_tier": {
+    "max_qps": 10.0,
+    "max_inflight": 100,
+    "flops_per_window": 0,
+    "priority": 1
+  },
+  "tenants": {
+    "0x0101010101010101010101010101010101010101": {
+      "max_qps": 50.0,
+      "burst": 100,
+      "max_inflight": 500,
+      "flops_per_window": 5000000000000000,
+      "priority": 2
+    },
+    "0x0202020202020202020202020202020202020202": {
+      "max_qps": 1.0,
+      "max_inflight": 5,
+      "priority": 0
+    }
+  }
+}
+```
+
+Every field has a default (the `default_tier` shown above *is* the default:
+10 QPS, 100 in-flight, unlimited FLOPs, priority 1) — an empty `{}` file
+enables quota accounting with generous limits.
+
+- **Absent flag → quotas off.** Admission always succeeds; the fee escrow on
+  the submission path remains the economic backpressure. Chosen over a
+  default-on tier so existing deployments are unchanged by this upgrade.
+  Accounting (in-flight gauges, FLOPs metering, cost reports) runs either
+  way.
+- **Hot reload:** the node re-checks the file's mtime every ~30 s and
+  reloads on change. A file that fails to parse is logged and **ignored**
+  (previous config stays active). No restart needed; a restart also works.
+- Startup with an invalid file is a hard error (fail fast).
+
+## Admission & enforcement
+
+`TaskPool::try_submit_public_task` checks, in order:
+
+1. **Pool pressure** (degradation order, below)
+2. **QPS** token bucket
+3. **In-flight** limit
+4. **FLOPs budget**
+
+A rejected submission consumes nothing (no token, no budget). Rejections are
+typed (`QuotaError`) — never a panic — and counted in
+`qfc_ai_tasks_rejected_total{reason=...}` with
+`reason ∈ pool_pressure | qps | in_flight | flops_budget`.
+
+### RPC error surface
+
+`qfc_submitPublicTask` surfaces rejections as JSON-RPC error **-32029** with
+the violated limit and a retry-after hint in both the message and structured
+`data` (the escrowed fee is refunded first):
+
+```json
+{
+  "code": -32029,
+  "message": "Quota exceeded (qps): QPS limit exceeded for tenant 0x01…: limit 10 req/s; retry after 73ms",
+  "data": { "reason": "qps", "retryAfterMs": 73 }
+}
+```
+
+### Degradation order (pool pressure)
+
+Under pool pressure the **lowest-priority tenants are shed first**, at
+thresholds derived from `max_pending` (the hard cap on the pending queue):
+
+| Pending queue ≥ | Shed (rejected at admission) |
+|---|---|
+| 50% of `max_pending` | priority 0 |
+| 75% of `max_pending` | priority 0, 1 |
+| 100% of `max_pending` | everyone (hard cap) |
+
+### Fair scheduling
+
+When a miner fetches work (`TaskPool::fetch_task_for`), selection is:
+
+1. **Highest priority tier present** (tier 2 before 1 before 0);
+2. **round-robin across tenants** within that tier — tenants ordered by
+   address, served cyclically from a single cursor, so no tenant is served
+   twice before every other tenant with matching pending work is served once
+   (starvation-free, regardless of fees);
+3. **highest fee within a tenant** (the pre-T5 fee ordering, preserved).
+
+Synthetic (filler) tasks have no submitter and run as the zero-address
+tenant at the default tier's priority.
+
+## Cost attribution & treasury hook
+
+Every **completed** public task is metered — `estimated_flops` + fee,
+attributed to both the tenant (who pays) and the miner (who earned) —
+expired tasks are not metered (never executed; their escrow is refunded).
+
+A periodic **cost report** (`--ai-cost-report-interval-secs`, default 600,
+`0` = off) aggregates interval + cumulative totals per tenant and per miner,
+sorted by interval FLOPs:
+
+- emitted as a structured log, target **`qfc::ai_cost`** (JSON payload in
+  the `report` field);
+- retained in memory, queryable via `TaskPool::last_cost_report()` /
+  `cost_meter()`;
+- handed to the **treasury hook**.
+
+### TreasuryHook contract
+
+```rust
+pub trait TreasuryHook: Send + Sync {
+    /// Once per completed task (per-task charge granularity).
+    fn on_task_charged(&self, tenant: &Address, miner: &Address,
+                       flops: u64, fee_wei: u128) {}
+    /// Once per periodic cost report (batch settlement granularity).
+    fn on_cost_report(&self, report: &CostReport) {}
+}
+```
+
+Install with `TaskPool::set_treasury_hook`. Both callbacks run **while the
+TaskPool lock is held** — implementations must be cheap and non-blocking
+(enqueue, don't settle inline). The default `LoggingTreasuryHook` only logs.
+The real on-chain treasury integration (charging tenants / crediting miners
+against `qfc-ai-coordinator::Treasury`) is explicitly out of scope for T5 —
+this trait is the integration point it will implement.
+
+## Metrics & operations
+
+Exported by the qfc-node exporter (`:6060/metrics`, see
+[observability/README.md](observability/README.md)). Labels use the
+**priority tier** (`tenant_tier` ∈ 0/1/2), never the tenant address —
+tenant cardinality is unbounded, tiers are fixed at three. Per-tenant detail
+is in the cost report.
+
+| Metric | Type | Labels |
+|---|---|---|
+| `qfc_ai_quotas_enabled` | gauge (0/1) | — |
+| `qfc_ai_pending_tasks` | gauge | — |
+| `qfc_ai_tasks_submitted_total` | counter | `tenant_tier` |
+| `qfc_ai_tasks_rejected_total` | counter | `reason` |
+| `qfc_ai_flops_metered_total` | counter | `tenant_tier` |
+| `qfc_ai_tenant_inflight` | gauge | `tenant_tier` |
+| `qfc_ai_cost_report_last_timestamp_seconds` | gauge | — (0 = never; alert on age) |
+
+**Spotting a throttled tenant:**
+
+1. `rate(qfc_ai_tasks_rejected_total[5m]) > 0` → someone is being limited;
+   the `reason` label says which limit.
+2. Node logs name the tenant: every rejection logs
+   `Public task rejected by quota for 0x…: <limit details>` at info level;
+   clients simultaneously see `-32029` with `retryAfterMs`.
+3. `reason="pool_pressure"` rising while `qfc_ai_pending_tasks` approaches
+   `max_pending` → the pool is saturated and shedding by priority
+   (degradation order above), not a per-tenant misconfiguration.
+4. Per-tenant consumption: grep the `qfc::ai_cost` cost-report logs for the
+   tenant address (interval + cumulative FLOPs/fees per tenant and miner).
+5. `time() - qfc_ai_cost_report_last_timestamp_seconds` much larger than the
+   configured interval → the reporting task is stuck/disabled.

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -126,6 +126,26 @@ and place `grafana-dashboard.json` in that path. The dashboard has an
 | `qfc_rpc_request_duration_seconds` | histogram | `method`, `le` | RPC middleware |
 | `qfc_rpc_errors_total` | counter | `method`, `code` | RPC middleware |
 
+## Metric inventory — AI task pool quotas (T5)
+
+Quota/cost-attribution metrics from the shared AI task pool, always exported
+(`qfc_ai_quotas_enabled` says whether enforcement is on — accounting runs
+regardless). Labeled by tenant **priority tier** (`tenant_tier` ∈ `0`/`1`/`2`,
+0 = lowest/shed first), never by tenant address: tenant cardinality is
+unbounded, tiers are fixed at three. Per-tenant detail lives in the periodic
+cost report (structured log, target `qfc::ai_cost`). Full model + operational
+notes: [docs/AI-QUOTAS.md](../AI-QUOTAS.md).
+
+| Metric | Type | Labels | Source |
+|---|---|---|---|
+| `qfc_ai_quotas_enabled` | gauge (0/1) | — | `--ai-quotas` flag |
+| `qfc_ai_pending_tasks` | gauge | — | task pool pending queue |
+| `qfc_ai_tasks_submitted_total` | counter | `tenant_tier` | admitted public-task submissions |
+| `qfc_ai_tasks_rejected_total` | counter | `reason` (`pool_pressure`/`qps`/`in_flight`/`flops_budget`) | quota admission |
+| `qfc_ai_flops_metered_total` | counter | `tenant_tier` | `estimated_flops` of completed public tasks |
+| `qfc_ai_tenant_inflight` | gauge | `tenant_tier` | tasks in Pending/Assigned, summed per tier |
+| `qfc_ai_cost_report_last_timestamp_seconds` | gauge | — | cost-report task (0 = never since start; alert on age, like `qfc_snapshot_*`) |
+
 ## Metric inventory — RocksDB (T2.1)
 
 Property-based gauges, always exported (computed on demand from live engine


### PR DESCRIPTION
Implements roadmap item **T5 — Multi-tenant quotas + cost attribution** (docs/ROADMAP-SRE.md): per-submitter quotas on the AI task pool with fair scheduling, FLOPs metering per tenant and per miner with a periodic cost report, a `TreasuryHook` integration point, and exporter metrics. Full doc: `docs/AI-QUOTAS.md`.

## Quota model

Tenant = submitter address. Config is JSON (`--ai-quotas <path>`, hot-reloaded on mtime ~30s; absent = quotas off so existing deployments are unchanged — fee escrow stays the economic backpressure). JSON over TOML because `serde_json` is already in the tree and the workspace has no `toml` dependency.

| Limit | Mechanism | Default tier | Disabled by |
|---|---|---|---|
| QPS | token bucket (`max_qps` refill, `burst` capacity) | 10 req/s | `max_qps: 0` |
| In-flight | tasks in Pending/Assigned per tenant | 100 | `max_inflight: 0` |
| FLOPs budget | `estimated_flops` per fixed window (`window_secs`, default 1h) | unlimited | `flops_per_window: 0` |
| Priority | tier 0–2 (2 = highest) | 1 | — |

Admission order: pool pressure → QPS → in-flight → FLOPs budget; a rejected request consumes nothing. Rejections are typed (`QuotaError`), surfaced on `qfc_submitPublicTask` as JSON-RPC **-32029** with the violated limit and `data: {reason, retryAfterMs}`; the escrowed fee is refunded first.

## Degradation order

Under pool pressure, **lowest-priority tenants shed first**, thresholds derived from `max_pending`:

| Pending ≥ | Shed |
|---|---|
| 50% | priority 0 |
| 75% | priority 0–1 |
| 100% (hard cap) | everyone |

Fair scheduling on fetch: highest priority tier first → round-robin across tenants within the tier (single address-ordered cursor; starvation-free regardless of fees) → highest fee within a tenant (pre-T5 ordering preserved). Synthetic tasks run as the zero-address tenant at default priority.

## Metering flow

1. `complete_public_task` meters `estimated_flops` (same estimate as fee pricing, from `task_requirements`) + fee, attributed to **both** tenant and miner; `TreasuryHook::on_task_charged` fires per task. Expired tasks are not metered (never executed; refunded).
2. qfc-node drives a periodic cost report (`--ai-cost-report-interval-secs`, default 600, 0 = off): interval + cumulative totals per tenant/per miner, emitted as a structured log (target `qfc::ai_cost`), kept queryable via `TaskPool::last_cost_report()`, and handed to `TreasuryHook::on_cost_report`.
3. `TreasuryHook` (Send+Sync, default no-op `LoggingTreasuryHook`) is the deliverable — the real on-chain treasury integration is explicitly out of scope.

## Metric inventory (exporter, render test extended)

Tier/reason labels only — tenant cardinality is unbounded, tiers are fixed at 3; per-tenant detail lives in the cost-report logs (documented in docs/AI-QUOTAS.md + observability README).

| Metric | Type | Labels |
|---|---|---|
| `qfc_ai_quotas_enabled` | gauge 0/1 | — |
| `qfc_ai_pending_tasks` | gauge | — |
| `qfc_ai_tasks_submitted_total` | counter | `tenant_tier` |
| `qfc_ai_tasks_rejected_total` | counter | `reason` (pool_pressure/qps/in_flight/flops_budget) |
| `qfc_ai_flops_metered_total` | counter | `tenant_tier` |
| `qfc_ai_tenant_inflight` | gauge | `tenant_tier` |
| `qfc_ai_cost_report_last_timestamp_seconds` | gauge | — (0 = never; alert on age, T4.2 convention) |

## Test results

- `cargo test -p qfc-ai-coordinator --lib`: **127 passed** (new: token-bucket edges incl. exact-refill boundary, rejected-request-consumes-nothing, in-flight limits, budget window expiry, shed-order, config parsing/bad address, two-tenant fairness/starvation-freedom, priority-before-fee, degradation order under pressure, per-tenant+per-miner metering, expired-task non-metering, treasury hook invocation, report interval/reset/sorting)
- `cargo test -p qfc-rpc --lib`: **37 passed** (new: -32029 mapping with retry hint + structured data)
- `cargo test -p qfc-node --bin qfc-node`: **17 passed** (render test asserts all 7 new metric names + seeded label values)
- `cargo test -p qfc-node --test integration_test` (against freshly built `target/release/qfc-node`): **6 passed**
- `cargo check --workspace` clean; `cargo fmt --all --check` clean; clippy introduces no new warnings on touched crates (pre-existing ones untouched)

## Scope notes

- `crates/qfc-storage`, `crates/qfc-state` untouched (T8 owns them); `crates/qfc-watchdog`, `scripts/` untouched.
- Quota state is in-memory per node (consistent with the in-memory TaskPool); buckets/windows reset on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
