### PR TITLE
T8: periodic hot-key window-reset scheduler

### DIFF
--- a/crates/qfc-node/src/main.rs
+++ b/crates/qfc-node/src/main.rs
@@ -111,6 +111,14 @@ struct Args {
     #[arg(long, env = "QFC_HOT_KEY_SAMPLING")]
     hot_key_sampling: Option<u32>,
 
+    /// T8: hot-key sampling window in seconds. Every window the node logs a
+    /// ranked report (target `qfc::hot_keys`) and resets the sketches, so the
+    /// space-saving estimates stay accurate and the /metrics gauges read
+    /// per-window instead of cumulative-since-start. 0 = never reset
+    /// (cumulative). No effect without --hot-key-sampling.
+    #[arg(long, default_value_t = 0, env = "QFC_HOT_KEY_WINDOW_SECS")]
+    hot_key_window_secs: u64,
+
     /// IPFS Kubo API URL for large inference result storage (optional)
     #[arg(long, env = "QFC_IPFS_API_URL")]
     ipfs_api_url: Option<String>,
@@ -304,6 +312,10 @@ async fn main() -> Result<()> {
         args.ai_quotas.clone(),
         args.ai_cost_report_interval_secs,
     );
+
+    // T8: periodic hot-key/hot-account window reset (no-op unless sampling is
+    // on and a window is configured).
+    spawn_hot_key_window_task(db.clone(), chain.clone(), args.hot_key_window_secs);
 
     // v2.0 P2: Shared challenge generator, redundant verifier, task router
     let challenge_generator = Arc::new(RwLock::new(
@@ -681,4 +693,161 @@ fn spawn_ai_quota_task(
             }
         }
     });
+}
+
+/// T8: drive the hot-key/hot-account sampling window. Every
+/// `--hot-key-window-secs`, [`hot_key_window_tick`] logs a ranked report
+/// (target `qfc::hot_keys` — the permanent record of the hot *identities*
+/// that are deliberately kept out of the Prometheus labels) and resets both
+/// sketches, keeping the space-saving estimates accurate and making the
+/// `/metrics` gauges per-window instead of cumulative. No-op unless sampling
+/// is enabled and a window is configured.
+fn spawn_hot_key_window_task(db: Database, chain: Arc<Chain>, window_secs: u64) {
+    if window_secs == 0 || db.hot_key_sampling().is_none() {
+        return;
+    }
+    info!(
+        "Hot-key sampling window: {}s (reports logged to target qfc::hot_keys, then sketches reset)",
+        window_secs
+    );
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(window_secs));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // The first tick fires immediately; skip it so the first reset lands
+        // after a full window rather than at startup.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            hot_key_window_tick(&db, &chain);
+        }
+    });
+}
+
+/// Log the current hot-key/hot-account reports, then reset both windows.
+/// Split out from the spawn loop so it is directly unit-testable.
+fn hot_key_window_tick(db: &Database, chain: &Chain) {
+    const TOP_N: usize = 16;
+
+    if let Some(report) = db.hot_key_report(TOP_N) {
+        let busiest = report
+            .cfs
+            .iter()
+            .max_by_key(|c| c.estimated_reads + c.estimated_writes);
+        let hottest = report
+            .cfs
+            .iter()
+            .filter_map(|c| c.top_keys.first().map(|k| (c.cf.as_str(), k)))
+            .max_by_key(|(_, k)| k.estimated_count);
+        info!(
+            target: "qfc::hot_keys",
+            rate = report.sampling_rate,
+            cfs_active = report.cfs.len(),
+            busiest_cf = busiest.map(|c| c.cf.as_str()).unwrap_or("-"),
+            busiest_cf_reads = busiest.map(|c| c.estimated_reads).unwrap_or(0),
+            busiest_cf_writes = busiest.map(|c| c.estimated_writes).unwrap_or(0),
+            hottest_key_cf = hottest.map(|(cf, _)| cf).unwrap_or("-"),
+            hottest_key = hottest.map(|(_, k)| k.key_hex.as_str()).unwrap_or("-"),
+            hottest_key_count = hottest.map(|(_, k)| k.estimated_count).unwrap_or(0),
+            "hot-key window closed (storage)"
+        );
+        db.reset_hot_key_stats();
+    }
+
+    let state = chain.state();
+    if let Some(acct) = state.hot_account_report(TOP_N) {
+        let top_acct = acct.top_accounts.first();
+        let top_code = acct.top_code.first();
+        info!(
+            target: "qfc::hot_keys",
+            est_account_reads = acct.estimated_account_reads,
+            est_account_writes = acct.estimated_account_writes,
+            est_code_reads = acct.estimated_code_reads,
+            hottest_account = top_acct.map(|a| a.address.as_str()).unwrap_or("-"),
+            hottest_account_count = top_acct.map(|a| a.estimated_count).unwrap_or(0),
+            hottest_code = top_code.map(|c| c.code_hash.as_str()).unwrap_or("-"),
+            hottest_code_count = top_code.map(|c| c.estimated_count).unwrap_or(0),
+            "hot-key window closed (accounts)"
+        );
+        state.reset_hot_account_stats();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qfc_chain::{ChainConfig, GenesisConfig};
+    use qfc_consensus::{ConsensusConfig, ConsensusEngine};
+
+    fn total_traffic(db: &Database) -> u64 {
+        db.hot_key_report(16)
+            .map(|r| {
+                r.cfs
+                    .iter()
+                    .map(|c| c.estimated_reads + c.estimated_writes)
+                    .sum()
+            })
+            .unwrap_or(0)
+    }
+
+    /// A window tick logs and then resets both sketches: traffic accumulated
+    /// before the tick is gone after it, and the window keeps sampling.
+    #[test]
+    fn hot_key_window_tick_resets_sketches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(StorageConfig {
+            path: tmp.path().join("db"),
+            create_if_missing: true,
+            hot_key_sampling: Some(1),
+            ..Default::default()
+        })
+        .unwrap();
+        let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
+        let chain = Chain::new(
+            db.clone(),
+            ChainConfig {
+                chain_id: 9000,
+                genesis: GenesisConfig::dev(),
+            },
+            consensus,
+        )
+        .unwrap();
+
+        // Genesis init wrote to several CFs, so the window has traffic.
+        assert!(total_traffic(&db) > 0, "expected genesis sampling traffic");
+        let window_before = db.hot_key_report(16).unwrap().window_start_unix_ms;
+
+        hot_key_window_tick(&db, &chain);
+
+        // Reset: counts cleared, sampling still on, new window opened.
+        assert_eq!(total_traffic(&db), 0, "tick must reset the sketch");
+        assert!(db.hot_key_sampling().is_some(), "sampling stays enabled");
+        let window_after = db.hot_key_report(16).unwrap().window_start_unix_ms;
+        assert!(window_after >= window_before, "reset opens a fresh window");
+    }
+
+    /// With sampling off, a tick is a harmless no-op (reports are `None`).
+    #[test]
+    fn hot_key_window_tick_noop_when_sampling_off() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(StorageConfig {
+            path: tmp.path().join("db"),
+            create_if_missing: true,
+            ..Default::default()
+        })
+        .unwrap();
+        let consensus = Arc::new(ConsensusEngine::new(ConsensusConfig::default()));
+        let chain = Chain::new(
+            db.clone(),
+            ChainConfig {
+                chain_id: 9000,
+                genesis: GenesisConfig::dev(),
+            },
+            consensus,
+        )
+        .unwrap();
+
+        assert!(db.hot_key_sampling().is_none());
+        hot_key_window_tick(&db, &chain); // must not panic
+        assert!(db.hot_key_report(16).is_none());
+    }
 }

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -210,6 +210,12 @@ Exported only when the node runs with `--hot-key-sampling <N>` (env
 two). When sampling is off, the single gauge `qfc_hot_key_sampling_enabled 0`
 is emitted and nothing else — zero per-op cost in the hot path.
 
+Add `--hot-key-window-secs <N>` (env `QFC_HOT_KEY_WINDOW_SECS`, 0 = cumulative)
+to make sampling **windowed**: every N seconds the node logs a ranked report
+(`tracing` target `qfc::hot_keys`) and resets the sketches, so estimates stay
+accurate and these gauges read per-window (a sawtooth) rather than
+cumulative-since-start.
+
 **Cardinality:** the top-N hot *identities* (raw keys, account addresses, code
 hashes) are deliberately **not** Prometheus labels — the hot set churns
 window-to-window and would leak unbounded short-lived series (same reasoning

--- a/docs/observability/grafana-dashboard.json
+++ b/docs/observability/grafana-dashboard.json
@@ -18,7 +18,7 @@
   ],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 3,
+  "version": 4,
   "refresh": "15s",
   "time": {
     "from": "now-6h",
@@ -1205,7 +1205,7 @@
     {
       "type": "timeseries",
       "title": "Per-CF hottest-key skew (est. accesses to top key)",
-      "description": "Cumulative estimated accesses to the single hottest key in each CF since the sampling window opened (power-law hotspot indicator; identities deliberately not labelled). No periodic window-reset scheduler yet \u2014 see docs/profiling/HOT-KEYS.md.",
+      "description": "Cumulative estimated accesses to the single hottest key in each CF since the sampling window opened (power-law hotspot indicator; identities deliberately not labelled). With --hot-key-window-secs set, the gauge is per-window (sawtooth, reset each window); otherwise cumulative since start. See docs/profiling/HOT-KEYS.md.",
       "gridPos": {
         "h": 8,
         "w": 10,

--- a/docs/profiling/HOT-KEYS.md
+++ b/docs/profiling/HOT-KEYS.md
@@ -182,14 +182,26 @@ stable keys (code, transactions, receipts) and for per-CF traffic *volume*.
 ## Follow-up
 
 **Exporter wiring — done.** The Prometheus surface for `hot_key_report` /
-`hot_account_report` is now wired into the node's `/metrics` endpoint, gated
-on a new `--hot-key-sampling <N>` flag (env `QFC_HOT_KEY_SAMPLING`). To avoid
-leaking churning identities as labels, the exporter publishes bounded
-aggregates and skew gauges only (per-CF traffic estimates, hottest-entry
-counts); the ranked identities above stay in the report accessors. Full metric
-inventory: [docs/observability/README.md](../observability/README.md#metric-inventory--hot-key--hot-account-analytics-t8).
+`hot_account_report` is wired into the node's `/metrics` endpoint, gated on
+`--hot-key-sampling <N>` (env `QFC_HOT_KEY_SAMPLING`). To avoid leaking
+churning identities as labels, the exporter publishes bounded aggregates and
+skew gauges only (per-CF traffic estimates, hottest-entry counts); the ranked
+identities above stay in the report accessors. Full metric inventory:
+[docs/observability/README.md](../observability/README.md#metric-inventory--hot-key--hot-account-analytics-t8).
 
-Still open: a Grafana panel group for the hot-key metrics, an RPC method to
-fetch the full ranked `hot_key_report` on demand, and periodic window resets
-(the exporter reads a cumulative window; `reset_hot_key_stats` exists but no
-scheduler calls it yet).
+**Grafana panel — done.** The *Hot keys & accounts (T8)* dashboard row plots
+sampling status, per-CF access rate (`deriv()` of the window gauges), and the
+per-CF / account / bytecode skew gauges.
+
+**Window reset scheduler — done.** `--hot-key-window-secs <N>` (env
+`QFC_HOT_KEY_WINDOW_SECS`, 0 = cumulative) makes sampling *windowed*: every N
+seconds the node logs a ranked report (`tracing` target `qfc::hot_keys` — the
+permanent record of the hot identities kept out of Prometheus) and then resets
+both sketches. This keeps the space-saving estimates accurate (the `state`-CF
+saturation noted above is bounded to one window) and makes the `/metrics`
+gauges read per-window. With a window set the gauges are a sawtooth; the
+dashboard's traffic panels already apply `deriv()`, so they read correctly
+either way.
+
+Still open: an RPC method to fetch the full ranked `hot_key_report` on demand
+(the windowed `qfc::hot_keys` log is the current record of ranked identities).


### PR DESCRIPTION
Adds the windowing scheduler — the last code item from the #117 follow-up list.

## What
`--hot-key-window-secs <N>` (env `QFC_HOT_KEY_WINDOW_SECS`, default 0 = cumulative). When set together with `--hot-key-sampling`, a background tokio task every N seconds:
1. logs a ranked report to `tracing` target `qfc::hot_keys` (busiest CF, hottest key/account/bytecode + estimated counts) — the permanent record of the hot **identities** that are deliberately kept out of Prometheus labels, and
2. resets both the storage (`Database::reset_hot_key_stats`) and account (`StateDB::reset_hot_account_stats`) sketches.

## Why
Two problems with cumulative-since-start sampling, both called out in `docs/profiling/HOT-KEYS.md`:
- the space-saving sketches **saturate** over time (the `state` CF hit ~99.5% overestimate in the findings run);
- the `/metrics` gauges grew without bound, which is why the #118 Grafana panels had to wrap them in `deriv()`.

Windowing fixes both: estimates stay accurate (error bounded to one window) and the gauges read per-window. With a window set they become a sawtooth; the dashboard's traffic panels already use `deriv()`, so they read correctly either way.

## Implementation
- `spawn_hot_key_window_task` — interval task; skips the immediate first tick so the first reset lands after a full window; no-op unless sampling is on and window > 0.
- `hot_key_window_tick` — split out from the loop for unit testing.
- Reaches the account tracker via the chain's persistent `chain.state()` handle; no other wiring.

## Tests / evidence
- `hot_key_window_tick_resets_sketches` (genesis traffic present before the tick, zero after, sampling stays enabled, window advances) and `hot_key_window_tick_noop_when_sampling_off`. qfc-node unit suite **20/20**; `cargo fmt --all --check` clean; clippy clean on changed code; dashboard JSON validates.
- Live dev-node smoke (`--hot-key-sampling 8 --hot-key-window-secs 5`):
  ```
  Hot-key sampling window: 5s (...)
  qfc::hot_keys: hot-key window closed (storage) rate=8 cfs_active=3 busiest_cf="state" busiest_cf_writes=48 hottest_key_cf="block_hash_index" hottest_key=0x3a1b… hottest_key_count=8
  qfc::hot_keys: hot-key window closed (accounts) est_account_reads=40 hottest_account=0x…0003 hottest_account_count=8
  ```
  next window samples independently after the reset; `/metrics` reads per-window.

## Docs
`HOT-KEYS.md` follow-up updated (scheduler done — only the on-demand RPC remains), `observability/README.md` window note added, stale dashboard panel description refreshed (version 3→4).

Remaining T8 open item after this: an RPC method to fetch the full ranked `hot_key_report` on demand (the `qfc::hot_keys` log is the current record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)