### PR TITLE
T8: per-CF/per-account hot-key sampling + top-N reports

### DIFF
--- a/crates/qfc-state/Cargo.toml
+++ b/crates/qfc-state/Cargo.toml
@@ -21,3 +21,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 tempfile = "3.9"
+serde_json.workspace = true

--- a/crates/qfc-state/examples/hot_key_workload.rs
+++ b/crates/qfc-state/examples/hot_key_workload.rs
@@ -1,0 +1,151 @@
+//! Synthetic hot-key workload for SRE T8 findings (docs/profiling/HOT-KEYS.md).
+//!
+//! Simulates a block-import-shaped workload against a temporary database
+//! with hot-key sampling enabled at the production default (1-in-64):
+//! zipf-distributed transfers between accounts, zipf-distributed contract
+//! code reads, and periodic state commits. Dumps the storage-level
+//! `hot_key_report` and the state-level `hot_account_report` as JSON, plus a
+//! rank/count table to eyeball the power-law shape.
+//!
+//! Run: `cargo run -p qfc-state --release --example hot_key_workload [transfers]`
+
+use qfc_state::StateDB;
+use qfc_storage::{Database, StorageConfig};
+use qfc_types::{Address, U256};
+use std::time::Instant;
+
+/// Deterministic xorshift64* PRNG.
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545F4914F6CDD1D)
+    }
+    fn next_f64(&mut self) -> f64 {
+        (self.next() >> 11) as f64 / (1u64 << 53) as f64
+    }
+}
+
+/// Zipf(s) sampler over ranks 0..n via inverse-CDF table.
+struct Zipf {
+    cdf: Vec<f64>,
+}
+impl Zipf {
+    fn new(n: usize, s: f64) -> Self {
+        let mut weights: Vec<f64> = (1..=n).map(|k| 1.0 / (k as f64).powf(s)).collect();
+        let total: f64 = weights.iter().sum();
+        let mut acc = 0.0;
+        for w in &mut weights {
+            acc += *w / total;
+            *w = acc;
+        }
+        Self { cdf: weights }
+    }
+    fn sample(&self, rng: &mut Rng) -> usize {
+        let u = rng.next_f64();
+        self.cdf.partition_point(|&c| c < u).min(self.cdf.len() - 1)
+    }
+}
+
+fn addr_for(rank: usize) -> Address {
+    let mut bytes = [0u8; 20];
+    bytes[12..20].copy_from_slice(&(rank as u64).to_be_bytes());
+    Address::new(bytes)
+}
+
+fn main() {
+    let transfers: u64 = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(100_000);
+
+    const ACCOUNTS: usize = 5_000;
+    const CONTRACTS: usize = 100;
+    const COMMIT_EVERY: u64 = 500;
+
+    let dir = tempfile::tempdir().unwrap();
+    let config = StorageConfig {
+        path: dir.path().to_path_buf(),
+        create_if_missing: true,
+        hot_key_sampling: Some(64), // production default
+        ..Default::default()
+    };
+    let db = Database::open(config).unwrap();
+    let state = StateDB::new(db.clone());
+
+    // Seed balances and contract code.
+    for rank in 0..ACCOUNTS {
+        state
+            .set_balance(&addr_for(rank), U256::from_u64(1_000_000_000))
+            .unwrap();
+    }
+    let contract_base = ACCOUNTS; // contracts live above the EOA range
+    for c in 0..CONTRACTS {
+        // Distinct bytecode per contract so code hashes differ.
+        let code = format!("contract-{c:04}-{}", "f".repeat(64)).into_bytes();
+        state.set_code(&addr_for(contract_base + c), code).unwrap();
+    }
+    state.commit().unwrap();
+    // Measure only the steady-state workload, not the seeding phase.
+    db.reset_hot_key_stats();
+    state.reset_hot_account_stats();
+
+    let acct_zipf = Zipf::new(ACCOUNTS, 1.1);
+    let code_zipf = Zipf::new(CONTRACTS, 1.2);
+    let mut rng = Rng(0x00C0_FFEE_D00D_F00D);
+
+    let start = Instant::now();
+    for i in 0..transfers {
+        let from = addr_for(acct_zipf.sample(&mut rng));
+        let to = addr_for(acct_zipf.sample(&mut rng));
+        if from != to {
+            let _ = state.transfer(&from, &to, U256::from_u64(1));
+        }
+        let _ = state.increment_nonce(&from);
+        // One "contract call" (code fetch) per 4 transfers.
+        if i % 4 == 0 {
+            let c = code_zipf.sample(&mut rng);
+            let _ = state.get_code(&addr_for(contract_base + c)).unwrap();
+        }
+        if (i + 1) % COMMIT_EVERY == 0 {
+            state.commit().unwrap();
+        }
+    }
+    state.commit().unwrap();
+    let elapsed = start.elapsed();
+
+    eprintln!(
+        "workload: {transfers} transfers over {ACCOUNTS} accounts (zipf s=1.1), \
+         {CONTRACTS} contracts (zipf s=1.2), commit every {COMMIT_EVERY}; \
+         took {elapsed:.2?} ({:.0} transfers/s)",
+        transfers as f64 / elapsed.as_secs_f64()
+    );
+
+    let storage_report = db.hot_key_report(8).unwrap();
+    let state_report = state.hot_account_report(20).unwrap();
+
+    println!("=== storage hot_key_report (top 8 keys/CF) ===");
+    println!("{}", serde_json::to_string_pretty(&storage_report).unwrap());
+    println!("=== state hot_account_report (top 20) ===");
+    println!("{}", serde_json::to_string_pretty(&state_report).unwrap());
+
+    // Rank/count table for the power-law eyeball check: estimated count vs
+    // account rank (true zipf rank is recoverable from the address suffix).
+    println!("=== top accounts: rank vs estimated count ===");
+    println!("report_rank,address,true_zipf_rank,estimated_count,max_overestimate");
+    for (i, e) in state_report.top_accounts.iter().enumerate() {
+        let true_rank = u64::from_str_radix(&e.address[2..].to_string()[24..], 16).ok();
+        println!(
+            "{},{},{},{},{}",
+            i + 1,
+            e.address,
+            true_rank.map_or("?".into(), |r| r.to_string()),
+            e.estimated_count,
+            e.max_overestimate
+        );
+    }
+}

--- a/crates/qfc-state/src/hot_account.rs
+++ b/crates/qfc-state/src/hot_account.rs
@@ -1,0 +1,275 @@
+//! Hot-account attribution (SRE roadmap T8).
+//!
+//! `qfc-storage`'s hot-key sampler sees raw keys — for the `state` CF those
+//! are trie *node hashes*, which cannot be mapped back to accounts. This
+//! module does the attribution at the layer that knows the key encoding:
+//! [`crate::StateDB`] samples its own account-level API
+//! (`get_account` / `set_account` / `get_code`) into heavy-hitter sketches
+//! keyed by [`Address`] (accounts) and code [`Hash`] (contract bytecode).
+//!
+//! Sampling is recorded at StateDB API entry, *before* the LRU caches — the
+//! report therefore reflects the logical access distribution (what cache
+//! sizing needs), not just cache misses. Internal helpers funnel through
+//! `get_account`/`set_account`, so e.g. one `set_balance` counts one account
+//! read + one account write.
+//!
+//! Enabled automatically (at the same 1-in-N rate and sketch capacity) when
+//! the underlying [`qfc_storage::Database`] was opened with
+//! [`qfc_storage::StorageConfig::hot_key_sampling`] set. The sampling
+//! machinery and error bounds are shared with `qfc-storage` — see
+//! [`qfc_storage::hotkeys`] for the space-saving sketch guarantees.
+
+use parking_lot::Mutex;
+use qfc_storage::SpaceSaving;
+use qfc_types::{Address, Hash};
+use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Samples StateDB account/code accesses into heavy-hitter sketches.
+pub struct HotAccountTracker {
+    /// Effective 1-in-N rate (power of two).
+    rate: u32,
+    mask: u64,
+    tick: AtomicU64,
+    window_start_unix_ms: AtomicU64,
+    account_reads_sampled: AtomicU64,
+    account_writes_sampled: AtomicU64,
+    code_reads_sampled: AtomicU64,
+    /// Hot accounts (reads + writes combined in one sketch).
+    accounts: Mutex<SpaceSaving<Address>>,
+    /// Hot contract code, keyed by code hash (content-addressed).
+    code: Mutex<SpaceSaving<Hash>>,
+}
+
+impl HotAccountTracker {
+    /// `rate` is rounded up to the next power of two (min 1); `capacity` is
+    /// the per-sketch tracked-key budget.
+    pub fn new(rate: u32, capacity: usize) -> Self {
+        let rate = rate.max(1).next_power_of_two();
+        Self {
+            rate,
+            mask: u64::from(rate) - 1,
+            tick: AtomicU64::new(0),
+            window_start_unix_ms: AtomicU64::new(unix_ms()),
+            account_reads_sampled: AtomicU64::new(0),
+            account_writes_sampled: AtomicU64::new(0),
+            code_reads_sampled: AtomicU64::new(0),
+            accounts: Mutex::new(SpaceSaving::new(capacity)),
+            code: Mutex::new(SpaceSaving::new(capacity)),
+        }
+    }
+
+    /// Effective sampling rate (power of two).
+    pub fn rate(&self) -> u32 {
+        self.rate
+    }
+
+    #[inline]
+    fn should_sample(&self) -> bool {
+        self.tick.fetch_add(1, Ordering::Relaxed) & self.mask == 0
+    }
+
+    /// Record an account read (StateDB `get_account`).
+    #[inline]
+    pub(crate) fn record_account_read(&self, address: &Address) {
+        if !self.should_sample() {
+            return;
+        }
+        self.account_reads_sampled.fetch_add(1, Ordering::Relaxed);
+        self.accounts.lock().offer(*address);
+    }
+
+    /// Record an account write (StateDB `set_account`).
+    #[inline]
+    pub(crate) fn record_account_write(&self, address: &Address) {
+        if !self.should_sample() {
+            return;
+        }
+        self.account_writes_sampled.fetch_add(1, Ordering::Relaxed);
+        self.accounts.lock().offer(*address);
+    }
+
+    /// Record a contract-code read (StateDB `get_code` with a code hash).
+    #[inline]
+    pub(crate) fn record_code_read(&self, code_hash: &Hash) {
+        if !self.should_sample() {
+            return;
+        }
+        self.code_reads_sampled.fetch_add(1, Ordering::Relaxed);
+        self.code.lock().offer(*code_hash);
+    }
+
+    /// Snapshot the current window with at most `top_n` accounts / code
+    /// hashes.
+    pub fn report(&self, top_n: usize) -> HotAccountReport {
+        let rate = u64::from(self.rate);
+        let accounts = self.accounts.lock();
+        let top_accounts = accounts
+            .top(top_n)
+            .into_iter()
+            .map(|(addr, count, error)| HotAccountEntry {
+                address: addr.to_string(),
+                sampled_count: count,
+                estimated_count: count * rate,
+                max_overestimate: error * rate,
+            })
+            .collect();
+        let sketch_capacity = accounts.capacity();
+        drop(accounts);
+
+        let top_code = self
+            .code
+            .lock()
+            .top(top_n)
+            .into_iter()
+            .map(|(hash, count, error)| HotCodeEntry {
+                code_hash: hash.to_string(),
+                sampled_count: count,
+                estimated_count: count * rate,
+                max_overestimate: error * rate,
+            })
+            .collect();
+
+        let reads = self.account_reads_sampled.load(Ordering::Relaxed);
+        let writes = self.account_writes_sampled.load(Ordering::Relaxed);
+        let code_reads = self.code_reads_sampled.load(Ordering::Relaxed);
+        HotAccountReport {
+            sampling_rate: self.rate,
+            sketch_capacity,
+            window_start_unix_ms: self.window_start_unix_ms.load(Ordering::Relaxed),
+            account_reads_sampled: reads,
+            account_writes_sampled: writes,
+            code_reads_sampled: code_reads,
+            estimated_account_reads: reads * rate,
+            estimated_account_writes: writes * rate,
+            estimated_code_reads: code_reads * rate,
+            top_accounts,
+            top_code,
+        }
+    }
+
+    /// Reset counters and sketches and start a new window.
+    pub fn reset(&self) {
+        self.account_reads_sampled.store(0, Ordering::Relaxed);
+        self.account_writes_sampled.store(0, Ordering::Relaxed);
+        self.code_reads_sampled.store(0, Ordering::Relaxed);
+        self.accounts.lock().clear();
+        self.code.lock().clear();
+        self.window_start_unix_ms
+            .store(unix_ms(), Ordering::Relaxed);
+    }
+}
+
+/// Serializable hot-account report for one sampling window.
+///
+/// Estimates carry the same error characteristics as the storage-level
+/// report: space-saving overestimation bounded by `max_overestimate`, plus
+/// 1-in-N sampling noise (relative error ~ `sqrt(N / true_count)`).
+#[derive(Clone, Debug, Serialize)]
+pub struct HotAccountReport {
+    /// Effective 1-in-N sampling rate (power of two).
+    pub sampling_rate: u32,
+    /// Heavy-hitter sketch capacity (accounts / code hashes tracked).
+    pub sketch_capacity: usize,
+    /// Window start (Unix milliseconds); set at creation and on `reset()`.
+    pub window_start_unix_ms: u64,
+    /// Sampled `get_account` calls in this window.
+    pub account_reads_sampled: u64,
+    /// Sampled `set_account` calls in this window.
+    pub account_writes_sampled: u64,
+    /// Sampled contract-code reads in this window.
+    pub code_reads_sampled: u64,
+    /// `account_reads_sampled * sampling_rate`.
+    pub estimated_account_reads: u64,
+    /// `account_writes_sampled * sampling_rate`.
+    pub estimated_account_writes: u64,
+    /// `code_reads_sampled * sampling_rate`.
+    pub estimated_code_reads: u64,
+    /// Hottest accounts (reads + writes), descending by estimated count.
+    pub top_accounts: Vec<HotAccountEntry>,
+    /// Hottest contract code by code hash, descending by estimated count.
+    pub top_code: Vec<HotCodeEntry>,
+}
+
+/// One hot account.
+#[derive(Clone, Debug, Serialize)]
+pub struct HotAccountEntry {
+    /// Account address (`0x…`, 20 bytes hex).
+    pub address: String,
+    /// Raw sampled count (unscaled).
+    pub sampled_count: u64,
+    /// `sampled_count * sampling_rate`.
+    pub estimated_count: u64,
+    /// Space-saving overestimation bound, scaled by the sampling rate.
+    pub max_overestimate: u64,
+}
+
+/// One hot contract bytecode entry.
+#[derive(Clone, Debug, Serialize)]
+pub struct HotCodeEntry {
+    /// Contract code hash (content-addressed; shared by all instances of the
+    /// same bytecode).
+    pub code_hash: String,
+    /// Raw sampled count (unscaled).
+    pub sampled_count: u64,
+    /// `sampled_count * sampling_rate`.
+    pub estimated_count: u64,
+    /// Space-saving overestimation bound, scaled by the sampling rate.
+    pub max_overestimate: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_rounds_up_and_clamps() {
+        assert_eq!(HotAccountTracker::new(0, 8).rate(), 1);
+        assert_eq!(HotAccountTracker::new(3, 8).rate(), 4);
+        assert_eq!(HotAccountTracker::new(64, 8).rate(), 64);
+    }
+
+    #[test]
+    fn tracks_accounts_and_code_separately() {
+        let t = HotAccountTracker::new(1, 8);
+        let a = Address::new([0x11; 20]);
+        let b = Address::new([0x22; 20]);
+        let h = Hash::new([0x33; 32]);
+
+        for _ in 0..5 {
+            t.record_account_read(&a);
+        }
+        t.record_account_write(&a);
+        t.record_account_read(&b);
+        for _ in 0..3 {
+            t.record_code_read(&h);
+        }
+
+        let r = t.report(10);
+        assert_eq!(r.account_reads_sampled, 6);
+        assert_eq!(r.account_writes_sampled, 1);
+        assert_eq!(r.code_reads_sampled, 3);
+        assert_eq!(r.top_accounts[0].address, a.to_string());
+        assert_eq!(r.top_accounts[0].estimated_count, 6);
+        assert_eq!(r.top_code[0].code_hash, h.to_string());
+        assert_eq!(r.top_code[0].estimated_count, 3);
+    }
+
+    #[test]
+    fn reset_clears_window() {
+        let t = HotAccountTracker::new(1, 8);
+        t.record_account_read(&Address::new([0x11; 20]));
+        t.reset();
+        let r = t.report(10);
+        assert_eq!(r.account_reads_sampled, 0);
+        assert!(r.top_accounts.is_empty());
+    }
+}

--- a/crates/qfc-state/src/lib.rs
+++ b/crates/qfc-state/src/lib.rs
@@ -3,12 +3,14 @@
 //! Manages blockchain state including accounts, storage, and code.
 
 mod error;
+mod hot_account;
 mod pruning;
 pub mod rent;
 mod snap;
 mod state_db;
 
 pub use error::*;
+pub use hot_account::*;
 pub use pruning::*;
 pub use rent::*;
 pub use snap::*;

--- a/crates/qfc-state/src/state_db.rs
+++ b/crates/qfc-state/src/state_db.rs
@@ -1,6 +1,7 @@
 //! State database for managing accounts and storage
 
 use crate::error::{Result, StateError};
+use crate::hot_account::{HotAccountReport, HotAccountTracker};
 use lru::LruCache;
 use parking_lot::RwLock;
 use qfc_crypto::blake3_hash;
@@ -9,6 +10,7 @@ use qfc_trie::Trie;
 use qfc_types::{Account, Address, Hash, Undelegation, U256};
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use tracing::debug;
 
 /// Maximum number of accounts in the LRU cache
@@ -32,12 +34,24 @@ pub struct StateDB {
     code_cache: RwLock<LruCache<Hash, Vec<u8>>>,
     /// Current state root
     root: RwLock<Hash>,
+    /// Hot-account access tracker (SRE T8). Enabled iff the underlying
+    /// `Database` was opened with hot-key sampling on; `None` otherwise, so
+    /// the disabled per-op cost is a single branch.
+    hot_accounts: Option<Arc<HotAccountTracker>>,
+}
+
+/// Build the hot-account tracker iff the database has hot-key sampling
+/// enabled, mirroring its rate and sketch capacity.
+fn hot_tracker_for(db: &Database) -> Option<Arc<HotAccountTracker>> {
+    db.hot_key_sampling()
+        .map(|rate| Arc::new(HotAccountTracker::new(rate, db.hot_key_capacity())))
 }
 
 impl StateDB {
     /// Create a new state database with empty state
     pub fn new(db: Database) -> Self {
         let trie = Trie::new(db.clone());
+        let hot_accounts = hot_tracker_for(&db);
         Self {
             db,
             trie: RwLock::new(trie),
@@ -49,12 +63,14 @@ impl StateDB {
             )),
             code_cache: RwLock::new(LruCache::new(NonZeroUsize::new(CODE_CACHE_SIZE).unwrap())),
             root: RwLock::new(Hash::ZERO),
+            hot_accounts,
         }
     }
 
     /// Create a state database at a specific root
     pub fn with_root(db: Database, root: Hash) -> Self {
         let trie = Trie::with_root(db.clone(), root);
+        let hot_accounts = hot_tracker_for(&db);
         Self {
             db,
             trie: RwLock::new(trie),
@@ -66,6 +82,7 @@ impl StateDB {
             )),
             code_cache: RwLock::new(LruCache::new(NonZeroUsize::new(CODE_CACHE_SIZE).unwrap())),
             root: RwLock::new(root),
+            hot_accounts,
         }
     }
 
@@ -85,6 +102,13 @@ impl StateDB {
 
     /// Get an account (returns default if not exists)
     pub fn get_account(&self, address: &Address) -> Result<Account> {
+        // Hot-account sampling happens before the cache check on purpose:
+        // the report must reflect the logical access distribution (which is
+        // what cache sizing needs), not just cache misses.
+        if let Some(hot) = &self.hot_accounts {
+            hot.record_account_read(address);
+        }
+
         // Check cache first (LruCache::get requires &mut self)
         if let Some(account) = self.account_cache.write().get(address) {
             return Ok(account.clone());
@@ -108,6 +132,10 @@ impl StateDB {
 
     /// Set an account
     pub fn set_account(&self, address: &Address, account: &Account) -> Result<()> {
+        if let Some(hot) = &self.hot_accounts {
+            hot.record_account_write(address);
+        }
+
         // Update cache
         self.account_cache.write().put(*address, account.clone());
 
@@ -204,6 +232,11 @@ impl StateDB {
 
         match account.code_hash {
             Some(hash) => {
+                // Sampled before the code cache, same rationale as accounts.
+                if let Some(hot) = &self.hot_accounts {
+                    hot.record_code_read(&hash);
+                }
+
                 // Check cache
                 if let Some(code) = self.code_cache.write().get(&hash) {
                     return Ok(code.clone());
@@ -499,6 +532,31 @@ impl StateDB {
         Ok(new_root)
     }
 
+    /// Hot-account sampling rate (SRE T8), or `None` when disabled.
+    ///
+    /// Enabled automatically (same rate/capacity) when the underlying
+    /// database was opened with `StorageConfig::hot_key_sampling` set.
+    pub fn hot_account_sampling(&self) -> Option<u32> {
+        self.hot_accounts.as_ref().map(|h| h.rate())
+    }
+
+    /// Snapshot of hot-account / hot-code statistics for the current window,
+    /// with at most `top_n` entries per sketch. Returns `None` when sampling
+    /// is disabled. See [`crate::hot_account`] for semantics and error
+    /// bounds; pair with [`StateDB::reset_hot_account_stats`] for windowed
+    /// use.
+    pub fn hot_account_report(&self, top_n: usize) -> Option<HotAccountReport> {
+        self.hot_accounts.as_ref().map(|h| h.report(top_n))
+    }
+
+    /// Reset hot-account counters and sketches and start a new window.
+    /// No-op when sampling is disabled.
+    pub fn reset_hot_account_stats(&self) {
+        if let Some(hot) = &self.hot_accounts {
+            hot.reset();
+        }
+    }
+
     /// Clear all caches
     pub fn clear_cache(&self) {
         self.account_cache.write().clear();
@@ -582,6 +640,8 @@ impl Clone for StateDB {
             storage_cache: RwLock::new(storage_cache),
             code_cache: RwLock::new(code_cache),
             root: RwLock::new(self.root()),
+            // Clones share the tracker: they observe the same logical state.
+            hot_accounts: self.hot_accounts.clone(),
         }
     }
 }
@@ -804,6 +864,102 @@ mod tests {
             .unwrap());
         let (_, amount) = state.get_delegation(&delegator).unwrap();
         assert_eq!(amount, U256::from_u64(1000));
+    }
+
+    /// StateDB over a database with hot-key sampling at rate 1 (every access
+    /// sampled, counts exact). Keeps the TempDir alive.
+    fn create_sampled_state() -> (StateDB, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let config = qfc_storage::StorageConfig {
+            path: dir.path().to_path_buf(),
+            create_if_missing: true,
+            hot_key_sampling: Some(1),
+            ..Default::default()
+        };
+        let db = Database::open(config).unwrap();
+        (StateDB::new(db), dir)
+    }
+
+    #[test]
+    fn test_hot_accounts_disabled_by_default() {
+        let state = create_test_state();
+        assert!(state.hot_account_sampling().is_none());
+        state
+            .set_balance(&Address::new([0x11; 20]), U256::from_u64(1))
+            .unwrap();
+        assert!(state.hot_account_report(10).is_none());
+        state.reset_hot_account_stats(); // no-op, must not panic
+    }
+
+    #[test]
+    fn test_hot_accounts_attribution() {
+        let (state, _dir) = create_sampled_state();
+        assert_eq!(state.hot_account_sampling(), Some(1));
+
+        let hot = Address::new([0xAA; 20]);
+        let cold = Address::new([0xBB; 20]);
+
+        for _ in 0..20 {
+            let _ = state.get_balance(&hot).unwrap(); // 1 account read each
+        }
+        state.set_balance(&hot, U256::from_u64(1)).unwrap(); // 1 read + 1 write
+        let _ = state.get_balance(&cold).unwrap(); // 1 read
+
+        let report = state.hot_account_report(10).unwrap();
+        assert_eq!(report.sampling_rate, 1);
+        assert_eq!(report.account_reads_sampled, 22);
+        assert_eq!(report.account_writes_sampled, 1);
+
+        // Hottest account is attributed correctly, with exact counts at rate 1.
+        assert_eq!(report.top_accounts[0].address, hot.to_string());
+        assert_eq!(report.top_accounts[0].estimated_count, 22);
+        assert_eq!(report.top_accounts[1].address, cold.to_string());
+        assert_eq!(report.top_accounts[1].estimated_count, 1);
+    }
+
+    #[test]
+    fn test_hot_accounts_code_attribution() {
+        let (state, _dir) = create_sampled_state();
+        let contract = Address::new([0xCC; 20]);
+        let code = vec![0x60, 0x00, 0xf3];
+
+        let code_hash = state.set_code(&contract, code).unwrap();
+        for _ in 0..7 {
+            let _ = state.get_code(&contract).unwrap();
+        }
+        // EOA without code must not record a code read.
+        let _ = state.get_code(&Address::new([0xDD; 20])).unwrap();
+
+        let report = state.hot_account_report(10).unwrap();
+        assert_eq!(report.code_reads_sampled, 7);
+        assert_eq!(report.top_code.len(), 1);
+        assert_eq!(report.top_code[0].code_hash, code_hash.to_string());
+        assert_eq!(report.top_code[0].estimated_count, 7);
+    }
+
+    #[test]
+    fn test_hot_accounts_reset() {
+        let (state, _dir) = create_sampled_state();
+        let _ = state.get_balance(&Address::new([0x11; 20])).unwrap();
+        assert!(state.hot_account_report(10).unwrap().account_reads_sampled > 0);
+
+        state.reset_hot_account_stats();
+        let report = state.hot_account_report(10).unwrap();
+        assert_eq!(report.account_reads_sampled, 0);
+        assert!(report.top_accounts.is_empty());
+        assert!(report.top_code.is_empty());
+    }
+
+    #[test]
+    fn test_hot_accounts_shared_across_clones() {
+        let (state, _dir) = create_sampled_state();
+        let clone = state.clone();
+        let _ = clone.get_balance(&Address::new([0x11; 20])).unwrap();
+        assert_eq!(
+            state.hot_account_report(10).unwrap().account_reads_sampled,
+            1,
+            "clones share one tracker"
+        );
     }
 
     #[test]

--- a/crates/qfc-storage/benches/storage_bench.rs
+++ b/crates/qfc-storage/benches/storage_bench.rs
@@ -1,7 +1,21 @@
 //! Benchmarks for QFC RocksDB storage layer
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use qfc_storage::{cf, Database, WriteBatch};
+use qfc_storage::{cf, Database, StorageConfig, WriteBatch};
+
+/// Open a temporary database with hot-key sampling enabled at the default
+/// 1-in-64 rate (SRE T8 overhead measurement). The TempDir must be kept
+/// alive for the duration of the benchmark.
+fn open_temp_sampled() -> (Database, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let config = StorageConfig {
+        path: dir.path().to_path_buf(),
+        create_if_missing: true,
+        hot_key_sampling: Some(64),
+        ..Default::default()
+    };
+    (Database::open(config).unwrap(), dir)
+}
 
 fn bench_storage_put(c: &mut Criterion) {
     let mut group = c.benchmark_group("storage_put");
@@ -110,6 +124,68 @@ fn bench_storage_delete(c: &mut Criterion) {
     });
 }
 
+/// Same as the 256b case of `bench_storage_put`, but with hot-key sampling
+/// at the default 1-in-64 rate. Compare against `storage_put/256b` from the
+/// same run to quantify the enabled-sampling overhead.
+fn bench_storage_put_sampled(c: &mut Criterion) {
+    let mut group = c.benchmark_group("storage_put_sampled");
+    let value = vec![0xABu8; 256];
+    group.throughput(Throughput::Bytes(256));
+    group.bench_function("256b", |b| {
+        let (db, _dir) = open_temp_sampled();
+        let mut i = 0u64;
+        b.iter(|| {
+            let key = i.to_be_bytes();
+            i += 1;
+            db.put(cf::STATE, black_box(&key), black_box(&value))
+                .unwrap()
+        })
+    });
+    group.finish();
+}
+
+/// Same as the 10k-key case of `bench_storage_get`, with hot-key sampling at
+/// the default 1-in-64 rate.
+fn bench_storage_get_sampled(c: &mut Criterion) {
+    let mut group = c.benchmark_group("storage_get_sampled");
+    let (db, _dir) = open_temp_sampled();
+    let value = vec![0xABu8; 256];
+    for i in 0..10_000u64 {
+        db.put(cf::STATE, &i.to_be_bytes(), &value).unwrap();
+    }
+    group.bench_function("from_10000_keys", |b| {
+        let mut i = 0u64;
+        b.iter(|| {
+            let key = (i % 10_000).to_be_bytes();
+            i += 1;
+            db.get(cf::STATE, black_box(&key)).unwrap()
+        })
+    });
+    group.finish();
+}
+
+/// Same as the 500-op case of `bench_storage_batch_write`, with hot-key
+/// sampling at the default 1-in-64 rate.
+fn bench_storage_batch_write_sampled(c: &mut Criterion) {
+    let mut group = c.benchmark_group("storage_batch_write_sampled");
+    group.throughput(Throughput::Elements(500));
+    group.bench_function("ops/500", |b| {
+        let (db, _dir) = open_temp_sampled();
+        let value = vec![0xCDu8; 256];
+        let mut counter = 0u64;
+        b.iter(|| {
+            let mut batch = WriteBatch::new();
+            for _ in 0..500 {
+                let key = counter.to_be_bytes().to_vec();
+                counter += 1;
+                batch.put(cf::STATE, key, value.clone());
+            }
+            db.write_batch(black_box(batch)).unwrap()
+        })
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_storage_put,
@@ -117,5 +193,8 @@ criterion_group!(
     bench_storage_get_miss,
     bench_storage_batch_write,
     bench_storage_delete,
+    bench_storage_put_sampled,
+    bench_storage_get_sampled,
+    bench_storage_batch_write_sampled,
 );
 criterion_main!(benches);

--- a/crates/qfc-storage/src/db.rs
+++ b/crates/qfc-storage/src/db.rs
@@ -2,6 +2,7 @@
 
 use crate::batch::{BatchOp, WriteBatch};
 use crate::error::{Result, StorageError};
+use crate::hotkeys::{HotKeyReport, HotKeySampler, DEFAULT_HOT_KEY_CAPACITY};
 use crate::schema::{cf, meta, DB_VERSION};
 use rocksdb::statistics::StatsLevel;
 use rocksdb::{
@@ -125,6 +126,17 @@ pub struct StorageConfig {
     /// enabled, read them via [`Database::statistics`] /
     /// [`Database::statistics_ticker`].
     pub enable_statistics: bool,
+
+    /// Hot-key access sampling rate (SRE T8): `Some(n)` samples roughly 1 in
+    /// `n` get/put/delete/batch ops into per-CF heavy-hitter sketches (`n` is
+    /// rounded up to a power of two). `None` or `Some(0)` disables sampling
+    /// entirely — the per-op cost is then a single branch on an `Option`.
+    /// Read results via [`Database::hot_key_report`].
+    pub hot_key_sampling: Option<u32>,
+
+    /// Heavy-hitter sketch capacity (tracked keys per column family) used
+    /// when `hot_key_sampling` is enabled.
+    pub hot_key_capacity: usize,
 }
 
 impl Default for StorageConfig {
@@ -137,6 +149,8 @@ impl Default for StorageConfig {
             enable_compression: true,
             create_if_missing: true,
             enable_statistics: false,
+            hot_key_sampling: None,
+            hot_key_capacity: DEFAULT_HOT_KEY_CAPACITY,
         }
     }
 }
@@ -148,6 +162,9 @@ pub struct Database {
     /// shared with the running DB, which is the only way to read tickers back.
     db_opts: Arc<Options>,
     config: StorageConfig,
+    /// Hot-key access sampler (SRE T8); `None` when disabled, so the per-op
+    /// cost in that case is a single branch.
+    hot_keys: Option<Arc<HotKeySampler>>,
     /// For [`Database::open_temp`]: keeps the temp directory alive while any
     /// clone of this database exists, and removes it from disk afterwards.
     /// Declared after `db` so the RocksDB instance is closed before the
@@ -238,10 +255,16 @@ impl Database {
 
         let db = RocksDB::open_cf_descriptors(&opts, &config.path, cf_descriptors)?;
 
+        let hot_keys = config
+            .hot_key_sampling
+            .filter(|rate| *rate > 0)
+            .map(|rate| Arc::new(HotKeySampler::new(rate, config.hot_key_capacity, cf::ALL)));
+
         let db = Self {
             db: Arc::new(db),
             db_opts: Arc::new(opts),
             config,
+            hot_keys,
             temp_dir: None,
         };
 
@@ -282,18 +305,27 @@ impl Database {
 
     /// Get a value from a column family
     pub fn get(&self, cf_name: &str, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        if let Some(hk) = &self.hot_keys {
+            hk.record_read(cf_name, key);
+        }
         let cf = self.get_cf(cf_name)?;
         Ok(self.db.get_cf(&cf, key)?)
     }
 
     /// Put a value in a column family
     pub fn put(&self, cf_name: &str, key: &[u8], value: &[u8]) -> Result<()> {
+        if let Some(hk) = &self.hot_keys {
+            hk.record_write(cf_name, key);
+        }
         let cf = self.get_cf(cf_name)?;
         Ok(self.db.put_cf(&cf, key, value)?)
     }
 
     /// Delete a value from a column family
     pub fn delete(&self, cf_name: &str, key: &[u8]) -> Result<()> {
+        if let Some(hk) = &self.hot_keys {
+            hk.record_write(cf_name, key);
+        }
         let cf = self.get_cf(cf_name)?;
         Ok(self.db.delete_cf(&cf, key)?)
     }
@@ -304,6 +336,9 @@ impl Database {
     /// negative is answered from the filter/memtable without touching data
     /// blocks. A "maybe" is confirmed with a pinned get (no value copy).
     pub fn contains(&self, cf_name: &str, key: &[u8]) -> Result<bool> {
+        if let Some(hk) = &self.hot_keys {
+            hk.record_read(cf_name, key);
+        }
         let cf = self.get_cf(cf_name)?;
         if !self.db.key_may_exist_cf(&cf, key) {
             return Ok(false);
@@ -326,6 +361,10 @@ impl Database {
             };
             if !handles.contains_key(cf_name) {
                 handles.insert(cf_name, self.get_cf(cf_name)?);
+            }
+            if let Some(hk) = &self.hot_keys {
+                let (BatchOp::Put { key, .. } | BatchOp::Delete { key, .. }) = op;
+                hk.record_write(cf_name, key);
             }
             let handle = &handles[cf_name];
             match op {
@@ -357,6 +396,10 @@ impl Database {
             };
             if !handles.contains_key(cf_name) {
                 handles.insert(cf_name, self.get_cf(cf_name)?);
+            }
+            if let Some(hk) = &self.hot_keys {
+                let (BatchOp::Put { key, .. } | BatchOp::Delete { key, .. }) = op;
+                hk.record_write(cf_name, key);
             }
             let handle = &handles[cf_name];
             match op {
@@ -509,6 +552,38 @@ impl Database {
         Ok(self.db.property_int_value_cf(&cf, name)?)
     }
 
+    /// Effective hot-key sampling rate (SRE T8), or `None` when disabled.
+    ///
+    /// The rate is the configured [`StorageConfig::hot_key_sampling`] rounded
+    /// up to a power of two. Higher layers (e.g. `qfc-state` account
+    /// attribution) use this to enable their own sampling at the same rate.
+    pub fn hot_key_sampling(&self) -> Option<u32> {
+        self.hot_keys.as_ref().map(|hk| hk.rate())
+    }
+
+    /// Heavy-hitter sketch capacity configured for hot-key sampling.
+    pub fn hot_key_capacity(&self) -> usize {
+        self.config.hot_key_capacity
+    }
+
+    /// Snapshot of per-CF hot-key statistics for the current window, with at
+    /// most `top_n` keys per CF. Returns `None` when sampling is disabled.
+    ///
+    /// See [`crate::hotkeys`] module docs for the error characteristics of
+    /// the estimates. Pair with [`Database::reset_hot_key_stats`] for
+    /// windowed use (e.g. a periodic exporter dump).
+    pub fn hot_key_report(&self, top_n: usize) -> Option<HotKeyReport> {
+        self.hot_keys.as_ref().map(|hk| hk.report(top_n))
+    }
+
+    /// Reset hot-key counters and sketches and start a new sampling window.
+    /// No-op when sampling is disabled.
+    pub fn reset_hot_key_stats(&self) {
+        if let Some(hk) = &self.hot_keys {
+            hk.reset();
+        }
+    }
+
     /// Flush the database
     pub fn flush(&self) -> Result<()> {
         for cf_name in cf::ALL {
@@ -545,6 +620,7 @@ impl Clone for Database {
             db: Arc::clone(&self.db),
             db_opts: Arc::clone(&self.db_opts),
             config: self.config.clone(),
+            hot_keys: self.hot_keys.clone(),
             temp_dir: self.temp_dir.clone(),
         }
     }
@@ -785,6 +861,111 @@ mod tests {
         assert!(db
             .property_int_cf("no_such_cf", props::CUR_SIZE_ALL_MEM_TABLES)
             .is_err());
+    }
+
+    #[test]
+    fn test_hot_keys_disabled_by_default() {
+        let db = Database::open_temp().unwrap();
+        assert!(db.hot_key_sampling().is_none());
+
+        db.put(cf::STATE, b"k", b"v").unwrap();
+        let _ = db.get(cf::STATE, b"k").unwrap();
+
+        assert!(db.hot_key_report(10).is_none(), "disabled => no report");
+        db.reset_hot_key_stats(); // must be a no-op, not a panic
+    }
+
+    #[test]
+    fn test_hot_keys_zero_rate_is_disabled() {
+        let (db, _dir) = open_temp_with(|c| c.hot_key_sampling = Some(0));
+        assert!(db.hot_key_sampling().is_none());
+        assert!(db.hot_key_report(10).is_none());
+    }
+
+    #[test]
+    fn test_hot_keys_rate_rounded_to_power_of_two() {
+        let (db, _dir) = open_temp_with(|c| c.hot_key_sampling = Some(48));
+        assert_eq!(db.hot_key_sampling(), Some(64));
+    }
+
+    #[test]
+    fn test_hot_keys_counts_reads_writes_per_cf() {
+        // rate 1 => every op sampled, counts are exact.
+        let (db, _dir) = open_temp_with(|c| c.hot_key_sampling = Some(1));
+        db.reset_hot_key_stats(); // discard init_metadata traffic
+
+        for _ in 0..5 {
+            let _ = db.get(cf::STATE, b"hot").unwrap();
+        }
+        db.put(cf::STATE, b"hot", b"v").unwrap();
+        db.put(cf::CODE, b"codekey", b"v").unwrap();
+        db.delete(cf::CODE, b"codekey").unwrap();
+
+        let report = db.hot_key_report(10).expect("enabled => report");
+        assert_eq!(report.sampling_rate, 1);
+
+        let state = report.cfs.iter().find(|c| c.cf == cf::STATE).unwrap();
+        assert_eq!(state.reads_sampled, 5);
+        assert_eq!(state.writes_sampled, 1);
+        assert_eq!(state.top_keys[0].key_hex, "0x686f74"); // "hot"
+        assert_eq!(state.top_keys[0].estimated_count, 6);
+
+        // Per-CF isolation: "hot" only under STATE, "codekey" only under CODE.
+        let code = report.cfs.iter().find(|c| c.cf == cf::CODE).unwrap();
+        assert_eq!(code.writes_sampled, 2, "put + delete");
+        assert!(code.top_keys.iter().all(|k| k.key_hex != "0x686f74"));
+    }
+
+    #[test]
+    fn test_hot_keys_batch_writes_recorded() {
+        let (db, _dir) = open_temp_with(|c| c.hot_key_sampling = Some(1));
+        db.reset_hot_key_stats();
+
+        let mut batch = WriteBatch::new();
+        batch.put(cf::STATE, b"a".to_vec(), b"v".to_vec());
+        batch.put(cf::TRANSACTIONS, b"t".to_vec(), b"v".to_vec());
+        batch.delete(cf::STATE, b"a".to_vec());
+        db.write_batch(batch).unwrap();
+
+        let mut batch = WriteBatch::new();
+        batch.put(cf::STATE, b"a".to_vec(), b"v".to_vec());
+        db.write_batch_sync(batch).unwrap();
+
+        let report = db.hot_key_report(10).unwrap();
+        let state = report.cfs.iter().find(|c| c.cf == cf::STATE).unwrap();
+        assert_eq!(state.writes_sampled, 3, "2 batch ops + 1 sync batch op");
+        let txs = report
+            .cfs
+            .iter()
+            .find(|c| c.cf == cf::TRANSACTIONS)
+            .unwrap();
+        assert_eq!(txs.writes_sampled, 1);
+    }
+
+    #[test]
+    fn test_hot_keys_reset_starts_new_window() {
+        let (db, _dir) = open_temp_with(|c| c.hot_key_sampling = Some(1));
+        db.put(cf::STATE, b"k", b"v").unwrap();
+        let before = db.hot_key_report(10).unwrap();
+        assert!(!before.cfs.is_empty());
+
+        db.reset_hot_key_stats();
+        let after = db.hot_key_report(10).unwrap();
+        assert!(after.cfs.is_empty());
+        assert!(after.window_start_unix_ms >= before.window_start_unix_ms);
+    }
+
+    #[test]
+    fn test_hot_keys_shared_across_clones() {
+        let (db, _dir) = open_temp_with(|c| c.hot_key_sampling = Some(1));
+        db.reset_hot_key_stats();
+
+        let clone = db.clone();
+        clone.put(cf::STATE, b"k", b"v").unwrap();
+
+        let report = db.hot_key_report(10).unwrap();
+        let state = report.cfs.iter().find(|c| c.cf == cf::STATE).unwrap();
+        assert_eq!(state.writes_sampled, 1, "clones share one sampler");
     }
 
     #[test]

--- a/crates/qfc-storage/src/hotkeys.rs
+++ b/crates/qfc-storage/src/hotkeys.rs
@@ -1,0 +1,581 @@
+//! Hot-key access analytics (SRE roadmap T8).
+//!
+//! Low-overhead 1-in-N sampling of `get`/`put`/`delete`/batch traffic, with a
+//! per-column-family heavy-hitter sketch over the sampled keys. The output
+//! (top-N hot keys per CF, plus per-CF sampled read/write totals) feeds cache
+//! sizing decisions (T3) and is the chain-side mirror of embedding hot-key
+//! skew in the AI stack.
+//!
+//! # Design
+//!
+//! - **Sampling**: a single shared `AtomicU64` tick, incremented with
+//!   `Ordering::Relaxed` on every recorded operation. An op is sampled when
+//!   `tick & (rate - 1) == 0`; the configured rate is rounded **up** to a
+//!   power of two so the check is a mask, not a division. When sampling is
+//!   disabled the `Database` holds no sampler at all, so the per-op cost is a
+//!   single `Option` branch (no atomics, no allocation).
+//! - **Sketch**: the *space-saving* algorithm (Metwally, Agrawal, El Abbadi,
+//!   "Efficient computation of frequent and top-k elements in data streams",
+//!   2005) with a fixed capacity `C` per CF. See [`SpaceSaving`] for the
+//!   error characteristics.
+//! - **Stride-sampling caveat**: deterministic 1-in-N sampling can alias with
+//!   access loops whose period divides N. For hash-keyed blockchain traffic
+//!   (trie nodes, tx hashes) this is a non-issue; for adversarial or strictly
+//!   periodic workloads, interpret results accordingly.
+//!
+//! # Error bounds (what the report numbers mean)
+//!
+//! Let `S` = number of *sampled* increments a CF sketch has absorbed in the
+//! current window, `C` = sketch capacity, and `N` = sampling rate.
+//!
+//! 1. **Space-saving guarantee** (within sampled counts): for every tracked
+//!    key, `sampled_count - error <= true_sampled <= sampled_count`, and the
+//!    per-entry `error` is at most `S / C`. Any key whose true sampled count
+//!    exceeds `S / C` is guaranteed to be present in the sketch.
+//! 2. **Sampling noise**: `estimated_count = sampled_count * N` estimates the
+//!    true access count `T` with standard deviation ~ `sqrt(T * N)`, i.e.
+//!    relative error ~ `sqrt(N / T)`. For genuinely hot keys (large `T`) this
+//!    shrinks fast — which is exactly the regime the sketch targets.
+//!
+//! The report exposes both raw `sampled_count` and the scaled
+//! `estimated_count`, plus `max_overestimate` (= space-saving `error * N`).
+
+use parking_lot::Mutex;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::hash::Hash as StdHash;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Default 1-in-N sampling rate when hot-key analytics is enabled.
+pub const DEFAULT_HOT_KEY_SAMPLING: u32 = 64;
+
+/// Default heavy-hitter sketch capacity (entries per column family).
+pub const DEFAULT_HOT_KEY_CAPACITY: usize = 256;
+
+/// Current Unix time in milliseconds (0 if the clock is before the epoch).
+fn unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// A counter tracked by [`SpaceSaving`].
+#[derive(Clone, Copy, Debug)]
+struct SsCounter {
+    /// Estimated count (never underestimates the true count).
+    count: u64,
+    /// Maximum possible overestimation, inherited from the evicted entry.
+    error: u64,
+}
+
+/// Fixed-capacity *space-saving* heavy-hitter sketch.
+///
+/// Tracks at most `capacity` distinct keys. When a new key arrives and the
+/// sketch is full, the entry with the minimum count is evicted and the new
+/// key inherits `min + 1` as its count with `min` recorded as its error.
+///
+/// Guarantees, for a stream of `S` offers:
+/// - `count - error <= true_count <= count` for every tracked key;
+/// - the minimum tracked count (hence every `error`) is at most `S / capacity`;
+/// - every key with `true_count > S / capacity` is tracked (no false
+///   negatives above that threshold).
+///
+/// Storage layout: entries live in a contiguous `Vec` with a `HashMap`
+/// index over keys. Eviction (only on the sampled, new-key, sketch-full
+/// path) does an O(capacity) min-scan over the contiguous counters —
+/// L1/L2-resident at the default capacity of 256, a few hundred
+/// nanoseconds even in the adversarial all-distinct-keys stream.
+pub struct SpaceSaving<K> {
+    capacity: usize,
+    /// key -> position in `entries`.
+    index: HashMap<K, usize>,
+    entries: Vec<(K, SsCounter)>,
+}
+
+impl<K: Eq + StdHash + Clone> SpaceSaving<K> {
+    /// Create a sketch tracking at most `capacity` keys (min 1).
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            capacity,
+            index: HashMap::with_capacity(capacity),
+            entries: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Offer one occurrence of `key` to the sketch.
+    pub fn offer(&mut self, key: K) {
+        if let Some(&i) = self.index.get(&key) {
+            self.entries[i].1.count += 1;
+            return;
+        }
+        self.insert_new(key);
+    }
+
+    fn insert_new(&mut self, key: K) {
+        if self.entries.len() < self.capacity {
+            self.index.insert(key.clone(), self.entries.len());
+            self.entries.push((key, SsCounter { count: 1, error: 0 }));
+            return;
+        }
+        // Full: evict the minimum-count entry in place; the newcomer
+        // inherits its count as the upper bound on how often it might have
+        // been seen before being tracked.
+        let min_idx = self
+            .entries
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, (_, c))| c.count)
+            .map(|(i, _)| i)
+            .expect("sketch capacity >= 1");
+        let min_count = self.entries[min_idx].1.count;
+        let new_entry = (
+            key.clone(),
+            SsCounter {
+                count: min_count + 1,
+                error: min_count,
+            },
+        );
+        let (old_key, _) = std::mem::replace(&mut self.entries[min_idx], new_entry);
+        self.index.remove(&old_key);
+        self.index.insert(key, min_idx);
+    }
+
+    /// Top `n` keys by estimated count, descending. Returns
+    /// `(key, count, error)` triples in *sampled* (unscaled) units.
+    pub fn top(&self, n: usize) -> Vec<(K, u64, u64)> {
+        let mut all: Vec<_> = self
+            .entries
+            .iter()
+            .map(|(k, c)| (k.clone(), c.count, c.error))
+            .collect();
+        all.sort_by_key(|e| std::cmp::Reverse(e.1));
+        all.truncate(n);
+        all
+    }
+
+    /// Number of keys currently tracked.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the sketch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Maximum number of tracked keys.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Drop all tracked keys (capacity is retained).
+    pub fn clear(&mut self) {
+        self.index.clear();
+        self.entries.clear();
+    }
+}
+
+impl SpaceSaving<Box<[u8]>> {
+    /// Byte-slice fast path: avoids allocating the key on the (common)
+    /// already-tracked path; allocates only when inserting a new entry.
+    pub fn offer_bytes(&mut self, key: &[u8]) {
+        if let Some(&i) = self.index.get(key) {
+            self.entries[i].1.count += 1;
+            return;
+        }
+        self.insert_new(Box::from(key));
+    }
+}
+
+/// Per-CF sampling state.
+struct CfSampler {
+    reads_sampled: AtomicU64,
+    writes_sampled: AtomicU64,
+    sketch: Mutex<SpaceSaving<Box<[u8]>>>,
+}
+
+impl CfSampler {
+    fn new(capacity: usize) -> Self {
+        Self {
+            reads_sampled: AtomicU64::new(0),
+            writes_sampled: AtomicU64::new(0),
+            sketch: Mutex::new(SpaceSaving::new(capacity)),
+        }
+    }
+}
+
+/// Samples database key accesses and maintains per-CF heavy-hitter sketches.
+///
+/// Created by [`crate::Database::open`] when
+/// [`crate::StorageConfig::hot_key_sampling`] is `Some(rate)` with `rate > 0`.
+pub struct HotKeySampler {
+    /// Effective 1-in-N rate (configured rate rounded up to a power of two).
+    rate: u32,
+    /// `rate - 1`, for the mask fast path.
+    mask: u64,
+    tick: AtomicU64,
+    window_start_unix_ms: AtomicU64,
+    cfs: HashMap<&'static str, CfSampler>,
+}
+
+impl HotKeySampler {
+    /// Build a sampler for the given CF names. `rate` is rounded up to the
+    /// next power of two (`rate >= 1`).
+    pub(crate) fn new(rate: u32, capacity: usize, cf_names: &[&'static str]) -> Self {
+        let rate = rate.max(1).next_power_of_two();
+        Self {
+            rate,
+            mask: u64::from(rate) - 1,
+            tick: AtomicU64::new(0),
+            window_start_unix_ms: AtomicU64::new(unix_ms()),
+            cfs: cf_names
+                .iter()
+                .map(|name| (*name, CfSampler::new(capacity)))
+                .collect(),
+        }
+    }
+
+    /// Effective sampling rate (power of two).
+    pub fn rate(&self) -> u32 {
+        self.rate
+    }
+
+    /// One relaxed atomic increment + mask check.
+    #[inline]
+    fn should_sample(&self) -> bool {
+        self.tick.fetch_add(1, Ordering::Relaxed) & self.mask == 0
+    }
+
+    /// Record a read access. Hot path: one relaxed `fetch_add`; the sketch is
+    /// touched only for the 1-in-N sampled ops.
+    #[inline]
+    pub(crate) fn record_read(&self, cf: &str, key: &[u8]) {
+        if !self.should_sample() {
+            return;
+        }
+        if let Some(s) = self.cfs.get(cf) {
+            s.reads_sampled.fetch_add(1, Ordering::Relaxed);
+            s.sketch.lock().offer_bytes(key);
+        }
+    }
+
+    /// Record a write access (put or delete). Same cost profile as
+    /// [`Self::record_read`].
+    #[inline]
+    pub(crate) fn record_write(&self, cf: &str, key: &[u8]) {
+        if !self.should_sample() {
+            return;
+        }
+        if let Some(s) = self.cfs.get(cf) {
+            s.writes_sampled.fetch_add(1, Ordering::Relaxed);
+            s.sketch.lock().offer_bytes(key);
+        }
+    }
+
+    /// Snapshot the current window into a serializable report. CFs with no
+    /// sampled traffic are omitted; CFs are sorted by total sampled traffic
+    /// descending; each CF carries at most `top_n` hot keys.
+    pub fn report(&self, top_n: usize) -> HotKeyReport {
+        let mut cfs: Vec<CfHotKeyStats> = Vec::new();
+        let mut capacity = DEFAULT_HOT_KEY_CAPACITY;
+        for (name, s) in &self.cfs {
+            let reads = s.reads_sampled.load(Ordering::Relaxed);
+            let writes = s.writes_sampled.load(Ordering::Relaxed);
+            if reads == 0 && writes == 0 {
+                continue;
+            }
+            let sketch = s.sketch.lock();
+            capacity = sketch.capacity();
+            let rate = u64::from(self.rate);
+            let top_keys = sketch
+                .top(top_n)
+                .into_iter()
+                .map(|(key, count, error)| HotKeyEntry {
+                    key_hex: hex(&key),
+                    sampled_count: count,
+                    estimated_count: count * rate,
+                    max_overestimate: error * rate,
+                })
+                .collect();
+            cfs.push(CfHotKeyStats {
+                cf: (*name).to_string(),
+                reads_sampled: reads,
+                writes_sampled: writes,
+                estimated_reads: reads * rate,
+                estimated_writes: writes * rate,
+                top_keys,
+            });
+        }
+        cfs.sort_by(|a, b| {
+            (b.reads_sampled + b.writes_sampled).cmp(&(a.reads_sampled + a.writes_sampled))
+        });
+        HotKeyReport {
+            sampling_rate: self.rate,
+            sketch_capacity: capacity,
+            window_start_unix_ms: self.window_start_unix_ms.load(Ordering::Relaxed),
+            cfs,
+        }
+    }
+
+    /// Reset all counters and sketches and start a new window.
+    pub fn reset(&self) {
+        for s in self.cfs.values() {
+            s.reads_sampled.store(0, Ordering::Relaxed);
+            s.writes_sampled.store(0, Ordering::Relaxed);
+            s.sketch.lock().clear();
+        }
+        self.window_start_unix_ms
+            .store(unix_ms(), Ordering::Relaxed);
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(2 + bytes.len() * 2);
+    out.push_str("0x");
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// Serializable hot-key report for one sampling window. See the module docs
+/// for the exact meaning of the estimate and error fields.
+#[derive(Clone, Debug, Serialize)]
+pub struct HotKeyReport {
+    /// Effective 1-in-N sampling rate (power of two).
+    pub sampling_rate: u32,
+    /// Heavy-hitter sketch capacity per CF.
+    pub sketch_capacity: usize,
+    /// Window start (Unix milliseconds); set at open and on `reset()`.
+    pub window_start_unix_ms: u64,
+    /// Per-CF stats, sorted by total sampled traffic descending. CFs with no
+    /// sampled traffic are omitted.
+    pub cfs: Vec<CfHotKeyStats>,
+}
+
+/// Per-column-family hot-key statistics.
+#[derive(Clone, Debug, Serialize)]
+pub struct CfHotKeyStats {
+    /// Column family name.
+    pub cf: String,
+    /// Sampled read ops in this window.
+    pub reads_sampled: u64,
+    /// Sampled write ops (puts + deletes) in this window.
+    pub writes_sampled: u64,
+    /// `reads_sampled * sampling_rate` — estimated true reads.
+    pub estimated_reads: u64,
+    /// `writes_sampled * sampling_rate` — estimated true writes.
+    pub estimated_writes: u64,
+    /// Hottest keys, descending by estimated count.
+    pub top_keys: Vec<HotKeyEntry>,
+}
+
+/// One hot key with its estimated access count and error bound.
+#[derive(Clone, Debug, Serialize)]
+pub struct HotKeyEntry {
+    /// Hex-encoded raw key (`0x…`).
+    pub key_hex: String,
+    /// Raw sampled count (space-saving estimate, unscaled).
+    pub sampled_count: u64,
+    /// `sampled_count * sampling_rate` — estimated true access count.
+    pub estimated_count: u64,
+    /// Space-saving overestimation bound, scaled by the sampling rate:
+    /// the true (estimated) count is in
+    /// `[estimated_count - max_overestimate, estimated_count]`
+    /// up to sampling noise.
+    pub max_overestimate: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic xorshift64* PRNG (no external deps).
+    struct Rng(u64);
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x >> 12;
+            x ^= x << 25;
+            x ^= x >> 27;
+            self.0 = x;
+            x.wrapping_mul(0x2545F4914F6CDD1D)
+        }
+        fn next_f64(&mut self) -> f64 {
+            (self.next() >> 11) as f64 / (1u64 << 53) as f64
+        }
+    }
+
+    /// Zipf(s) sampler over ranks 1..=n via inverse-CDF table.
+    struct Zipf {
+        cdf: Vec<f64>,
+    }
+    impl Zipf {
+        fn new(n: usize, s: f64) -> Self {
+            let mut weights: Vec<f64> = (1..=n).map(|k| 1.0 / (k as f64).powf(s)).collect();
+            let total: f64 = weights.iter().sum();
+            let mut acc = 0.0;
+            for w in &mut weights {
+                acc += *w / total;
+                *w = acc;
+            }
+            Self { cdf: weights }
+        }
+        /// Returns a rank in 0..n (0 = hottest).
+        fn sample(&self, rng: &mut Rng) -> usize {
+            let u = rng.next_f64();
+            self.cdf.partition_point(|&c| c < u).min(self.cdf.len() - 1)
+        }
+    }
+
+    #[test]
+    fn space_saving_exact_when_under_capacity() {
+        let mut ss = SpaceSaving::<u32>::new(16);
+        for _ in 0..5 {
+            ss.offer(1);
+        }
+        for _ in 0..3 {
+            ss.offer(2);
+        }
+        ss.offer(3);
+        let top = ss.top(10);
+        assert_eq!(top[0], (1, 5, 0));
+        assert_eq!(top[1], (2, 3, 0));
+        assert_eq!(top[2], (3, 1, 0));
+    }
+
+    #[test]
+    fn space_saving_zipf_accuracy() {
+        // 10k distinct keys, zipf(1.05), 200k offers, capacity 256.
+        let n = 10_000;
+        let offers = 200_000u64;
+        let capacity = 256;
+        let zipf = Zipf::new(n, 1.05);
+        let mut rng = Rng(0x9E3779B97F4A7C15);
+
+        let mut ss = SpaceSaving::<u64>::new(capacity);
+        let mut truth = HashMap::<u64, u64>::new();
+        for _ in 0..offers {
+            let rank = zipf.sample(&mut rng) as u64;
+            *truth.entry(rank).or_default() += 1;
+            ss.offer(rank);
+        }
+
+        let top = ss.top(capacity);
+        // Top-1 must always be found: the true hottest key (rank 0).
+        assert_eq!(top[0].0, 0, "true hottest key must rank first");
+
+        let bound = offers / capacity as u64;
+        for (key, count, error) in &top {
+            let true_count = truth.get(key).copied().unwrap_or(0);
+            // Documented guarantees: count - error <= true <= count,
+            // error <= S/C.
+            assert!(*count >= true_count, "estimate must not underestimate");
+            assert!(
+                count - error <= true_count,
+                "count({count}) - error({error}) must lower-bound true({true_count})"
+            );
+            assert!(*error <= bound, "error({error}) must be <= S/C({bound})");
+        }
+
+        // Every key with true count > S/C must be tracked.
+        let tracked: std::collections::HashSet<u64> = top.iter().map(|(k, _, _)| *k).collect();
+        for (key, true_count) in &truth {
+            if *true_count > bound {
+                assert!(tracked.contains(key), "key {key} above S/C must be tracked");
+            }
+        }
+    }
+
+    #[test]
+    fn space_saving_eviction_inherits_min() {
+        let mut ss = SpaceSaving::<u32>::new(2);
+        for _ in 0..10 {
+            ss.offer(1);
+        }
+        ss.offer(2); // fills capacity
+        ss.offer(3); // evicts key 2 (count 1) -> count 2, error 1
+        let top = ss.top(2);
+        assert_eq!(top[0], (1, 10, 0));
+        assert_eq!(top[1], (3, 2, 1));
+    }
+
+    #[test]
+    fn sampler_rate_rounds_up_to_power_of_two() {
+        let s = HotKeySampler::new(3, 8, &["a"]);
+        assert_eq!(s.rate(), 4);
+        let s = HotKeySampler::new(64, 8, &["a"]);
+        assert_eq!(s.rate(), 64);
+        let s = HotKeySampler::new(0, 8, &["a"]); // clamped to 1
+        assert_eq!(s.rate(), 1);
+    }
+
+    #[test]
+    fn sampler_rate_one_counts_everything() {
+        let s = HotKeySampler::new(1, 8, &["a", "b"]);
+        for _ in 0..10 {
+            s.record_read("a", b"k1");
+        }
+        s.record_write("a", b"k1");
+        s.record_write("b", b"k2");
+
+        let report = s.report(10);
+        assert_eq!(report.sampling_rate, 1);
+        assert_eq!(report.cfs.len(), 2);
+        let a = report.cfs.iter().find(|c| c.cf == "a").unwrap();
+        assert_eq!(a.reads_sampled, 10);
+        assert_eq!(a.writes_sampled, 1);
+        assert_eq!(a.estimated_reads, 10);
+        assert_eq!(a.top_keys[0].key_hex, "0x6b31"); // "k1"
+        assert_eq!(a.top_keys[0].estimated_count, 11);
+
+        // Per-CF isolation: k1 must not appear under "b".
+        let b = report.cfs.iter().find(|c| c.cf == "b").unwrap();
+        assert_eq!(b.top_keys.len(), 1);
+        assert_eq!(b.top_keys[0].key_hex, "0x6b32"); // "k2"
+    }
+
+    #[test]
+    fn sampler_rate_n_samples_one_in_n() {
+        let s = HotKeySampler::new(8, 8, &["a"]);
+        for _ in 0..800 {
+            s.record_read("a", b"k");
+        }
+        let report = s.report(10);
+        let a = &report.cfs[0];
+        assert_eq!(a.reads_sampled, 100);
+        assert_eq!(a.estimated_reads, 800);
+    }
+
+    #[test]
+    fn sampler_unknown_cf_is_ignored() {
+        let s = HotKeySampler::new(1, 8, &["a"]);
+        s.record_read("nope", b"k");
+        assert!(s.report(10).cfs.is_empty());
+    }
+
+    #[test]
+    fn sampler_reset_clears_and_restarts_window() {
+        let s = HotKeySampler::new(1, 8, &["a"]);
+        s.record_read("a", b"k");
+        let before = s.report(10);
+        assert_eq!(before.cfs.len(), 1);
+
+        s.reset();
+        let after = s.report(10);
+        assert!(after.cfs.is_empty(), "counters and sketches cleared");
+        assert!(after.window_start_unix_ms >= before.window_start_unix_ms);
+    }
+
+    #[test]
+    fn report_serializes_to_json() {
+        let s = HotKeySampler::new(1, 8, &["a"]);
+        s.record_read("a", b"\x01\x02");
+        let json = serde_json::to_string(&s.report(10)).unwrap();
+        assert!(json.contains("\"key_hex\":\"0x0102\""));
+        assert!(json.contains("\"sampling_rate\":1"));
+    }
+}

--- a/crates/qfc-storage/src/lib.rs
+++ b/crates/qfc-storage/src/lib.rs
@@ -5,11 +5,13 @@
 mod batch;
 mod db;
 mod error;
+pub mod hotkeys;
 mod schema;
 mod snapshot;
 
 pub use batch::*;
 pub use db::*;
 pub use error::*;
+pub use hotkeys::*;
 pub use schema::*;
 pub use snapshot::*;

--- a/docs/profiling/HOT-KEYS.md
+++ b/docs/profiling/HOT-KEYS.md
@@ -1,0 +1,187 @@
+# T8 — Hot-key analytics: design, overhead, findings
+
+SRE roadmap T8 (`docs/ROADMAP-SRE.md`). Per-CF and per-account access sampling
+in `qfc-storage`/`qfc-state`, with top-N heavy-hitter reports. Feeds cache
+sizing for T3 and is the chain-side mirror of embedding hot-key skew in the AI
+stack.
+
+## Design
+
+Two layers, because raw storage keys are not attributable to accounts:
+
+1. **`qfc_storage::hotkeys::HotKeySampler`** — wired into `Database`
+   `get`/`put`/`delete`/`contains`/`write_batch{,_sync}`. Enabled via
+   `StorageConfig::hot_key_sampling: Option<u32>` (1-in-N, rounded up to a
+   power of two so the sample check is a mask, not a division; default rate
+   constant is 64). Per column family: sampled read/write counters plus a
+   fixed-capacity **space-saving** heavy-hitter sketch (Metwally et al. 2005,
+   default 256 entries/CF) over the sampled keys. Read via
+   `Database::hot_key_report(top_n)`, windowed via
+   `Database::reset_hot_key_stats()`.
+2. **`qfc_state::HotAccountTracker`** — the `state` CF stores trie nodes keyed
+   by *node hash*, which cannot be mapped back to accounts (and churns on
+   every commit — see findings). So `StateDB` samples its own API
+   (`get_account`/`set_account`/`get_code`) into sketches keyed by `Address`
+   and code `Hash`, **before** the LRU caches, so the report reflects the
+   logical access distribution that cache sizing needs. Enabled automatically
+   at the same rate/capacity when the underlying `Database` has sampling on.
+   Read via `StateDB::hot_account_report(top_n)` /
+   `reset_hot_account_stats()`.
+
+Cost model:
+
+- **Disabled** (default): the `Database`/`StateDB` holds no sampler at all —
+  per-op cost is a single `Option` branch. No atomics, no allocation.
+- **Enabled, non-sampled op** (63 of 64): one relaxed `fetch_add` + mask
+  check.
+- **Enabled, sampled op** (1 of 64): one relaxed counter increment + mutex +
+  sketch offer. Already-tracked keys are a hash-map hit and a counter bump;
+  new keys on a full sketch take an O(capacity) min-scan eviction
+  (L1/L2-resident at capacity 256).
+
+### Error bounds (what the report numbers mean)
+
+Let `S` = sampled offers absorbed by a sketch in the window, `C` = sketch
+capacity (256), `N` = sampling rate (64).
+
+1. **Space-saving guarantee** (within sampled counts): for every tracked key,
+   `sampled_count − error ≤ true_sampled ≤ sampled_count`, with
+   `error ≤ S/C`. Every key whose true sampled count exceeds `S/C` is
+   guaranteed present. The report exposes `max_overestimate = error × N`; when
+   `max_overestimate ≈ estimated_count` the entry is churn noise, not a real
+   heavy hitter (diagnostic in itself — see the trie-node finding below).
+2. **Sampling noise**: `estimated_count = sampled_count × N` estimates the
+   true count `T` with relative error ≈ `sqrt(N/T)` — e.g. ±5.7 % at
+   `T = 20 000`, ±18 % at `T = 2 000`. Genuinely hot keys (large `T`) are
+   exactly the regime where this is small.
+3. **Stride-sampling caveat**: deterministic 1-in-N can alias with access
+   loops whose period divides N. Hash-keyed blockchain traffic is fine;
+   strictly periodic synthetic loops should be interpreted accordingly.
+
+## Overhead benchmarks
+
+`cargo bench -p qfc-storage`. The `*_sampled` groups are structurally
+identical to their unsampled twins but open the DB with
+`hot_key_sampling: Some(64)`. Numbers below are Criterion medians from the
+focused back-to-back run on an otherwise idle machine (2026-06-12, macOS,
+same binary); baseline is `main` @ a762936.
+
+| Benchmark | main baseline | branch, sampling disabled | branch, sampling 1/64 | enabled vs disabled |
+|---|---|---|---|---|
+| `storage_put/256b` | 1.81 µs | 1.55 µs | 1.70 µs | +9.3 % (+0.15 µs/op) |
+| `storage_get/from_10000_keys` | 398 ns | 331 ns | 356 ns | +7.4 % (+25 ns/op) |
+| `storage_batch_write/ops/500` | 79.1 µs | 79.3 µs | 97.8 µs | +23 % (+37 ns/batched-op) |
+
+Honest reading:
+
+- **Disabled vs baseline: no measurable delta.** Across three independent
+  runs the branch-with-sampling-disabled numbers straddle the main baseline
+  (puts ran *faster* than baseline in all three runs, gets within the
+  run-to-run band). The disabled path is one branch; any true cost is below
+  environment noise, which for these RocksDB microbenches is large
+  (`storage_batch_write/ops/500` with *identical* code ranged 79–152 µs
+  across earlier preliminary runs — treat single-run percentages
+  accordingly).
+- **Enabled overhead is tens of ns/op and these benches are the sketch's
+  worst case**: keys are all-distinct and monotonically increasing, so every
+  sampled offer misses the sketch and takes the O(256) eviction scan +
+  allocation. Real hot-key traffic (the workload below) takes the cheap
+  already-tracked increment path. The absolute penalty — ~25 ns/get,
+  ~37 ns/batched-write — is small against RocksDB op costs and applies only
+  while sampling is switched on.
+
+Earlier full-suite runs (preliminary, same ordering of magnitude):
+baseline `/tmp/t8_bench_baseline_main.txt`, branch runs
+`/tmp/t8_bench_branch.txt` / `/tmp/t8_bench_branch2.txt`.
+
+## Findings: synthetic block-import workload
+
+Generator: `cargo run -p qfc-state --release --example hot_key_workload
+[transfers]` — 200 000 zipf(s = 1.1)-distributed transfers over 5 000
+accounts, one zipf(s = 1.2) contract-code read per 4 transfers over 100
+contracts, commit every 500 transfers; sampling at the production default
+1-in-64; counters reset after seeding so only steady state is measured.
+Throughput on the dev machine: ≈ 39 k transfers/s.
+
+### Account layer: clean power law, rank order recovered
+
+Total estimated account ops 1.41 M (829 k reads, 581 k writes; writes are
+`set_account`, i.e. transfer + nonce updates).
+
+| report rank | true zipf rank | estimated count | max_overestimate |
+|---|---|---|---|
+| 1 | 0 | 194 560 | 0 |
+| 2 | 1 | 101 056 | 0 |
+| 3 | 2 | 66 624 | 0 |
+| 5 | 4 | 36 928 | 0 |
+| 10 | 9 | 17 792 | 0 |
+| 20 | 18 | 8 768 | 0 |
+
+- Successive-rank ratios ≈ 1.9–2.0 ≈ 2^1.1 — the configured zipf exponent is
+  recovered; `max_overestimate = 0` for the whole top-20 (hot entries were
+  never evicted).
+- Rank order is essentially exact: report ranks 1–13 are true ranks 0–12 with
+  a single adjacent swap; one "intruder" at report rank 14 is the hottest
+  *contract* address — `get_code` funnels through `get_account`, so contract
+  accounts correctly show up in account traffic too.
+- **Concentration**: the top 13 accounts (0.26 % of 5 000) carry ≈ 43 % of
+  all account traffic; the top 20 carry ≈ 48 %.
+
+### Code layer: even more concentrated
+
+Estimated code reads 52.9 k. Top contract = 28 % of all code reads; top 4 of
+100 contracts = 53 %; top 20 = 81 %. All `max_overestimate = 0`.
+
+### Storage layer: trie-node keys churn — no stable hot keys
+
+The `state` CF saw an estimated **3.38 M writes** for 200 k transfers
+(≈ 17 trie-node writes per transfer — path copying on every commit) but only
+**51 k reads** at the storage layer: the `StateDB` account LRU (10 k entries
+≥ the 5 k-account working set) absorbs virtually all logical reads before
+RocksDB. The per-CF sketch for `state` is fully saturated churn: every top
+entry sits at sampled_count 210 with `max_overestimate` 13 376 (≈ 99.5 % of
+the estimate) — i.e. **there are no stable hot keys at trie-node granularity**,
+because node hashes change on every write. This is the empirical
+justification for the two-layer design: account attribution must happen in
+`qfc-state`, and the storage-layer sketch is mainly useful for CFs with
+stable keys (code, transactions, receipts) and for per-CF traffic *volume*.
+
+### Implications for the T3 per-CF cache split
+
+1. **Weight the `state` CF by traffic volume, not key reuse.** It dominates
+   ops (3.4 M writes vs zero observed traffic on most other CFs in this
+   workload), but its keys churn — size its share for write-path health
+   (write buffer, upper-trie-level block reuse during commit) rather than
+   expecting stable per-key block-cache hits.
+2. **The in-process account LRU is the real read cache and it is already
+   ample.** A few-hundred-entry account cache would capture ~40–50 % of
+   logical account traffic under this skew; the existing 10 k-entry LRU
+   covers the entire working set. Do not grow it; per-CF block cache for
+   `state` buys little for reads while the LRU is warm (cold-start/restart is
+   the exception).
+3. **`code` CF block-cache share can be small.** Code access is extremely
+   top-heavy (top 4 bytecodes = 53 % of reads) and the code LRU
+   (content-addressed) absorbs it; allocate the `code` CF a token share.
+4. **Give zero-traffic CFs the minimum.** The report omits CFs with no
+   sampled traffic — under block-import-style load that is most of the 18+
+   CFs; the report is the live input for rebalancing on real nodes.
+
+### Caveats
+
+- **Synthetic dev workload ≠ testnet.** Single process, no RPC read traffic,
+  no EVM execution, no compaction pressure from history, zipf exponents
+  chosen a priori. Real skew (and the read/write mix) must be re-measured on
+  a testnet node before committing T3 cache numbers; the mechanism (enable
+  `hot_key_sampling`, window with `reset_*`, dump both reports) is what this
+  item delivers.
+- Storage-level read counts reflect *cache misses* of the layers above, by
+  design at that layer; the account-level report is the logical distribution.
+- Counts are estimates: ±`sqrt(64/T)` relative sampling noise plus the
+  space-saving bound surfaced per entry as `max_overestimate`.
+
+## Follow-up (deferred)
+
+Exporter/RPC wiring (Prometheus surface for `hot_key_report` /
+`hot_account_report`, periodic windowing in the node) is deferred to the
+orchestrator — T2's exporter is the natural home; this item deliberately
+stops at the library + reports to keep the scope at qfc-storage/qfc-state.


### PR DESCRIPTION
SRE roadmap **T8 — Hot-key analytics** (`docs/ROADMAP-SRE.md`). Scope: `qfc-storage` + `qfc-state` only; exporter/RPC wiring deferred (see follow-up).

## Design

Two layers, because raw storage keys are not attributable to accounts:

- **`qfc_storage::hotkeys::HotKeySampler`** — opt-in via `StorageConfig::hot_key_sampling: Option<u32>` (1-in-N, rounded up to a power of two so the sample check is a mask). Wired into `get`/`put`/`delete`/`contains`/`write_batch{,_sync}`. Per CF: sampled read/write counters + a fixed-capacity **space-saving** heavy-hitter sketch (Metwally 2005, 256 entries/CF) over sampled keys. `Database::hot_key_report(top_n)` / `reset_hot_key_stats()` for windowed use.
- **`qfc_state::HotAccountTracker`** — the `state` CF stores trie nodes keyed by node hash (unattributable, churns every commit), so `StateDB` samples its own API (`get_account`/`set_account`/`get_code`) **before** the LRU caches into `Address`/code-`Hash` sketches. Enabled automatically at the database's rate. `StateDB::hot_account_report(top_n)` / `reset_hot_account_stats()`.

**Disabled by default** — the per-op cost is then a single `Option` branch (no atomics, no allocation). Enabled: 63/64 ops pay one relaxed `fetch_add` + mask check; the sampled op pays a mutex + sketch offer.

### Error bounds
With `S` sampled offers, capacity `C = 256`, rate `N = 64`:
- Space-saving: `sampled_count − error ≤ true_sampled ≤ sampled_count`, `error ≤ S/C`; every key with true sampled count > `S/C` is tracked. Surfaced per entry as `max_overestimate = error × N`.
- Sampling noise: relative error ≈ `sqrt(N/T)` for true count `T` (±5.7 % at T=20k) — smallest exactly for hot keys.

## Overhead (Criterion medians; focused back-to-back run, idle machine; baseline = main @ a762936)

| Benchmark | main baseline | sampling disabled | sampling 1/64 | enabled vs disabled |
|---|---|---|---|---|
| `storage_put/256b` | 1.81 µs | 1.55 µs | 1.70 µs | +9.3 % (+0.15 µs/op) |
| `storage_get/from_10000_keys` | 398 ns | 331 ns | 356 ns | +7.4 % (+25 ns/op) |
| `storage_batch_write/ops/500` | 79.1 µs | 79.3 µs | 97.8 µs | +23 % (+37 ns/batched-op) |

- **Disabled vs baseline: no measurable delta** (disabled runs straddle/beat baseline across three runs; run-to-run noise on these RocksDB microbenches is large — identical-code batch/500 ranged 79–152 µs across runs).
- **Enabled overhead is tens of ns/op, and the benches are the sketch's worst case** (all-distinct monotonic keys ⇒ every sampled offer takes the O(256) eviction path; real hot-key traffic takes the cheap increment path).

## Findings (docs/profiling/HOT-KEYS.md)

From the synthetic block-import workload (`cargo run -p qfc-state --release --example hot_key_workload`, 200k zipf transfers / 5k accounts, code reads over 100 contracts, sampling 1/64):

- **Account layer recovers the power law with exact rank order** (successive-rank ratios ≈ 2^1.1, `max_overestimate = 0` across the top-20). Top 13 accounts (0.26 %) carry ≈ 43 % of account traffic; code even more concentrated (top 4 of 100 bytecodes = 53 % of code reads).
- **Trie-node keys in the `state` CF have no stable hot keys** — 3.38 M estimated writes for 200k transfers (~17 nodes/transfer) with the sketch fully churned (`max_overestimate` ≈ 99.5 % of the estimate). Empirical justification for doing attribution in `qfc-state`.
- **T3 cache-split inputs**: weight the `state` CF by traffic volume not key reuse; the 10k-entry account LRU already covers the working set (don't grow it); `code` CF needs only a token share; zero-traffic CFs get the minimum.
- **Caveat**: synthetic/dev workload ≠ testnet — re-measure on a real node before fixing T3 numbers; this PR delivers the mechanism.

## Tests / gates

- 47 (qfc-storage) + 37 (qfc-state) tests pass, incl. zipf accuracy vs documented sketch guarantees, per-CF/per-account attribution, batch recording, windows/reset, clone-sharing.
- `cargo check --workspace` clean; `cargo fmt --all --check` clean; clippy clean on touched code (remaining qfc-state warnings are pre-existing in `snap.rs`).

## Follow-up (deferred to orchestrator)

Exporter/RPC wiring — Prometheus surface for `hot_key_report`/`hot_account_report` and periodic windowing in the node (natural home: T2 exporter). Deliberately out of scope to keep this PR at qfc-storage/qfc-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)