### PR TITLE
T8 follow-up: hot-key/hot-account metrics in the node exporter + --hot-key-sampling flag

### DIFF
--- a/crates/qfc-node/src/main.rs
+++ b/crates/qfc-node/src/main.rs
@@ -104,6 +104,13 @@ struct Args {
     #[arg(long, env = "QFC_DB_STATISTICS")]
     db_statistics: bool,
 
+    /// T8: enable hot-key/hot-account access sampling at a 1-in-N rate
+    /// (rounded up to a power of two; e.g. 64). Unset/0 = disabled (zero
+    /// per-op cost). Results surface on /metrics (aggregate skew gauges) and
+    /// via the in-memory report accessors. See docs/profiling/HOT-KEYS.md.
+    #[arg(long, env = "QFC_HOT_KEY_SAMPLING")]
+    hot_key_sampling: Option<u32>,
+
     /// IPFS Kubo API URL for large inference result storage (optional)
     #[arg(long, env = "QFC_IPFS_API_URL")]
     ipfs_api_url: Option<String>,
@@ -206,12 +213,17 @@ async fn main() -> Result<()> {
         path: args.datadir.join("db"),
         create_if_missing: true,
         enable_statistics: args.db_statistics,
+        hot_key_sampling: args.hot_key_sampling.filter(|&n| n > 0),
         ..Default::default()
     };
     let db = Database::open(storage_config)?;
     info!(
-        "Database opened (statistics: {})",
-        if args.db_statistics { "on" } else { "off" }
+        "Database opened (statistics: {}, hot-key sampling: {})",
+        if args.db_statistics { "on" } else { "off" },
+        match db.hot_key_sampling() {
+            Some(rate) => format!("1-in-{rate}"),
+            None => "off".to_string(),
+        }
     );
 
     // Create genesis config

--- a/crates/qfc-node/src/metrics.rs
+++ b/crates/qfc-node/src/metrics.rs
@@ -426,6 +426,9 @@ impl MetricsServer {
             Self::render_ai_quota_metrics(&snapshot, &mut out);
         }
 
+        // --- hot-key / hot-account analytics (T8) ---
+        self.render_hot_key_metrics(&mut out);
+
         out
     }
 
@@ -765,6 +768,151 @@ impl MetricsServer {
         }
     }
 
+    /// T8: hot-key / hot-account analytics.
+    ///
+    /// **Cardinality:** the top-N hot *identities* (raw keys, account
+    /// addresses, code hashes) are deliberately NOT exported as Prometheus
+    /// labels — the hot set churns window-to-window, which would leak
+    /// unbounded, short-lived time series (same reasoning as T5's tier-only
+    /// labels). What we export is bounded and stable: per-CF traffic
+    /// estimates (one series per `cf::ALL` entry) and per-CF / DB-wide skew
+    /// gauges (the hottest entry's *count*, without its identity). The actual
+    /// top-N identities live in `Database::hot_key_report` /
+    /// `StateDB::hot_account_report` and the findings in
+    /// `docs/profiling/HOT-KEYS.md`.
+    ///
+    /// **Accuracy caveat:** per-CF key stats are complete (the storage
+    /// sampler is shared across every `Database` clone). Per-account stats
+    /// cover only the chain's persistent state handle (`chain.state()`); the
+    /// sync path's transient `state_at` handles carry their own trackers and
+    /// are not aggregated here.
+    fn render_hot_key_metrics(&self, out: &mut String) {
+        const TOP_N: usize = 16;
+
+        let storage_report = self
+            .storage
+            .as_ref()
+            .and_then(|db| db.hot_key_report(TOP_N));
+
+        let enabled: u8 = if storage_report.is_some() { 1 } else { 0 };
+        let _ = writeln!(
+            out,
+            "# HELP qfc_hot_key_sampling_enabled 1 if T8 hot-key sampling is active, else 0."
+        );
+        let _ = writeln!(out, "# TYPE qfc_hot_key_sampling_enabled gauge");
+        let _ = writeln!(out, "qfc_hot_key_sampling_enabled {enabled}");
+
+        let Some(report) = storage_report else {
+            return;
+        };
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_hot_key_sampling_rate Effective 1-in-N sampling rate (power of two)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_hot_key_sampling_rate gauge");
+        let _ = writeln!(out, "qfc_hot_key_sampling_rate {}", report.sampling_rate);
+
+        let _ = writeln!(
+            out,
+            "# HELP qfc_hot_key_window_start_timestamp_seconds Unix time the current sampling window opened (0 = never reset)."
+        );
+        let _ = writeln!(
+            out,
+            "# TYPE qfc_hot_key_window_start_timestamp_seconds gauge"
+        );
+        let _ = writeln!(
+            out,
+            "qfc_hot_key_window_start_timestamp_seconds {}",
+            report.window_start_unix_ms / 1000
+        );
+
+        // Per-CF estimated traffic (bounded by cf::ALL). Gauges: windowed
+        // estimates that reset with the sampling window.
+        let _ = writeln!(
+            out,
+            "# HELP qfc_hot_key_estimated_reads Estimated read ops per CF this window (sampled * rate)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_hot_key_estimated_reads gauge");
+        for cf in &report.cfs {
+            let _ = writeln!(
+                out,
+                "qfc_hot_key_estimated_reads{{cf=\"{}\"}} {}",
+                cf.cf, cf.estimated_reads
+            );
+        }
+        let _ = writeln!(
+            out,
+            "# HELP qfc_hot_key_estimated_writes Estimated write ops per CF this window (sampled * rate)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_hot_key_estimated_writes gauge");
+        for cf in &report.cfs {
+            let _ = writeln!(
+                out,
+                "qfc_hot_key_estimated_writes{{cf=\"{}\"}} {}",
+                cf.cf, cf.estimated_writes
+            );
+        }
+
+        // Per-CF skew: the hottest single key's estimated count (no identity).
+        let _ = writeln!(
+            out,
+            "# HELP qfc_hot_key_top_estimated_count Estimated access count of the hottest key in each CF (skew indicator)."
+        );
+        let _ = writeln!(out, "# TYPE qfc_hot_key_top_estimated_count gauge");
+        for cf in &report.cfs {
+            if let Some(top) = cf.top_keys.first() {
+                let _ = writeln!(
+                    out,
+                    "qfc_hot_key_top_estimated_count{{cf=\"{}\"}} {}",
+                    cf.cf, top.estimated_count
+                );
+            }
+        }
+
+        // Hot-account analytics from the chain's persistent state handle.
+        if let Some(acct) = self.chain.state().hot_account_report(TOP_N) {
+            let aggregates: &[(&str, &str, u64)] = &[
+                (
+                    "qfc_hot_account_estimated_reads",
+                    "Estimated account reads this window (sampled * rate).",
+                    acct.estimated_account_reads,
+                ),
+                (
+                    "qfc_hot_account_estimated_writes",
+                    "Estimated account writes this window (sampled * rate).",
+                    acct.estimated_account_writes,
+                ),
+                (
+                    "qfc_hot_account_estimated_code_reads",
+                    "Estimated contract-code reads this window (sampled * rate).",
+                    acct.estimated_code_reads,
+                ),
+            ];
+            for (name, help, value) in aggregates {
+                let _ = writeln!(out, "# HELP {name} {help}");
+                let _ = writeln!(out, "# TYPE {name} gauge");
+                let _ = writeln!(out, "{name} {value}");
+            }
+
+            let _ = writeln!(
+                out,
+                "# HELP qfc_hot_account_top_estimated_count Estimated access count of the hottest account (skew indicator)."
+            );
+            let _ = writeln!(out, "# TYPE qfc_hot_account_top_estimated_count gauge");
+            let top_account = acct.top_accounts.first().map_or(0, |a| a.estimated_count);
+            let _ = writeln!(out, "qfc_hot_account_top_estimated_count {top_account}");
+
+            let _ = writeln!(
+                out,
+                "# HELP qfc_hot_code_top_estimated_count Estimated read count of the hottest contract bytecode (skew indicator)."
+            );
+            let _ = writeln!(out, "# TYPE qfc_hot_code_top_estimated_count gauge");
+            let top_code = acct.top_code.first().map_or(0, |c| c.estimated_count);
+            let _ = writeln!(out, "qfc_hot_code_top_estimated_count {top_code}");
+        }
+    }
+
     /// Wall-clock seconds since the head block's timestamp (block timestamps
     /// are unix milliseconds). Returns 0 when the chain is empty or clocks
     /// disagree.
@@ -851,12 +999,16 @@ mod tests {
     /// Build a `MetricsServer` over a temp DB (optionally with RocksDB
     /// statistics) wired the same way `main.rs` does it. The returned
     /// `TempDir` must stay alive as long as the server.
-    fn test_server(enable_statistics: bool) -> (MetricsServer, tempfile::TempDir) {
+    fn test_server(
+        enable_statistics: bool,
+        hot_key_sampling: Option<u32>,
+    ) -> (MetricsServer, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();
         let db = Database::open(StorageConfig {
             path: tmp.path().join("db"),
             create_if_missing: true,
             enable_statistics,
+            hot_key_sampling,
             ..Default::default()
         })
         .unwrap();
@@ -953,7 +1105,7 @@ mod tests {
     /// referenced by docs/observability/ (dashboard + alert rules).
     #[test]
     fn render_metrics_includes_expected_metric_names() {
-        let (server, _tmp) = test_server(true);
+        let (server, _tmp) = test_server(true, Some(1));
         let out = server.render_metrics();
 
         for name in [
@@ -1015,6 +1167,18 @@ mod tests {
             "qfc_ai_flops_metered_total",
             "qfc_ai_tenant_inflight",
             "qfc_ai_cost_report_last_timestamp_seconds",
+            // hot-key / hot-account analytics (T8)
+            "qfc_hot_key_sampling_enabled",
+            "qfc_hot_key_sampling_rate",
+            "qfc_hot_key_window_start_timestamp_seconds",
+            "qfc_hot_key_estimated_reads",
+            "qfc_hot_key_estimated_writes",
+            "qfc_hot_key_top_estimated_count",
+            "qfc_hot_account_estimated_reads",
+            "qfc_hot_account_estimated_writes",
+            "qfc_hot_account_estimated_code_reads",
+            "qfc_hot_account_top_estimated_count",
+            "qfc_hot_code_top_estimated_count",
         ] {
             assert!(
                 out.contains(name),
@@ -1040,6 +1204,9 @@ mod tests {
         assert!(out.contains("qfc_ai_flops_metered_total{tenant_tier=\"1\"} 1000000000"));
         assert!(out.contains("qfc_ai_tenant_inflight{tenant_tier=\"1\"} 0"));
         assert!(out.contains("qfc_ai_cost_report_last_timestamp_seconds 1765000000"));
+        // T8: sampling enabled at 1-in-1; genesis writes populate the reports.
+        assert!(out.contains("qfc_hot_key_sampling_enabled 1"));
+        assert!(out.contains("qfc_hot_key_sampling_rate 1"));
         // Per-CF metrics carry a {cf="..."} label for every CF in cf::ALL.
         for cf_name in cf::ALL {
             assert!(
@@ -1054,7 +1221,7 @@ mod tests {
     /// `qfc_storage_statistics_enabled 0` gauge.
     #[test]
     fn render_metrics_degrades_without_statistics() {
-        let (server, _tmp) = test_server(false);
+        let (server, _tmp) = test_server(false, Some(1));
         let out = server.render_metrics();
 
         assert!(out.contains("qfc_storage_statistics_enabled 0"));
@@ -1083,6 +1250,30 @@ mod tests {
             assert!(
                 !out.contains(name),
                 "ticker metric `{name}` must not render without statistics"
+            );
+        }
+    }
+
+    /// T8: with sampling off, only the single `enabled 0` gauge renders; the
+    /// detail/skew metrics must be absent (no zero-valued noise, no panic
+    /// from the `None` reports).
+    #[test]
+    fn render_metrics_hot_keys_disabled() {
+        let (server, _tmp) = test_server(false, None);
+        let out = server.render_metrics();
+
+        assert!(out.contains("qfc_hot_key_sampling_enabled 0"));
+        for name in [
+            "qfc_hot_key_sampling_rate",
+            "qfc_hot_key_estimated_reads",
+            "qfc_hot_key_top_estimated_count",
+            "qfc_hot_account_estimated_reads",
+            "qfc_hot_account_top_estimated_count",
+            "qfc_hot_code_top_estimated_count",
+        ] {
+            assert!(
+                !out.contains(name),
+                "hot-key detail metric `{name}` must not render when sampling is off"
             );
         }
     }

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -203,6 +203,43 @@ Notes:
   engine-side p99 gauge. RocksDB's C API exposes histogram percentiles, not
   bucket boundaries, so a full Prometheus histogram is not derivable.
 
+## Metric inventory — hot-key / hot-account analytics (T8)
+
+Exported only when the node runs with `--hot-key-sampling <N>` (env
+`QFC_HOT_KEY_SAMPLING`; 1-in-N access sampling, N rounded up to a power of
+two). When sampling is off, the single gauge `qfc_hot_key_sampling_enabled 0`
+is emitted and nothing else — zero per-op cost in the hot path.
+
+**Cardinality:** the top-N hot *identities* (raw keys, account addresses, code
+hashes) are deliberately **not** Prometheus labels — the hot set churns
+window-to-window and would leak unbounded short-lived series (same reasoning
+as the T5 tier-only labels). What is exported is bounded and stable: per-CF
+traffic estimates (one series per column family) and per-CF / DB-wide **skew**
+gauges (the hottest entry's *count*, without its identity). The actual ranked
+identities live in `Database::hot_key_report` / `StateDB::hot_account_report`
+and in the findings: [docs/profiling/HOT-KEYS.md](../profiling/HOT-KEYS.md).
+
+| Metric | Type | Labels | Source |
+|---|---|---|---|
+| `qfc_hot_key_sampling_enabled` | gauge (0/1) | — | `--hot-key-sampling` flag (always emitted) |
+| `qfc_hot_key_sampling_rate` | gauge | — | effective 1-in-N rate (power of two) |
+| `qfc_hot_key_window_start_timestamp_seconds` | gauge | — | window open time (resets with `reset_hot_key_stats`) |
+| `qfc_hot_key_estimated_reads` | gauge | `cf` | per-CF sampled reads × rate |
+| `qfc_hot_key_estimated_writes` | gauge | `cf` | per-CF sampled writes × rate |
+| `qfc_hot_key_top_estimated_count` | gauge | `cf` | hottest key's estimated accesses in each CF (skew) |
+| `qfc_hot_account_estimated_reads` | gauge | — | sampled `get_account` × rate |
+| `qfc_hot_account_estimated_writes` | gauge | — | sampled `set_account` × rate |
+| `qfc_hot_account_estimated_code_reads` | gauge | — | sampled contract-code reads × rate |
+| `qfc_hot_account_top_estimated_count` | gauge | — | hottest account's estimated accesses (skew) |
+| `qfc_hot_code_top_estimated_count` | gauge | — | hottest bytecode's estimated reads (skew) |
+
+Accuracy caveat: per-CF key stats are complete (the storage sampler is shared
+across every `Database` clone). Per-account stats cover only the chain's
+persistent state handle (`chain.state()`); the sync path's transient
+`state_at` handles carry their own trackers and are not aggregated into the
+exporter. The estimates carry space-saving overestimation plus 1-in-N sampling
+noise (~`sqrt(N / true_count)` relative) — see HOT-KEYS.md for error bounds.
+
 ## Snapshot backups (T4.2) and the backup-freshness metrics
 
 Nodes started with `--snapshot-interval-secs <N>` (env

--- a/docs/profiling/HOT-KEYS.md
+++ b/docs/profiling/HOT-KEYS.md
@@ -179,9 +179,17 @@ stable keys (code, transactions, receipts) and for per-CF traffic *volume*.
 - Counts are estimates: ±`sqrt(64/T)` relative sampling noise plus the
   space-saving bound surfaced per entry as `max_overestimate`.
 
-## Follow-up (deferred)
+## Follow-up
 
-Exporter/RPC wiring (Prometheus surface for `hot_key_report` /
-`hot_account_report`, periodic windowing in the node) is deferred to the
-orchestrator — T2's exporter is the natural home; this item deliberately
-stops at the library + reports to keep the scope at qfc-storage/qfc-state.
+**Exporter wiring — done.** The Prometheus surface for `hot_key_report` /
+`hot_account_report` is now wired into the node's `/metrics` endpoint, gated
+on a new `--hot-key-sampling <N>` flag (env `QFC_HOT_KEY_SAMPLING`). To avoid
+leaking churning identities as labels, the exporter publishes bounded
+aggregates and skew gauges only (per-CF traffic estimates, hottest-entry
+counts); the ranked identities above stay in the report accessors. Full metric
+inventory: [docs/observability/README.md](../observability/README.md#metric-inventory--hot-key--hot-account-analytics-t8).
+
+Still open: a Grafana panel group for the hot-key metrics, an RPC method to
+fetch the full ranked `hot_key_report` on demand, and periodic window resets
+(the exporter reads a cumulative window; `reset_hot_key_stats` exists but no
+scheduler calls it yet).


### PR DESCRIPTION
Wires the T8 sampling machinery (PR #116) onto the node's Prometheus `/metrics` surface, and adds the CLI flag that was missing to turn it on.

## Why the flag
PR #116 added `StorageConfig::hot_key_sampling` and the report accessors, but `qfc-node` never set the knob — there was no way to enable sampling in a running node. This adds `--hot-key-sampling <N>` (env `QFC_HOT_KEY_SAMPLING`); unset/0 = disabled (zero per-op cost).

## What's exported
`render_hot_key_metrics` in `metrics.rs`, gated on sampling being on (off → only `qfc_hot_key_sampling_enabled 0`):

| Metric | Labels | Meaning |
|---|---|---|
| `qfc_hot_key_sampling_enabled` | — | 0/1, always emitted |
| `qfc_hot_key_sampling_rate` | — | effective 1-in-N |
| `qfc_hot_key_window_start_timestamp_seconds` | — | window open time |
| `qfc_hot_key_estimated_reads` / `_writes` | `cf` | per-CF traffic estimate |
| `qfc_hot_key_top_estimated_count` | `cf` | hottest key's count (skew) |
| `qfc_hot_account_estimated_reads` / `_writes` / `_code_reads` | — | DB-wide account traffic |
| `qfc_hot_account_top_estimated_count` / `qfc_hot_code_top_estimated_count` | — | hottest account / bytecode (skew) |

## Cardinality choice
Hot **identities** (raw keys, addresses, code hashes) are deliberately **not** labels — the hot set churns window-to-window and would leak unbounded short-lived series (same reasoning as T5's tier-only labels). The exporter publishes bounded aggregates + skew gauges; ranked identities stay in `Database::hot_key_report` / `StateDB::hot_account_report`.

The hot-account tracker is reached via the chain's persistent state handle (`chain.state()`), so no new plumbing in `main.rs` beyond the flag. Caveat (documented): per-CF key stats are complete; per-account stats cover only the persistent state handle, not the sync path's transient `state_at` handles.

## Tests / evidence
- Extended `render_metrics_includes_expected_metric_names` (11 new names + `enabled 1`/`rate 1` values, sampling seeded from genesis traffic).
- New `render_metrics_hot_keys_disabled` — off path emits only `qfc_hot_key_sampling_enabled 0`, no detail/skew metrics.
- qfc-node unit suite 18/18; `cargo fmt --all --check` clean; clippy clean on touched files.
- Live dev-node smoke: `--hot-key-sampling 8` → log `hot-key sampling: 1-in-8` → `/metrics` shows the full block (per-CF `state`/`metadata` estimates, account aggregates).

## Docs
`docs/observability/README.md` inventory section added; `docs/profiling/HOT-KEYS.md` "deferred" note updated to "done" with the remaining open items (Grafana panel, on-demand RPC, periodic window reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)