### PR TITLE
AI-V3 Feature A (A5): deterministic chain settlement — commitments, rewards, slashing

### DIFF
--- a/crates/qfc-ai-coordinator/Cargo.toml
+++ b/crates/qfc-ai-coordinator/Cargo.toml
@@ -12,6 +12,8 @@ qfc-types.workspace = true
 qfc-crypto.workspace = true
 qfc-inference.workspace = true
 qfc-ps.workspace = true
+qfc-storage.workspace = true
+blake3.workspace = true
 borsh.workspace = true
 hex.workspace = true
 serde.workspace = true
@@ -26,6 +28,7 @@ rand.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 parking_lot.workspace = true
 criterion.workspace = true
+tempfile.workspace = true
 
 [[bench]]
 name = "verification_bench"

--- a/crates/qfc-ai-coordinator/src/chain_store.rs
+++ b/crates/qfc-ai-coordinator/src/chain_store.rs
@@ -1,0 +1,218 @@
+//! Commitment persistence for training-epoch settlements (ROADMAP-AI-V3
+//! milestone A5; design in `docs/adr/0009-chain-integration.md`, Decision 5).
+//!
+//! [`TrainingChainStore`] is a thin append-only wrapper over a `qfc-storage`
+//! [`Database`]. Each closed epoch's [`TrainingEpochCommit`] is stored in the
+//! dedicated `TRAINING_COMMITMENTS` column family, keyed `job_id ‖ epoch(BE)`
+//! and Borsh-encoded. The BE epoch suffix makes a job's commits scan in epoch
+//! order, and the 32-byte job_id prefix isolates jobs.
+//!
+//! # `create_missing_column_families`: VERIFIED SAFE
+//!
+//! `qfc-storage`'s `Database::open` sets `create_missing_column_families(true)`
+//! (db.rs), so adding `TRAINING_COMMITMENTS` to `cf::ALL` does NOT break
+//! opening existing on-disk databases — RocksDB creates the missing CF on the
+//! next open. No migration is required (ADR-0009 Decision 5 risk: cleared).
+//!
+//! # Deferred to A6 / node integration (ADR-0009 Decision 6)
+//!
+//! Persistence stores the commitment only; it does NOT apply any state. Each
+//! is grep-able as `A6`:
+//!
+//! - **A6: state mutation at the epoch boundary** — crediting the settlement's
+//!   rewards to balances and applying its slashes to stake. This store is the
+//!   audit anchor, not the applier.
+//! - **A6: P2P broadcast** of stored commitments to peers.
+//! - **A6: N-of-M operator agreement** selecting the canonical commitment
+//!   before it is persisted (this store persists whatever it is given).
+
+use borsh::BorshDeserialize;
+use qfc_storage::{cf, Database, StorageConfig, WriteBatch};
+use qfc_types::Hash;
+
+use crate::settlement::{SettlementError, TrainingEpochCommit};
+
+/// Append-only persistence for [`TrainingEpochCommit`]s (ADR-0009 Decision 5).
+pub struct TrainingChainStore {
+    db: Database,
+}
+
+impl TrainingChainStore {
+    /// Open (or create) a commitment store at `path`. The
+    /// `TRAINING_COMMITMENTS` CF is created on open if missing (see module
+    /// docs — `create_missing_column_families` is set).
+    pub fn open(path: impl Into<std::path::PathBuf>) -> Result<Self, SettlementError> {
+        let config = StorageConfig {
+            path: path.into(),
+            create_if_missing: true,
+            ..Default::default()
+        };
+        let db = Database::open(config).map_err(|e| SettlementError::Storage(e.to_string()))?;
+        Ok(Self { db })
+    }
+
+    /// Open a temporary in-memory-ish store backed by a temp directory removed
+    /// on drop — for tests.
+    pub fn open_temp() -> Result<Self, SettlementError> {
+        let db = Database::open_temp().map_err(|e| SettlementError::Storage(e.to_string()))?;
+        Ok(Self { db })
+    }
+
+    /// Key = `job_id (32) ‖ epoch (u64 BE)`.
+    fn key(job_id: &Hash, epoch: u64) -> Vec<u8> {
+        let mut k = Vec::with_capacity(40);
+        k.extend_from_slice(job_id.as_bytes());
+        k.extend_from_slice(&epoch.to_be_bytes());
+        k
+    }
+
+    /// Persist a commitment (append-only; re-putting the same (job, epoch)
+    /// overwrites with identical data on an honest path).
+    pub fn put_commit(&self, commit: &TrainingEpochCommit) -> Result<(), SettlementError> {
+        let key = Self::key(&commit.job_id, commit.epoch);
+        let value = borsh::to_vec(commit).map_err(|e| SettlementError::Storage(e.to_string()))?;
+        let mut batch = WriteBatch::new();
+        batch.put(cf::TRAINING_COMMITMENTS, key, value);
+        self.db
+            .write_batch(batch)
+            .map_err(|e| SettlementError::Storage(e.to_string()))
+    }
+
+    /// Fetch one commitment by `(job_id, epoch)`, or `None` if absent.
+    pub fn get_commit(
+        &self,
+        job_id: &Hash,
+        epoch: u64,
+    ) -> Result<Option<TrainingEpochCommit>, SettlementError> {
+        let key = Self::key(job_id, epoch);
+        match self
+            .db
+            .get(cf::TRAINING_COMMITMENTS, &key)
+            .map_err(|e| SettlementError::Storage(e.to_string()))?
+        {
+            Some(bytes) => {
+                let commit = TrainingEpochCommit::try_from_slice(&bytes)
+                    .map_err(|e| SettlementError::Storage(e.to_string()))?;
+                Ok(Some(commit))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// All commitments for one job, in epoch order. Range-scans from the
+    /// job_id prefix and stops at the first key with a different prefix.
+    pub fn commits_for_job(
+        &self,
+        job_id: &Hash,
+    ) -> Result<Vec<TrainingEpochCommit>, SettlementError> {
+        let prefix = job_id.as_bytes();
+        // Start the scan at job_id ‖ 0; the BE epoch suffix keeps keys for
+        // this job contiguous and epoch-ordered.
+        let start = Self::key(job_id, 0);
+        let mut out = Vec::new();
+        let iter = self
+            .db
+            .try_iter_from(cf::TRAINING_COMMITMENTS, &start)
+            .map_err(|e| SettlementError::Storage(e.to_string()))?;
+        for item in iter {
+            let (key, value) = item.map_err(|e| SettlementError::Storage(e.to_string()))?;
+            // Stop once we leave this job's prefix.
+            if key.len() < 32 || &key[..32] != prefix {
+                break;
+            }
+            let commit = TrainingEpochCommit::try_from_slice(&value)
+                .map_err(|e| SettlementError::Storage(e.to_string()))?;
+            out.push(commit);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(b: u8) -> Hash {
+        Hash::new([b; 32])
+    }
+
+    fn commit(job: u8, epoch: u64) -> TrainingEpochCommit {
+        TrainingEpochCommit {
+            job_id: hash(job),
+            epoch,
+            params_hash: hash(0x55),
+            records_root: qfc_crypto::blake3_hash(&[job, epoch as u8]),
+            accepted_count: epoch + 1,
+            total_flops_accepted: (epoch + 1) * 1000,
+        }
+    }
+
+    #[test]
+    fn test_put_get_round_trip() {
+        let store = TrainingChainStore::open_temp().unwrap();
+        let c = commit(1, 0);
+        store.put_commit(&c).unwrap();
+        let got = store.get_commit(&hash(1), 0).unwrap().unwrap();
+        assert_eq!(got, c);
+    }
+
+    #[test]
+    fn test_get_missing_is_none() {
+        let store = TrainingChainStore::open_temp().unwrap();
+        assert!(store.get_commit(&hash(1), 0).unwrap().is_none());
+        // Put one epoch, query a different one.
+        store.put_commit(&commit(1, 0)).unwrap();
+        assert!(store.get_commit(&hash(1), 1).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_commits_for_job_sorted_by_epoch() {
+        let store = TrainingChainStore::open_temp().unwrap();
+        // Insert out of order; expect epoch-sorted output.
+        for e in [2u64, 0, 1] {
+            store.put_commit(&commit(1, e)).unwrap();
+        }
+        let commits = store.commits_for_job(&hash(1)).unwrap();
+        let epochs: Vec<u64> = commits.iter().map(|c| c.epoch).collect();
+        assert_eq!(epochs, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_multi_job_isolation() {
+        let store = TrainingChainStore::open_temp().unwrap();
+        store.put_commit(&commit(1, 0)).unwrap();
+        store.put_commit(&commit(1, 1)).unwrap();
+        store.put_commit(&commit(2, 0)).unwrap();
+        store.put_commit(&commit(2, 1)).unwrap();
+        store.put_commit(&commit(2, 2)).unwrap();
+
+        let job1 = store.commits_for_job(&hash(1)).unwrap();
+        assert_eq!(job1.len(), 2);
+        assert!(job1.iter().all(|c| c.job_id == hash(1)));
+
+        let job2 = store.commits_for_job(&hash(2)).unwrap();
+        assert_eq!(job2.len(), 3);
+        assert!(job2.iter().all(|c| c.job_id == hash(2)));
+
+        // A job with no commits.
+        assert!(store.commits_for_job(&hash(9)).unwrap().is_empty());
+    }
+
+    /// Reopen persistence: write, drop, reopen at the same path, read back.
+    /// Exercises that adding the CF to `cf::ALL` does NOT break reopening an
+    /// existing DB (create_missing_column_families is set — see module docs).
+    #[test]
+    fn test_reopen_persistence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let c = commit(3, 4);
+        {
+            let store = TrainingChainStore::open(&path).unwrap();
+            store.put_commit(&c).unwrap();
+            store.db.flush().unwrap();
+        } // store dropped, DB closed
+        let store = TrainingChainStore::open(&path).unwrap();
+        let got = store.get_commit(&hash(3), 4).unwrap().unwrap();
+        assert_eq!(got, c);
+    }
+}

--- a/crates/qfc-ai-coordinator/src/lib.rs
+++ b/crates/qfc-ai-coordinator/src/lib.rs
@@ -11,6 +11,7 @@
 //! - **Registry**: Governance-approved model list
 
 pub mod assignment;
+pub mod chain_store;
 pub mod challenge;
 pub mod cost;
 pub mod governance;
@@ -21,6 +22,7 @@ pub mod quota;
 pub mod redundant;
 pub mod registry;
 pub mod router;
+pub mod settlement;
 pub mod task_pool;
 pub mod task_types;
 pub mod training;
@@ -29,6 +31,7 @@ pub mod treasury;
 pub mod verification;
 
 pub use assignment::{MinerCapability, MinerRegistry};
+pub use chain_store::TrainingChainStore;
 pub use challenge::{
     ArbitrationManager, ArbitrationOutcome, ArbitrationPanel, ArbitrationVote, ChallengeGenerator,
     ChallengePenalty, ChallengeVerdict,
@@ -40,6 +43,10 @@ pub use param_governance::{
 };
 pub use proof_pool::ProofPool;
 pub use quota::{QuotaConfig, QuotaConfigError, QuotaError, TierQuota};
+pub use settlement::{
+    penalty_to_slash, records_root, settle_epoch, EpochSettlement, RewardCredit, SettlementError,
+    TrainingEpochCommit,
+};
 pub use task_pool::{AiQuotaMetrics, PublicTaskFilter, TaskPool};
 pub use task_types::estimate_base_fee;
 pub use training::{

--- a/crates/qfc-ai-coordinator/src/settlement.rs
+++ b/crates/qfc-ai-coordinator/src/settlement.rs
@@ -1,0 +1,907 @@
+//! Pure, deterministic epoch settlement (ROADMAP-AI-V3 milestone A5; design
+//! in `docs/adr/0009-chain-integration.md`, Decisions 1-4).
+//!
+//! [`settle_epoch`] is a **pure function** of one closed training epoch's
+//! result: it computes *what* changes on-chain — a version commitment
+//! ([`TrainingEpochCommit`]), pro-rata contribution rewards
+//! ([`RewardCredit`]), and slashes ([`SlashResult`], offense
+//! `InvalidTraining`) — but never *applies* them. Purity is the
+//! cross-operator-agreement primitive (ADR-0009 Decision 1): two operators
+//! that received the same accepted-update set produce a byte-identical
+//! [`EpochSettlement`] (and therefore the same `commit_hash()`), regardless of
+//! the order in which records or penalties arrive.
+//!
+//! # Deferred to A6 / node integration (ADR-0009 Decision 6)
+//!
+//! These are NOT done here; each is grep-able as `A6`:
+//!
+//! - **A6: state mutation at the epoch boundary** — actually crediting
+//!   [`RewardCredit`] amounts to balances and applying [`SlashResult`] to
+//!   validator/worker stake. Settlement produces the deltas; the node applies
+//!   them against its State, validator set, and clock.
+//! - **A6: absolute-amount slash entry point** in consensus. The existing
+//!   `consensus::slash_validator(percent, jail_ms)` is percent-of-stake;
+//!   training slashing is an absolute amount in
+//!   [`SlashResult::slashed_amount`] (ADR-0009 Decision 4). Capping the slash
+//!   at the worker's locked training stake also happens at application time
+//!   (settlement has no stake view).
+//! - **A6: P2P broadcast** of commitments and slashing evidence.
+//! - **A6: N-of-M operator agreement** that selects the canonical
+//!   `EpochOutcome` — settlement gives the deterministic-equality primitive
+//!   only, not the voting that picks the winner. Note the agreement boundary:
+//!   `commit_hash()` equality across operators certifies agreement on the
+//!   COMMITMENT only (`params_hash` + `records_root` + counts) — it does NOT
+//!   certify `rewards`/`slashes` agreement, since those depend on each
+//!   operator's observed penalty set and are not inputs to `commit_hash`. A6's
+//!   N-of-M must therefore agree on the outcome AND the penalty set before
+//!   applying any reward/slash.
+//! - **A6: VRF sampling entropy**, **A6: per-job stake-locking enforcement**,
+//!   and **A6: signed `ParamUpdate`** are likewise out of scope.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use qfc_ps::{AcceptanceRecord, EpochOutcome, PsConfig};
+use qfc_types::{Address, Hash, SlashResult, SlashableOffense, U256};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::training::TrainingJobSpec;
+use crate::training_verification::TrainingPenalty;
+
+/// Errors from epoch settlement. Settlement only fails on inconsistent
+/// inputs — a well-formed epoch result always settles.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SettlementError {
+    /// An accepted record names an epoch other than the outcome's epoch.
+    #[error("accepted record for worker {worker} has epoch {record_epoch}, expected {epoch}")]
+    RecordEpochMismatch {
+        worker: Address,
+        record_epoch: u64,
+        epoch: u64,
+    },
+
+    /// A penalty names an epoch other than the outcome's epoch.
+    #[error("penalty for worker {worker} has epoch {penalty_epoch}, expected {epoch}")]
+    PenaltyEpochMismatch {
+        worker: Address,
+        penalty_epoch: u64,
+        epoch: u64,
+    },
+
+    /// A penalty names a job other than the spec's job.
+    #[error("penalty for worker {worker} has job {penalty_job}, expected {job_id}")]
+    PenaltyJobMismatch {
+        worker: Address,
+        penalty_job: Hash,
+        job_id: Hash,
+    },
+
+    /// Commitment persistence failed (used by [`crate::chain_store`]).
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+/// The on-chain version-commitment anchor for one closed training epoch
+/// (ADR-0009 Decision 2). The full `Vec<AcceptanceRecord>` stays off-chain;
+/// only [`Self::records_root`] is committed, so any party holding the records
+/// can recompute and verify the root, and two operators with the same set get
+/// the same root.
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct TrainingEpochCommit {
+    /// Job this epoch belongs to.
+    pub job_id: Hash,
+    /// The closed epoch.
+    pub epoch: u64,
+    /// New model version: `EpochOutcome::params_hash` (duplicated here so the
+    /// commit is self-contained — ADR-0009 D2).
+    pub params_hash: Hash,
+    /// blake3 over the canonically-sorted ACCEPTED records (the full accepted
+    /// set; voiding is a payout concept and does not change the record set —
+    /// see [`settle_epoch`]). Computed by [`records_root`].
+    pub records_root: Hash,
+    /// Number of accepted records this epoch (the full accepted set).
+    pub accepted_count: u64,
+    /// Sum of `flops_estimated` over ALL accepted records (including any
+    /// later voided for payout — the commitment records what was accepted).
+    pub total_flops_accepted: u64,
+}
+
+impl TrainingEpochCommit {
+    /// blake3 over a canonical byte encoding of every field (big-endian
+    /// integers). Two operators with identical fields produce the same hash —
+    /// the cross-operator equality primitive (ADR-0009 Decision 1).
+    pub fn commit_hash(&self) -> Hash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.job_id.as_bytes());
+        hasher.update(&self.epoch.to_be_bytes());
+        hasher.update(self.params_hash.as_bytes());
+        hasher.update(self.records_root.as_bytes());
+        hasher.update(&self.accepted_count.to_be_bytes());
+        hasher.update(&self.total_flops_accepted.to_be_bytes());
+        Hash::new(*hasher.finalize().as_bytes())
+    }
+}
+
+/// A pro-rata reward to credit to one worker (ADR-0009 Decision 3). Settlement
+/// produces these; the node credits balances at the epoch boundary (A6).
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RewardCredit {
+    /// Worker to credit.
+    pub worker: Address,
+    /// Amount in wei.
+    pub amount: u128,
+}
+
+/// The complete deterministic output of settling one epoch (ADR-0009
+/// Decision 1).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EpochSettlement {
+    /// The on-chain version-commitment anchor.
+    pub commit: TrainingEpochCommit,
+    /// Pro-rata rewards, one per non-voided worker, sorted by worker bytes.
+    pub rewards: Vec<RewardCredit>,
+    /// Slashes, one per penalty, sorted by worker bytes (offense
+    /// `InvalidTraining`).
+    pub slashes: Vec<SlashResult>,
+    /// Wei reserved off the top of the gross `reward_pool` to pay verification
+    /// work (ADR-0008: verification is metered work "paid from the epoch reward
+    /// pool"). Computed as `reward_pool × p` (p = `spot_check_rate` in basis
+    /// points) and carved out BEFORE workers are pro-rated, so workers split
+    /// only the remainder (`reward_pool − verifier_reserve_wei`). A6 pays
+    /// verifiers from this reserve.
+    pub verifier_reserve_wei: u128,
+    /// FLOPs reserved for verification work (ADR-0008: `p × accepted FLOPs`).
+    /// Informational for A6 (the work budget); the actual pay is
+    /// [`Self::verifier_reserve_wei`].
+    pub verifier_budget_flops: u64,
+}
+
+/// Canonical blake3 root over an acceptance-record set (ADR-0009 Decision 2).
+///
+/// Records are sorted by `(worker bytes, epoch, clock, range.start, range.end,
+/// update_hash bytes)`, then each record's canonical bytes
+/// (`worker ‖ epoch BE ‖ clock BE ‖ range.start BE ‖ range.end BE ‖
+/// update_hash ‖ flops BE`) are streamed into one hasher. The result is
+/// order-independent: any permutation of the same set yields the same root.
+/// An empty set yields the well-defined hash of empty input.
+pub fn records_root(records: &[AcceptanceRecord]) -> Hash {
+    let mut sorted: Vec<&AcceptanceRecord> = records.iter().collect();
+    sorted.sort_by(|a, b| {
+        a.worker
+            .as_bytes()
+            .cmp(b.worker.as_bytes())
+            .then(a.epoch.cmp(&b.epoch))
+            .then(a.clock.cmp(&b.clock))
+            .then(a.range.start.cmp(&b.range.start))
+            .then(a.range.end.cmp(&b.range.end))
+            .then(a.update_hash.as_bytes().cmp(b.update_hash.as_bytes()))
+    });
+    let mut hasher = blake3::Hasher::new();
+    for r in sorted {
+        hasher.update(r.worker.as_bytes());
+        hasher.update(&r.epoch.to_be_bytes());
+        hasher.update(&r.clock.to_be_bytes());
+        hasher.update(&r.range.start.to_be_bytes());
+        hasher.update(&r.range.end.to_be_bytes());
+        hasher.update(r.update_hash.as_bytes());
+        hasher.update(&r.flops_estimated.to_be_bytes());
+    }
+    Hash::new(*hasher.finalize().as_bytes())
+}
+
+/// Convert a [`TrainingPenalty`] into a [`SlashResult`] (ADR-0009 Decision 4).
+///
+/// The slash is an ABSOLUTE amount (`penalty.slash_amount`, =
+/// `slash_multiple × per_step_reward` per ADR-0008), carried in
+/// [`SlashResult::slashed_amount`] — NOT a percent of stake. Jail until
+/// `now_ms + penalty.jail_duration_ms` (saturating).
+///
+/// A6: applying this against the worker's locked training stake (and capping
+/// at it) is node work — settlement has no stake view.
+pub fn penalty_to_slash(penalty: &TrainingPenalty, now_ms: u64) -> SlashResult {
+    SlashResult {
+        validator: penalty.worker,
+        offense: SlashableOffense::InvalidTraining,
+        slashed_amount: U256::from_u128(penalty.slash_amount),
+        jail_until: now_ms.saturating_add(penalty.jail_duration_ms),
+    }
+}
+
+/// Settle one closed training epoch into an [`EpochSettlement`] (ADR-0009
+/// Decisions 1-4). Pure and deterministic: identical inputs in ANY order of
+/// `outcome.accepted` / `penalties` yield a byte-identical result.
+///
+/// # Validation
+///
+/// - Every record in `outcome.accepted` must have `epoch == outcome.epoch`.
+/// - Every penalty must have `epoch == outcome.epoch` and
+///   `job_id == spec.job_id`.
+/// - A penalty naming a worker that is not among the accepted set is still
+///   slashed (it just earns no reward to begin with).
+///
+/// # Pool split (ADR-0008 + Decision 3)
+///
+/// `reward_pool` is the GROSS epoch pool. Settlement first reserves
+/// `verifier_reserve_wei = reward_pool × p` off the top (p = `spot_check_rate`
+/// in basis points; ADR-0008: verification is metered work paid from the same
+/// pool), then distributes the remainder `worker_pool = reward_pool −
+/// verifier_reserve_wei` to workers. A6 pays verifiers from the reserve.
+///
+/// # Rewards (Decision 3)
+///
+/// Penalized workers with `void_epoch_records == true` have ALL their records
+/// excluded from the reward computation (ADR-0004 retroactive voiding). The
+/// remaining records' `flops_estimated` are summed per worker; each
+/// non-voided worker's reward is `worker_pool × worker_flops / total_flops`
+/// (computed through a U256 intermediate so the product never overflows u128;
+/// integer division — the rounding remainder is carried forward, left in the
+/// pool, ADR-0009 D3). Zero-amount credits are omitted; rewards are sorted by
+/// worker bytes.
+///
+/// # Commitment (Decision 2)
+///
+/// `accepted_count`, `total_flops_accepted` and `records_root` cover the FULL
+/// accepted set, INCLUDING voided records: the commitment records what was
+/// *accepted* during the epoch; voiding only affects payout (ADR-0004 voids
+/// records "for that epoch" with respect to reward distribution). This keeps
+/// the commitment a faithful, operator-agreeable account of the epoch's work,
+/// independent of which penalties a given operator has observed at commit
+/// time.
+///
+/// # Verifier budget (ADR-0008)
+///
+/// `verifier_budget_flops = round_down(total_flops_accepted × p)` (p =
+/// `spot_check_rate` in basis points) — the metered verification WORK budget,
+/// informational for A6. The verification PAY is [`EpochSettlement::verifier_reserve_wei`].
+pub fn settle_epoch(
+    outcome: &EpochOutcome,
+    spec: &TrainingJobSpec,
+    penalties: &[TrainingPenalty],
+    reward_pool: u128,
+    config: &PsConfig,
+    now_ms: u64,
+) -> Result<EpochSettlement, SettlementError> {
+    // --- Validation ---
+    for record in &outcome.accepted {
+        if record.epoch != outcome.epoch {
+            return Err(SettlementError::RecordEpochMismatch {
+                worker: record.worker,
+                record_epoch: record.epoch,
+                epoch: outcome.epoch,
+            });
+        }
+    }
+    for penalty in penalties {
+        if penalty.epoch != outcome.epoch {
+            return Err(SettlementError::PenaltyEpochMismatch {
+                worker: penalty.worker,
+                penalty_epoch: penalty.epoch,
+                epoch: outcome.epoch,
+            });
+        }
+        if penalty.job_id != spec.job_id {
+            return Err(SettlementError::PenaltyJobMismatch {
+                worker: penalty.worker,
+                penalty_job: penalty.job_id,
+                job_id: spec.job_id,
+            });
+        }
+    }
+
+    // --- Void set (ADR-0004): workers whose records are excluded from payout ---
+    // Keyed by raw address bytes since `Address` is not `Ord`.
+    let voided: BTreeSet<[u8; 20]> = penalties
+        .iter()
+        .filter(|p| p.void_epoch_records)
+        .map(|p| *p.worker.as_bytes())
+        .collect();
+
+    // --- Commitment covers the FULL accepted set (voiding is payout-only) ---
+    let records_root = records_root(&outcome.accepted);
+    let accepted_count = outcome.accepted.len() as u64;
+    let total_flops_accepted: u64 = outcome
+        .accepted
+        .iter()
+        .fold(0u64, |acc, r| acc.saturating_add(r.flops_estimated));
+
+    let commit = TrainingEpochCommit {
+        job_id: spec.job_id,
+        epoch: outcome.epoch,
+        params_hash: outcome.params_hash,
+        records_root,
+        accepted_count,
+        total_flops_accepted,
+    };
+
+    // --- Verifier reserve (ADR-0008): carve p × pool off the GROSS pool ---
+    // Convert spot_check_rate (f64, e.g. 0.05) to deterministic integer basis
+    // points ONCE. This is the ONLY f64->int step in settlement; for a fixed
+    // config value it is deterministic (same input -> same bps on every
+    // operator). Clamp to a valid probability in [0, 10_000] bps.
+    let p_bps: u128 = {
+        let raw = (config.spot_check_rate * 10_000.0).round();
+        raw.clamp(0.0, 10_000.0) as u128
+    };
+    // verifier_reserve_wei = reward_pool × p_bps / 10_000, via U256 so the
+    // product never overflows u128. The quotient <= reward_pool <= u128::MAX,
+    // so the narrowing back to u128 is always exact.
+    let verifier_reserve_wei: u128 = (U256::from_u128(reward_pool) * U256::from_u128(p_bps)
+        / U256::from_u128(10_000))
+    .low_u128();
+    // worker_pool is the remainder distributed to workers (reserve <= pool, so
+    // this never underflows).
+    let worker_pool: u128 = reward_pool - verifier_reserve_wei;
+
+    // --- Rewards: pro-rata over non-voided FLOPs (ADR-0009 D3) ---
+    // Aggregate per-worker flops (one credit per worker, not per record).
+    // Keyed by raw address bytes (`Address` is not `Ord`); the BTreeMap keeps
+    // iteration sorted by worker bytes deterministically.
+    let mut worker_flops: BTreeMap<[u8; 20], u128> = BTreeMap::new();
+    let mut total_flops: u128 = 0;
+    for record in &outcome.accepted {
+        let bytes = *record.worker.as_bytes();
+        if voided.contains(&bytes) {
+            continue;
+        }
+        let f = u128::from(record.flops_estimated);
+        *worker_flops.entry(bytes).or_insert(0) += f;
+        total_flops += f;
+    }
+
+    let mut rewards: Vec<RewardCredit> = Vec::new();
+    for (worker_bytes, flops) in &worker_flops {
+        // amount = worker_pool × flops / total_flops (remainder carried forward
+        // / left in pool per ADR-0009 D3). Computed through a U256 intermediate
+        // so `worker_pool × flops` never overflows u128 (realistic pools ~2^90
+        // × epoch flops ~2^50 exceed u128). `total_flops` is a sum of the same
+        // non-voided records' flops, so it is >= every `flops` here and
+        // strictly positive whenever the map is non-empty — `checked_div`
+        // makes the no-division-by-zero contract explicit (the all-zero-flops
+        // edge yields total_flops == 0 -> 0). The quotient is bounded by
+        // worker_pool <= u128::MAX, so `low_u128()` is an exact narrowing.
+        let amount: u128 = if total_flops == 0 {
+            0
+        } else {
+            let scaled = U256::from_u128(worker_pool) * U256::from_u128(*flops);
+            let quotient = scaled
+                .checked_div(U256::from_u128(total_flops))
+                .expect("total_flops != 0 checked above");
+            debug_assert!(
+                quotient <= U256::from_u128(worker_pool),
+                "pro-rata share must not exceed the worker pool"
+            );
+            quotient.low_u128()
+        };
+        if amount > 0 {
+            rewards.push(RewardCredit {
+                worker: Address::new(*worker_bytes),
+                amount,
+            });
+        }
+    }
+    // worker_flops is a BTreeMap keyed by address bytes, so `rewards` is
+    // already sorted by worker bytes; this keeps the guarantee local.
+
+    // --- Slashes (ADR-0009 D4) ---
+    // Sort by a TOTAL order over the slash content, not by validator bytes
+    // alone: a single worker can incur multiple penalties in one epoch (one
+    // per failed step), and a validator-only key is a partial order whose
+    // stable-sort tie-break would leak the input order — breaking
+    // cross-operator determinism (Decision 1). Tie-break on slashed_amount
+    // then jail_until so equal-worker slashes have a deterministic order
+    // regardless of how penalties were observed.
+    let mut slashes: Vec<SlashResult> = penalties
+        .iter()
+        .map(|p| penalty_to_slash(p, now_ms))
+        .collect();
+    slashes.sort_by(|a, b| {
+        a.validator
+            .as_bytes()
+            .cmp(b.validator.as_bytes())
+            .then(a.slashed_amount.cmp(&b.slashed_amount))
+            .then(a.jail_until.cmp(&b.jail_until))
+    });
+
+    // --- Verifier budget (ADR-0008): p × accepted FLOPs (informational) ---
+    // Reuse the deterministic basis-points conversion for the FLOPs budget too,
+    // via U256 (no overflow, exact narrowing of a value <= total_flops_accepted).
+    let verifier_budget_flops: u64 = (U256::from_u128(u128::from(total_flops_accepted))
+        * U256::from_u128(p_bps)
+        / U256::from_u128(10_000))
+    .low_u64();
+
+    Ok(EpochSettlement {
+        commit,
+        rewards,
+        slashes,
+        verifier_reserve_wei,
+        verifier_budget_flops,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qfc_inference::{BackendType, GpuTier, ModelId, ShardEntry, ShardManifest};
+    use qfc_ps::ParamRange;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    fn addr(b: u8) -> Address {
+        Address::new([b; 20])
+    }
+
+    fn hash(b: u8) -> Hash {
+        Hash::new([b; 32])
+    }
+
+    fn range(start: u64, end: u64) -> ParamRange {
+        ParamRange::new(start, end).unwrap()
+    }
+
+    /// A spec whose job_id is `hash(1)` — only `job_id` matters to settlement.
+    fn spec() -> TrainingJobSpec {
+        TrainingJobSpec {
+            job_id: hash(1),
+            model_id: ModelId::new("bert-tiny", "v1"),
+            data_manifest: ShardManifest {
+                shards: vec![ShardEntry {
+                    cid: "QmShard0".to_string(),
+                    hash: hash(9),
+                    size_bytes: 1024,
+                    layer_range: None,
+                }],
+                total_size_bytes: 1024,
+                assembled_hash: hash(0xAA),
+            },
+            param_count: 1000,
+            range_partition: vec![range(0, 1000)],
+            epochs: 4,
+            steps_per_epoch: 10,
+            tokens_per_step: 128,
+            per_step_reward: 1_000_000,
+            required_backend: BackendType::Cpu,
+            min_tier: GpuTier::Cold,
+            min_memory_mb: 1024,
+        }
+    }
+
+    fn record(worker: u8, epoch: u64, clock: u64, flops: u64) -> AcceptanceRecord {
+        AcceptanceRecord {
+            worker: addr(worker),
+            epoch,
+            clock,
+            range: range(0, 1000),
+            // A distinct hash per (worker, clock) so root sensitivity is real.
+            update_hash: qfc_crypto::blake3_hash(&[worker, clock as u8]),
+            flops_estimated: flops,
+        }
+    }
+
+    fn penalty(worker: u8, epoch: u64, slash: u128, void: bool) -> TrainingPenalty {
+        TrainingPenalty {
+            worker: addr(worker),
+            job_id: hash(1),
+            epoch,
+            slash_amount: slash,
+            void_epoch_records: void,
+            jail_duration_ms: crate::training_verification::INVALID_TRAINING_JAIL_MS,
+        }
+    }
+
+    fn outcome(epoch: u64, accepted: Vec<AcceptanceRecord>) -> EpochOutcome {
+        EpochOutcome {
+            epoch,
+            params_hash: hash(0x55),
+            accepted,
+        }
+    }
+
+    // ---- records_root ----
+
+    #[test]
+    fn test_records_root_order_independent() {
+        let recs = vec![
+            record(1, 0, 0, 100),
+            record(2, 0, 0, 200),
+            record(3, 0, 1, 300),
+        ];
+        let root = records_root(&recs);
+        // Shuffle: same set, different order -> identical root.
+        let shuffled = vec![recs[2].clone(), recs[0].clone(), recs[1].clone()];
+        assert_eq!(records_root(&shuffled), root);
+    }
+
+    #[test]
+    fn test_records_root_sensitive_to_changes() {
+        let base = vec![record(1, 0, 0, 100), record(2, 0, 0, 200)];
+        let root = records_root(&base);
+
+        // Changed flops -> different root.
+        let mut changed_flops = base.clone();
+        changed_flops[0].flops_estimated = 101;
+        assert_ne!(records_root(&changed_flops), root);
+
+        // Changed worker -> different root.
+        let mut changed_worker = base.clone();
+        changed_worker[0].worker = addr(9);
+        assert_ne!(records_root(&changed_worker), root);
+    }
+
+    #[test]
+    fn test_records_root_empty_is_stable_known_value() {
+        // Empty input -> hash of empty input, the blake3 IV digest. Stable.
+        let expected = Hash::new(*blake3::Hasher::new().finalize().as_bytes());
+        assert_eq!(records_root(&[]), expected);
+        assert_eq!(records_root(&[]), records_root(&[]));
+    }
+
+    // ---- settle_epoch happy path ----
+
+    #[test]
+    fn test_settle_happy_path_pro_rata() {
+        // 3 workers, flops 100 / 200 / 700 = total 1000; gross pool 10_000.
+        // Verifier reserve = 10_000 × 0.05 = 500; worker_pool = 9_500.
+        // Pro-rata over 9_500: 950, 1_900, 6_650 exactly (no remainder).
+        let recs = vec![
+            record(1, 0, 0, 100),
+            record(2, 0, 0, 200),
+            record(3, 0, 0, 700),
+        ];
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        let s = settle_epoch(&out, &spec(), &[], 10_000, &cfg, 1_000).unwrap();
+
+        assert_eq!(s.verifier_reserve_wei, 500);
+        assert_eq!(
+            s.rewards,
+            vec![
+                RewardCredit {
+                    worker: addr(1),
+                    amount: 950
+                },
+                RewardCredit {
+                    worker: addr(2),
+                    amount: 1_900
+                },
+                RewardCredit {
+                    worker: addr(3),
+                    amount: 6_650
+                },
+            ]
+        );
+        // Sorted by worker bytes.
+        assert!(s
+            .rewards
+            .windows(2)
+            .all(|w| w[0].worker.as_bytes() <= w[1].worker.as_bytes()));
+        // Pool conservation (ADR-0008): sum(rewards) + reserve <= gross pool.
+        let paid: u128 = s.rewards.iter().map(|r| r.amount).sum();
+        assert!(paid + s.verifier_reserve_wei <= 10_000);
+
+        // Commit reflects the full accepted set.
+        assert_eq!(s.commit.accepted_count, 3);
+        assert_eq!(s.commit.total_flops_accepted, 1000);
+        assert_eq!(s.commit.params_hash, hash(0x55));
+        assert_eq!(s.commit.job_id, hash(1));
+        assert_eq!(s.commit.records_root, records_root(&out.accepted));
+        assert!(s.slashes.is_empty());
+    }
+
+    #[test]
+    fn test_settle_pro_rata_remainder_carried() {
+        // flops 1 / 1 / 1 = 3; gross pool 10. Reserve = 10×500/10_000 = 0
+        // (floor), so worker_pool = 10. Each gets 10×1/3 = 3 (floor); 9 paid,
+        // remainder 1 carried (left in pool, not distributed).
+        let recs = vec![record(1, 0, 0, 1), record(2, 0, 0, 1), record(3, 0, 0, 1)];
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        let s = settle_epoch(&out, &spec(), &[], 10, &cfg, 0).unwrap();
+        assert_eq!(s.verifier_reserve_wei, 0);
+        assert!(s.rewards.iter().all(|r| r.amount == 3));
+        let paid: u128 = s.rewards.iter().map(|r| r.amount).sum();
+        assert_eq!(paid, 9);
+    }
+
+    /// One reward per worker even when a worker has multiple accepted records.
+    #[test]
+    fn test_settle_aggregates_per_worker() {
+        let recs = vec![
+            record(1, 0, 0, 100),
+            record(1, 0, 1, 100), // worker 1 again -> aggregate to 200
+            record(2, 0, 0, 200),
+        ];
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        let s = settle_epoch(&out, &spec(), &[], 4_000, &cfg, 0).unwrap();
+        // gross 4_000; reserve = 200; worker_pool = 3_800. total flops 400;
+        // worker1 200/400, worker2 200/400 -> 1_900 each.
+        assert_eq!(s.verifier_reserve_wei, 200);
+        assert_eq!(s.rewards.len(), 2);
+        assert_eq!(
+            s.rewards[0],
+            RewardCredit {
+                worker: addr(1),
+                amount: 1_900
+            }
+        );
+        assert_eq!(
+            s.rewards[1],
+            RewardCredit {
+                worker: addr(2),
+                amount: 1_900
+            }
+        );
+        assert_eq!(s.commit.accepted_count, 3);
+    }
+
+    // ---- voiding ----
+
+    #[test]
+    fn test_settle_voiding_excludes_from_rewards_only() {
+        // 3 workers, flops 100 / 200 / 700. Worker 3 is penalized with
+        // void=true -> excluded from rewards; pool re-pro-rated over 100+200.
+        let recs = vec![
+            record(1, 0, 0, 100),
+            record(2, 0, 0, 200),
+            record(3, 0, 0, 700),
+        ];
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        let pen = vec![penalty(3, 0, 40_000_000, true)];
+        let s = settle_epoch(&out, &spec(), &pen, 3_000, &cfg, 5_000).unwrap();
+
+        // gross 3_000; reserve = 150; worker_pool = 2_850. Worker 3 absent from
+        // rewards; 1 and 2 split over remaining 300 flops.
+        // 2_850×100/300 = 950, 2_850×200/300 = 1_900.
+        assert_eq!(s.verifier_reserve_wei, 150);
+        assert_eq!(
+            s.rewards,
+            vec![
+                RewardCredit {
+                    worker: addr(1),
+                    amount: 950
+                },
+                RewardCredit {
+                    worker: addr(2),
+                    amount: 1_900
+                },
+            ]
+        );
+        assert!(s.rewards.iter().all(|r| r.worker != addr(3)));
+
+        // CHOSEN SEMANTICS: voided records STILL count toward the commitment.
+        assert_eq!(s.commit.accepted_count, 3);
+        assert_eq!(s.commit.total_flops_accepted, 1000); // includes voided 700
+        assert_eq!(s.commit.records_root, records_root(&out.accepted));
+
+        // Slash present for worker 3.
+        assert_eq!(s.slashes.len(), 1);
+        assert_eq!(s.slashes[0].validator, addr(3));
+        assert_eq!(s.slashes[0].offense, SlashableOffense::InvalidTraining);
+        assert_eq!(s.slashes[0].slashed_amount, U256::from_u128(40_000_000));
+        assert_eq!(
+            s.slashes[0].jail_until,
+            5_000 + crate::training_verification::INVALID_TRAINING_JAIL_MS
+        );
+    }
+
+    /// A penalty for an unknown worker (not in accepted) is still slashed.
+    #[test]
+    fn test_settle_penalty_unknown_worker_still_slashed() {
+        let recs = vec![record(1, 0, 0, 100), record(2, 0, 0, 100)];
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        let pen = vec![penalty(99, 0, 1234, true)];
+        let s = settle_epoch(&out, &spec(), &pen, 1_000, &cfg, 0).unwrap();
+        assert_eq!(s.slashes.len(), 1);
+        assert_eq!(s.slashes[0].validator, addr(99));
+        // Rewards unaffected (voiding an absent worker removes nothing).
+        assert_eq!(s.rewards.len(), 2);
+    }
+
+    // ---- penalty_to_slash ----
+
+    #[test]
+    fn test_penalty_to_slash_fields() {
+        let p = penalty(7, 3, 40_000_000, true);
+        let slash = penalty_to_slash(&p, 1_000);
+        assert_eq!(slash.validator, addr(7));
+        assert_eq!(slash.offense, SlashableOffense::InvalidTraining);
+        assert_eq!(slash.slashed_amount, U256::from_u128(40_000_000));
+        assert_eq!(
+            slash.jail_until,
+            1_000 + crate::training_verification::INVALID_TRAINING_JAIL_MS
+        );
+    }
+
+    #[test]
+    fn test_penalty_to_slash_jail_saturates() {
+        let mut p = penalty(7, 0, 1, true);
+        p.jail_duration_ms = u64::MAX;
+        let slash = penalty_to_slash(&p, 100);
+        assert_eq!(slash.jail_until, u64::MAX);
+    }
+
+    // ---- validation errors ----
+
+    #[test]
+    fn test_settle_record_epoch_mismatch() {
+        let recs = vec![record(1, 0, 0, 100), record(2, 5, 0, 100)]; // wrong epoch
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        assert_eq!(
+            settle_epoch(&out, &spec(), &[], 1_000, &cfg, 0),
+            Err(SettlementError::RecordEpochMismatch {
+                worker: addr(2),
+                record_epoch: 5,
+                epoch: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_settle_penalty_epoch_mismatch() {
+        let out = outcome(0, vec![record(1, 0, 0, 100)]);
+        let cfg = PsConfig::default();
+        let pen = vec![penalty(1, 7, 1, true)];
+        assert_eq!(
+            settle_epoch(&out, &spec(), &pen, 1_000, &cfg, 0),
+            Err(SettlementError::PenaltyEpochMismatch {
+                worker: addr(1),
+                penalty_epoch: 7,
+                epoch: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_settle_penalty_job_mismatch() {
+        let out = outcome(0, vec![record(1, 0, 0, 100)]);
+        let cfg = PsConfig::default();
+        let mut p = penalty(1, 0, 1, true);
+        p.job_id = hash(0xEE);
+        assert_eq!(
+            settle_epoch(&out, &spec(), &[p], 1_000, &cfg, 0),
+            Err(SettlementError::PenaltyJobMismatch {
+                worker: addr(1),
+                penalty_job: hash(0xEE),
+                job_id: hash(1),
+            })
+        );
+    }
+
+    // ---- verifier budget ----
+
+    #[test]
+    fn test_verifier_budget_is_rate_times_flops() {
+        // total flops 1000, default spot_check_rate 0.05 -> 50.
+        let recs = vec![record(1, 0, 0, 400), record(2, 0, 0, 600)];
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        let s = settle_epoch(&out, &spec(), &[], 1_000, &cfg, 0).unwrap();
+        assert_eq!(s.verifier_budget_flops, 50);
+    }
+
+    #[test]
+    fn test_verifier_reserve_carved_from_pool() {
+        // total flops 1000, default rate 0.05. gross 100_000.
+        // reserve = 100_000 × 0.05 = 5_000; worker_pool = 95_000.
+        let recs = vec![record(1, 0, 0, 400), record(2, 0, 0, 600)];
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        let s = settle_epoch(&out, &spec(), &[], 100_000, &cfg, 0).unwrap();
+        assert_eq!(s.verifier_reserve_wei, 5_000);
+        // 95_000 × 400/1000 = 38_000; 95_000 × 600/1000 = 57_000.
+        let paid: u128 = s.rewards.iter().map(|r| r.amount).sum();
+        assert_eq!(paid, 95_000);
+        // INVARIANT (pool conservation): sum(rewards) + reserve <= gross pool.
+        assert!(paid + s.verifier_reserve_wei <= 100_000);
+    }
+
+    /// Finding 2: large pool × large epoch flops overflows u128 in a naive
+    /// `pool × worker_flops` mul, but the U256 intermediate must settle cleanly.
+    #[test]
+    fn test_settle_large_pool_no_overflow() {
+        // pool ~2^90 wei, two workers with ~2^49 flops each (u64-range). A naive
+        // u128 `pool × flops` (~2^139) overflows; via U256 it must not.
+        let big_pool: u128 = 1u128 << 90;
+        let flops: u64 = 1u64 << 49;
+        let recs = vec![record(1, 0, 0, flops), record(2, 0, 0, flops)];
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        let s = settle_epoch(&out, &spec(), &[], big_pool, &cfg, 0).unwrap();
+        // worker_pool = big_pool - reserve; split 50/50 -> each = worker_pool/2.
+        let worker_pool = big_pool - s.verifier_reserve_wei;
+        assert_eq!(s.rewards.len(), 2);
+        for r in &s.rewards {
+            assert_eq!(r.amount, worker_pool / 2);
+        }
+        let paid: u128 = s.rewards.iter().map(|r| r.amount).sum();
+        assert!(paid + s.verifier_reserve_wei <= big_pool);
+    }
+
+    /// Finding 5: non-empty accepted set where ALL non-voided records have
+    /// flops_estimated == 0 and pool > 0. No panic (checked_div(0) guard),
+    /// all rewards omitted, entire worker_pool carried forward, and the
+    /// verifier reserve is still computed from the gross pool.
+    #[test]
+    fn test_settle_all_zero_flops_carries_whole_pool() {
+        let recs = vec![record(1, 0, 0, 0), record(2, 0, 0, 0), record(3, 0, 1, 0)];
+        let out = outcome(0, recs);
+        let cfg = PsConfig::default();
+        let s = settle_epoch(&out, &spec(), &[], 1_000_000, &cfg, 0).unwrap();
+        // No reward credits (all amounts would be 0 -> omitted).
+        assert!(s.rewards.is_empty());
+        // Reserve still carved from the gross pool: 1_000_000 × 0.05 = 50_000.
+        assert_eq!(s.verifier_reserve_wei, 50_000);
+        // total_flops_accepted == 0 -> verifier_budget_flops == 0.
+        assert_eq!(s.commit.total_flops_accepted, 0);
+        assert_eq!(s.verifier_budget_flops, 0);
+        // Entire worker_pool carried forward (nothing distributed).
+        let paid: u128 = s.rewards.iter().map(|r| r.amount).sum();
+        assert_eq!(paid, 0);
+        assert_eq!(s.commit.accepted_count, 3);
+    }
+
+    // ---- determinism property test (seeded, no proptest dep) ----
+
+    #[test]
+    fn test_settle_deterministic_under_shuffle() {
+        let mut rng = StdRng::seed_from_u64(0xA5_C0FFEE);
+        let cfg = PsConfig::default();
+
+        for _iter in 0..100 {
+            let epoch = 0u64;
+            let n = rng.gen_range(3..=12);
+            // Build N random accepted records. Use a small worker pool so
+            // per-worker aggregation and voiding actually bite.
+            let mut recs: Vec<AcceptanceRecord> = Vec::with_capacity(n);
+            for i in 0..n {
+                let worker = rng.gen_range(1..=6u8);
+                let flops = rng.gen_range(1..=10_000u64);
+                recs.push(record(worker, epoch, i as u64, flops));
+            }
+            // M random penalties on workers in the pool.
+            let m = rng.gen_range(0..=3);
+            let mut pens: Vec<TrainingPenalty> = Vec::with_capacity(m);
+            for _ in 0..m {
+                let worker = rng.gen_range(1..=6u8);
+                let void = rng.gen_bool(0.5);
+                let slash = rng.gen_range(1..=u128::from(u64::MAX));
+                pens.push(penalty(worker, epoch, slash, void));
+            }
+            let pool: u128 = rng.gen_range(0..=1_000_000_000u128);
+            let now = rng.gen_range(0..=1_000_000u64);
+            let out = outcome(epoch, recs.clone());
+
+            let a = settle_epoch(&out, &spec(), &pens, pool, &cfg, now).unwrap();
+
+            // Independently shuffle both input vectors.
+            let mut recs_shuf = recs.clone();
+            let mut pens_shuf = pens.clone();
+            for i in (1..recs_shuf.len()).rev() {
+                recs_shuf.swap(i, rng.gen_range(0..=i));
+            }
+            if !pens_shuf.is_empty() {
+                for i in (1..pens_shuf.len()).rev() {
+                    pens_shuf.swap(i, rng.gen_range(0..=i));
+                }
+            }
+            let out_shuf = outcome(epoch, recs_shuf);
+            let b = settle_epoch(&out_shuf, &spec(), &pens_shuf, pool, &cfg, now).unwrap();
+
+            assert_eq!(a.commit.commit_hash(), b.commit.commit_hash());
+            assert_eq!(a.commit, b.commit);
+            assert_eq!(a.rewards, b.rewards);
+            assert_eq!(a.slashes, b.slashes);
+            assert_eq!(a.verifier_reserve_wei, b.verifier_reserve_wei);
+            assert_eq!(a.verifier_budget_flops, b.verifier_budget_flops);
+
+            // Pool conservation (ADR-0008): sum(rewards) + reserve <= gross pool.
+            let paid: u128 = a.rewards.iter().map(|r| r.amount).sum();
+            assert!(paid + a.verifier_reserve_wei <= pool);
+        }
+    }
+}

--- a/crates/qfc-node/src/sync.rs
+++ b/crates/qfc-node/src/sync.rs
@@ -886,6 +886,26 @@ impl SyncManager {
             evidence.offender, evidence.offense, evidence.reporter
         );
 
+        // InvalidTraining is settled ONLY via the A5 absolute-slash path
+        // (`SlashResult.slashed_amount` = `slash_multiple × per_step_reward`,
+        // ADR-0009 Decision 4) and applied by the A6 absolute-amount slash
+        // entry point in consensus — it MUST NOT flow through the
+        // percent-of-stake `slash_validator(percent, ..)` path below. Routing
+        // it here would (a) silently drop the absolute-40r deterrent (a 0%
+        // slash) and (b) let any known validator jail an arbitrary victim for
+        // free by signing `SlashingEvidence{offense: InvalidTraining}`. Reject
+        // it explicitly: no state change, no jail.
+        if evidence.offense == qfc_types::SlashableOffense::InvalidTraining {
+            warn!(
+                "Rejecting InvalidTraining slashing evidence against {} from {}: \
+                 InvalidTraining is settled via the A5 absolute-slash path \
+                 (SlashResult.slashed_amount, ADR-0009 D4) and MUST NOT be applied \
+                 through the percent slash path (A6)",
+                evidence.offender, evidence.reporter
+            );
+            return;
+        }
+
         // Determine slash parameters based on offense type
         let (slash_percent, jail_duration_ms) = match evidence.offense {
             qfc_types::SlashableOffense::DoubleSign => (10, 24 * 60 * 60 * 1000), // 10%, 24 hours
@@ -894,6 +914,11 @@ impl SyncManager {
             qfc_types::SlashableOffense::Offline => (1, 1 * 60 * 60 * 1000),      // 1%, 1 hour
             qfc_types::SlashableOffense::FalseVote => (2, 2 * 60 * 60 * 1000),    // 2%, 2 hours
             qfc_types::SlashableOffense::InvalidInference => (5, 6 * 60 * 60 * 1000), // 5%, 6 hours
+            // InvalidTraining is handled by the early-return guard above
+            // (A5 absolute-slash path, ADR-0009 D4 + A6) and never reaches here.
+            qfc_types::SlashableOffense::InvalidTraining => {
+                unreachable!("InvalidTraining must be rejected before the percent-slash dispatch")
+            }
         };
 
         // Apply the slash

--- a/crates/qfc-storage/src/schema.rs
+++ b/crates/qfc-storage/src/schema.rs
@@ -59,6 +59,13 @@ pub mod cf {
     /// Persists completed/expired/failed tasks for long-term querying
     pub const TASKS: &str = "tasks";
 
+    /// Training-epoch commitments (ROADMAP-AI-V3 ADR-0009 Decision 5):
+    /// job_id (32 bytes Hash) + epoch (u64 BE) -> TrainingEpochCommit (borsh).
+    /// Append-only on-chain anchor for each closed training epoch; range-scan
+    /// over the job_id prefix yields a job's commits in epoch order. Written
+    /// by `qfc-ai-coordinator`'s `TrainingChainStore`.
+    pub const TRAINING_COMMITMENTS: &str = "training_commitments";
+
     /// All column families
     pub const ALL: &[&str] = &[
         BLOCK_HEADERS,
@@ -79,6 +86,7 @@ pub mod cf {
         ETH_TX_INDEX,
         MINER_EARNINGS,
         TASKS,
+        TRAINING_COMMITMENTS,
     ];
 }
 

--- a/crates/qfc-types/src/validator.rs
+++ b/crates/qfc-types/src/validator.rs
@@ -398,6 +398,12 @@ pub enum SlashableOffense {
     FalseVote,
     /// Fraudulent inference proof (output hash mismatch on spot-check)
     InvalidInference,
+    /// Failed training-step verification (sampled re-execution mismatch,
+    /// ROADMAP-AI-V3 ADR-0008/ADR-0009). Unlike the percent-of-stake offenses
+    /// above, training slashing is an ABSOLUTE amount (`slash_multiple ×
+    /// per_step_reward`, ADR-0009 Decision 4) carried directly in
+    /// [`SlashResult::slashed_amount`] — it does NOT use the percent path.
+    InvalidTraining,
 }
 
 /// Slash result

--- a/docs/adr/0009-chain-integration.md
+++ b/docs/adr/0009-chain-integration.md
@@ -1,0 +1,126 @@
+# ADR-0009: Chain integration — settlement, commitments, reward/slash
+
+**Status:** accepted · **Date:** 2026-06-14 · **Context:** ROADMAP-AI-V3 Feature A, milestone A5.
+
+## Problem
+
+A0–A4 produced off-chain machinery: PS aggregation (`EpochOutcome`), training
+assignment (`TrainingJobSpec`/`TrainingAssignment`), and sampled verification
+(`TrainingPenalty`). None of it touches the chain yet — every "A5 scope" note
+in `training.rs` / `training_verification.rs` / `qfc-ps` defers the on-chain
+half here. A5 wires the epoch result into chain state: a version commitment,
+contribution-driven rewards, and slashing for failed verification.
+
+## Decision 1 — A pure settlement layer; the chain stores only commitments
+
+Settlement is a **pure, deterministic function** of an epoch's result — it
+computes *what* changes on-chain, not *how* the node applies it:
+
+```
+settle_epoch(outcome, spec, penalties, reward_pool, config) -> EpochSettlement
+EpochSettlement {
+    commit:   TrainingEpochCommit,   // the on-chain anchor
+    rewards:  Vec<RewardCredit>,     // (worker, amount) to credit
+    slashes:  Vec<SlashResult>,      // qfc-types SlashResult, offense=InvalidTraining
+    verifier_budget_flops: u64,      // reserved for verification work (ADR-0008)
+}
+```
+
+Purity is the **cross-operator-agreement primitive** (the open item from the A4
+review): two of the ≥2 operators of a range (ADR-0002) that received the same
+accepted-update set produce a **byte-identical** `commit` and therefore the same
+`commit_hash()`. A5 gives the node a cheap equality check; the N-of-M voting that
+*selects* the canonical outcome is consensus-path work, deferred (Decision 6).
+
+Lives in `qfc-ai-coordinator/src/settlement.rs` — that crate already depends on
+`qfc-ps` (EpochOutcome/AcceptanceRecord), `qfc-types` (SlashResult/U256), and the
+training types. No new inter-crate edges for the computation.
+
+## Decision 2 — Commitment shape: full record set off-chain, anchored by a root
+
+```rust
+TrainingEpochCommit {
+    job_id: Hash,
+    epoch: u64,
+    params_hash: Hash,            // from EpochOutcome — the new model version
+    records_root: Hash,          // blake3 over canonically-sorted AcceptanceRecords
+    accepted_count: u64,
+    total_flops_accepted: u64,
+}
+```
+
+The full `Vec<AcceptanceRecord>` stays off-chain (it can be large); only
+`records_root` is committed. `records_root` sorts records canonically by
+`(worker bytes, epoch, clock, range.start, range.end, update_hash)` then streams
+blake3 — so any party holding the records can recompute and verify the root, and
+two operators with the same set get the same root. Borsh + serde, like every
+on-chain-adjacent type. `params_hash` duplicates `EpochOutcome.params_hash`
+deliberately so the commit is self-contained.
+
+## Decision 3 — Rewards: pro-rata over accepted, non-voided FLOPs
+
+Per ADR-0004, the per-epoch training reward pool splits pro-rata over accepted
+updates' `flops_estimated`. A penalized worker's records are **voided first**
+(ADR-0004 `void_epoch_records`) — excluded before pro-rating, earning nothing.
+Integer division: `worker_reward = pool * worker_flops / total_flops`. The
+rounding remainder is **carried forward** (left in the pool, not distributed) —
+deterministic and avoids a "remainder to whoever sorts first" bias. Workers with
+voided-to-zero remaining FLOPs are omitted from `rewards`.
+
+## Decision 4 — Slashing: new offense, absolute amount
+
+Add `SlashableOffense::InvalidTraining` to `qfc-types`, mirroring
+`InvalidInference`. `penalty_to_slash(penalty, now) -> SlashResult`:
+
+```
+SlashResult {
+    validator: penalty.worker,
+    offense:   InvalidTraining,
+    slashed_amount: U256(penalty.slash_amount),   // = slash_multiple × per_step_reward (ADR-0008)
+    jail_until:     now + penalty.jail_duration_ms, // 6h, INVALID_TRAINING_JAIL_MS
+}
+```
+
+**Note the model mismatch (flagged for A6):** the existing inference slash path
+(`consensus::slash_validator(percent, jail_ms)`) is **percent-of-stake**; ADR-0008
+training slashing is an **absolute amount** (40r). `SlashResult.slashed_amount`
+is already absolute, so the settlement output is correct — but the node needs an
+absolute-amount slash entry point to apply it (the percent path can't express
+"slash exactly 40r"). That node wiring is Decision 6, deferred. Capping the slash
+at the worker's locked training stake also happens at application time (settlement
+has no stake view).
+
+## Decision 5 — Commitment persistence
+
+New column family `TRAINING_COMMITMENTS` in `qfc-storage` `cf::ALL`, keyed
+`job_id ‖ epoch(BE)`, value = Borsh(`TrainingEpochCommit`). A thin
+`TrainingChainStore` (new `qfc-ai-coordinator/src/chain_store.rs`, adds the
+`qfc-storage` dep) wraps a dedicated-or-shared `Database`: `put_commit`,
+`get_commit`, `commits_for_job` (range scan), append-only. **Risk to verify:**
+adding a CF to `cf::ALL` must not break opening existing on-disk DBs —
+`Database::open` must use `create_missing_column_families`; the implementor
+confirms this before relying on it, else the CF addition is gated behind a
+migration note.
+
+## Decision 6 — Non-goals (deferred to A6 / node integration)
+
+Each stays grep-able as an `A6`/`node` scope note where the seam is:
+
+- **State mutation at the epoch boundary** — actually crediting `rewards` to
+  balances and applying `slashes` to validator stake (needs the node's State,
+  validator set, and clock). Settlement produces the deltas; the node applies.
+- **Absolute-amount slash entry point** in consensus (Decision 4).
+- **P2P broadcast** of commitments and `SlashingEvidence`.
+- **N-of-M operator agreement** that selects the canonical `EpochOutcome`
+  (Decision 1 provides the deterministic-equality primitive only).
+- **VRF sampling entropy** (A4 used committed `params_hash`; A6 upgrades to
+  on-chain VRF), **per-job stake locking** enforcement, **signed `ParamUpdate`**.
+
+## Consequences
+
+- A5 is fully unit-testable without standing up a node: settlement is pure;
+  persistence uses `Database::open_temp`.
+- `settle_epoch` determinism is property-tested (shuffled record/penalty order →
+  identical `commit_hash` and `rewards`).
+- Adding `InvalidTraining` touches every exhaustive `match` on `SlashableOffense`
+  — the implementor finds and updates all of them.


### PR DESCRIPTION
Milestone **A5** of [ROADMAP-AI-V3](docs/ROADMAP-AI-V3.md) Feature A — the on-chain half of decentralized training. ADR-0009. This is the last heavy Feature-A milestone before the A6 testnet pilot.

## What's here — a pure, deterministic settlement layer

`settle_epoch(outcome, spec, penalties, pool, config, now) → EpochSettlement` turns an epoch's off-chain result into exactly the state transitions the chain must apply. It's a **pure function**: the same accepted-update set in any order produces a **byte-identical commitment** — that determinism *is* the cross-operator-agreement primitive (the open item from the A4 review). A 100-seed property test shuffles both inputs independently and asserts identical `commit_hash`, rewards, slashes, and verifier reserve.

- **`TrainingEpochCommit`** `{ job_id, epoch, params_hash, records_root, accepted_count, total_flops_accepted }` — the full `AcceptanceRecord` set stays off-chain (it's large), anchored by a canonical blake3 `records_root` (fixed-width fields, no concatenation ambiguity → no cross-operator divergence, no omit/add collision). `commit_hash()` gives the node a cheap N-of-M equality check.
- **Rewards** pro-rata over accepted, non-voided FLOPs (ADR-0004). Penalized workers' records are voided from payout but remain in the commitment (so operators with different observed penalty sets still agree on `records_root`). U256 muldiv so a realistic large pool doesn't overflow u128; remainder carried forward (deterministic, no sort-order bias).
- **Verifier budget** reserved off the gross pool (ADR-0008 — verification is metered work paid from the pool); workers split the remainder. Pool conservation asserted.
- **Slashing** — new `SlashableOffense::InvalidTraining`; `penalty_to_slash` produces a `SlashResult` with the absolute amount `40r` (ADR-0008) and 6h jail.
- **Persistence** — `TrainingChainStore` over a new `TRAINING_COMMITMENTS` CF (`create_missing_column_families` confirmed on → no migration), keyed `job_id‖epoch(BE)`, with per-job range scan.

## Blocker/should-fixes caught by adversarial review

- **Free-jail griefing closed:** the live `handle_slashing_evidence` percent path mapped `InvalidTraining → (0%, 6h)` — a known validator could sign evidence to jail any victim for 6h at zero cost while the 40r deterrent was silently dropped. The percent path now explicitly rejects `InvalidTraining` (it's absolute-slash-only).
- **Reward overflow fixed:** `pool × worker_flops` overflowed u128 for large pools, failing legitimate epochs (deterministic DoS-by-scale). Now a U256 intermediate.
- **Verifier pay no longer double-counts:** the budget is carved from the pool, not added on top.

Determinism (the load-bearing property) survived every divergence attempt in review.

## Tests

qfc-ai-coordinator 169, qfc-types 41, qfc-ps 55 — all green; workspace/fmt/clippy clean.

## Deferred to A6 (grep `A6`)

Node-side **application** of the settlement: crediting `rewards` to balances, applying `slashes` to stake (needs an absolute-amount slash entry point — the existing path is percent-only), P2P broadcast of commitments/evidence, N-of-M operator agreement that selects the canonical outcome **and** penalty set, VRF sampling entropy, stake-locking enforcement, signed `ParamUpdate`. A5 computes the deltas; the node applies them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)