### PR TITLE
T8: qfc_hotKeyReport RPC for the full ranked hot-key report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Proof of Contribution (PoC) - 多维度贡献评分:
 - `qfc_getFinalizedBlock` - 最终确认区块
 - `qfc_getNetworkState` - 网络状态 (normal/congested/storage_shortage/under_attack)
 - `qfc_nodeInfo` - 节点信息
+- `qfc_hotKeyReport` - 热点 key/账户分析报告 (SRE T8, 参数 topN; 需 --hot-key-sampling)
 - `qfc_requestFaucet` - 请求测试币 (仅 dev 模式, chain_id=9000)
 - `qfc_getAgentInfo` - 查询 Agent 信息 (AgentRegistry 合约)
 - `qfc_listAgentsByOwner` - 按 owner 列出 Agent

--- a/crates/qfc-rpc/src/qfc.rs
+++ b/crates/qfc-rpc/src/qfc.rs
@@ -410,6 +410,104 @@ pub trait QfcApi {
     /// Get agent balance (stake + deposit)
     #[method(name = "getAgentBalance")]
     async fn get_agent_balance(&self, agent_id: String) -> RpcResult<RpcAgentBalance>;
+
+    // ---- SRE T8: hot-key analytics ----
+
+    /// On-demand hot-key / hot-account analytics report.
+    ///
+    /// Returns the current sampling-window snapshot: per-CF traffic with the
+    /// ranked hottest keys, plus the hottest accounts and contract bytecode —
+    /// the full ranked identities that are deliberately kept out of the
+    /// Prometheus labels. `topN` (default 16, clamped to 1..=256) bounds the
+    /// ranked lists. When the node runs without `--hot-key-sampling`,
+    /// `samplingEnabled` is false and the detail fields are null. The same
+    /// data is logged per window to the `qfc::hot_keys` target when
+    /// `--hot-key-window-secs` is set. See docs/profiling/HOT-KEYS.md.
+    #[method(name = "hotKeyReport")]
+    async fn hot_key_report(&self, top_n: Option<usize>) -> RpcResult<RpcHotKeyReport>;
+}
+
+/// T8: combined hot-key / hot-account report. Detail fields are `null` when
+/// the node is not running with `--hot-key-sampling`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHotKeyReport {
+    /// Whether hot-key sampling is active on this node.
+    pub sampling_enabled: bool,
+    /// Effective 1-in-N sampling rate (0 when disabled).
+    pub sampling_rate: u32,
+    /// Size of the ranked lists requested.
+    pub top_n: usize,
+    /// Per-CF storage-level sampling, or `null` when disabled.
+    pub storage: Option<RpcHotKeyStorage>,
+    /// Account/bytecode-level sampling, or `null` when disabled.
+    pub accounts: Option<RpcHotAccounts>,
+}
+
+/// Storage-level (per-column-family) hot-key sampling.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHotKeyStorage {
+    pub sampling_rate: u32,
+    pub sketch_capacity: usize,
+    pub window_start_unix_ms: u64,
+    pub cfs: Vec<RpcCfHotKeys>,
+}
+
+/// Per-column-family hot-key stats.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcCfHotKeys {
+    pub cf: String,
+    pub reads_sampled: u64,
+    pub writes_sampled: u64,
+    pub estimated_reads: u64,
+    pub estimated_writes: u64,
+    pub top_keys: Vec<RpcHotKeyEntry>,
+}
+
+/// One ranked hot key (`keyHex` is the raw `0x…` key).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHotKeyEntry {
+    pub key_hex: String,
+    pub sampled_count: u64,
+    pub estimated_count: u64,
+    pub max_overestimate: u64,
+}
+
+/// Account/bytecode-level hot-key sampling.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHotAccounts {
+    pub sampling_rate: u32,
+    pub sketch_capacity: usize,
+    pub window_start_unix_ms: u64,
+    pub estimated_account_reads: u64,
+    pub estimated_account_writes: u64,
+    pub estimated_code_reads: u64,
+    pub top_accounts: Vec<RpcHotAccountEntry>,
+    pub top_code: Vec<RpcHotCodeEntry>,
+}
+
+/// One ranked hot account.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHotAccountEntry {
+    pub address: String,
+    pub sampled_count: u64,
+    pub estimated_count: u64,
+    pub max_overestimate: u64,
+}
+
+/// One ranked hot contract bytecode (by code hash).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHotCodeEntry {
+    pub code_hash: String,
+    pub sampled_count: u64,
+    pub estimated_count: u64,
+    pub max_overestimate: u64,
 }
 
 /// Faucet response

--- a/crates/qfc-rpc/src/server.rs
+++ b/crates/qfc-rpc/src/server.rs
@@ -4,20 +4,21 @@ use crate::error::RpcError;
 use crate::eth::EthApiServer;
 use crate::qfc::{
     QfcApiServer, RpcAccountRentInfo, RpcAgentBalance, RpcAgentDetailView, RpcAgentInfo,
-    RpcAgentWriteResult, RpcBridgeDeposit, RpcBridgeStatus, RpcBridgeWithdrawal, RpcComputeInfo,
-    RpcEarningRecord, RpcEpoch, RpcEstimateInferenceFee, RpcFaucetResponse, RpcFreezeAgentParams,
-    RpcFundAgentRequest, RpcInferenceFeeEstimate, RpcInferenceProofSubmission, RpcInferenceStats,
-    RpcInferenceTask, RpcIssueSessionKeyParams, RpcListAgentsParams, RpcListAgentsResponse,
-    RpcListPublicTasksFilter, RpcMinerEarnings, RpcMinerEvent, RpcMinerStatusReport,
-    RpcMinerVesting, RpcModel, RpcModelProposal, RpcNodeInfo, RpcParameterOverride,
-    RpcParameterProposal, RpcProofResult, RpcProposeModelRequest, RpcProposeParameterRequest,
-    RpcProposeSpendRequest, RpcPublicTaskStatus, RpcQueryByCapabilityParams,
-    RpcRegisterAgentRequest, RpcRegisterMinerRequest, RpcRegisterMinerResult,
-    RpcRegisterWebhookRequest, RpcRegisteredMiner, RpcRemoveWebhookRequest, RpcRevokeAgentRequest,
-    RpcSessionKeyDetail, RpcSessionKeyInfo, RpcSpendProposal, RpcSubmitPublicTask, RpcTaskRequest,
-    RpcTreasuryInfo, RpcUndelegation, RpcUserOperation, RpcUserOperationStatus, RpcValidator,
-    RpcValidatorMetrics, RpcValidatorScoreBreakdown, RpcVoteModelRequest, RpcVoteParameterRequest,
-    RpcVoteSpendRequest, RpcWebhook,
+    RpcAgentWriteResult, RpcBridgeDeposit, RpcBridgeStatus, RpcBridgeWithdrawal, RpcCfHotKeys,
+    RpcComputeInfo, RpcEarningRecord, RpcEpoch, RpcEstimateInferenceFee, RpcFaucetResponse,
+    RpcFreezeAgentParams, RpcFundAgentRequest, RpcHotAccountEntry, RpcHotAccounts, RpcHotCodeEntry,
+    RpcHotKeyEntry, RpcHotKeyReport, RpcHotKeyStorage, RpcInferenceFeeEstimate,
+    RpcInferenceProofSubmission, RpcInferenceStats, RpcInferenceTask, RpcIssueSessionKeyParams,
+    RpcListAgentsParams, RpcListAgentsResponse, RpcListPublicTasksFilter, RpcMinerEarnings,
+    RpcMinerEvent, RpcMinerStatusReport, RpcMinerVesting, RpcModel, RpcModelProposal, RpcNodeInfo,
+    RpcParameterOverride, RpcParameterProposal, RpcProofResult, RpcProposeModelRequest,
+    RpcProposeParameterRequest, RpcProposeSpendRequest, RpcPublicTaskStatus,
+    RpcQueryByCapabilityParams, RpcRegisterAgentRequest, RpcRegisterMinerRequest,
+    RpcRegisterMinerResult, RpcRegisterWebhookRequest, RpcRegisteredMiner, RpcRemoveWebhookRequest,
+    RpcRevokeAgentRequest, RpcSessionKeyDetail, RpcSessionKeyInfo, RpcSpendProposal,
+    RpcSubmitPublicTask, RpcTaskRequest, RpcTreasuryInfo, RpcUndelegation, RpcUserOperation,
+    RpcUserOperationStatus, RpcValidator, RpcValidatorMetrics, RpcValidatorScoreBreakdown,
+    RpcVoteModelRequest, RpcVoteParameterRequest, RpcVoteSpendRequest, RpcWebhook,
 };
 use crate::txpool::{TxPoolApiServer, TxPoolContent, TxPoolStatus};
 use crate::types::{
@@ -4540,6 +4541,87 @@ impl QfcApiServer for RpcServer {
             stake_tier: tier.to_string(),
         })
     }
+
+    // ---- SRE T8: hot-key analytics ----
+
+    async fn hot_key_report(&self, top_n: Option<usize>) -> RpcResult<RpcHotKeyReport> {
+        let top_n = top_n.unwrap_or(16).clamp(1, 256);
+
+        // Per-CF storage-level report (sampler shared across all DB clones).
+        let storage = self
+            .chain
+            .db()
+            .hot_key_report(top_n)
+            .map(|r| RpcHotKeyStorage {
+                sampling_rate: r.sampling_rate,
+                sketch_capacity: r.sketch_capacity,
+                window_start_unix_ms: r.window_start_unix_ms,
+                cfs: r
+                    .cfs
+                    .into_iter()
+                    .map(|c| RpcCfHotKeys {
+                        cf: c.cf,
+                        reads_sampled: c.reads_sampled,
+                        writes_sampled: c.writes_sampled,
+                        estimated_reads: c.estimated_reads,
+                        estimated_writes: c.estimated_writes,
+                        top_keys: c
+                            .top_keys
+                            .into_iter()
+                            .map(|k| RpcHotKeyEntry {
+                                key_hex: k.key_hex,
+                                sampled_count: k.sampled_count,
+                                estimated_count: k.estimated_count,
+                                max_overestimate: k.max_overestimate,
+                            })
+                            .collect(),
+                    })
+                    .collect(),
+            });
+
+        // Account/bytecode-level report (chain's persistent state handle).
+        let accounts = self
+            .chain
+            .state()
+            .hot_account_report(top_n)
+            .map(|a| RpcHotAccounts {
+                sampling_rate: a.sampling_rate,
+                sketch_capacity: a.sketch_capacity,
+                window_start_unix_ms: a.window_start_unix_ms,
+                estimated_account_reads: a.estimated_account_reads,
+                estimated_account_writes: a.estimated_account_writes,
+                estimated_code_reads: a.estimated_code_reads,
+                top_accounts: a
+                    .top_accounts
+                    .into_iter()
+                    .map(|e| RpcHotAccountEntry {
+                        address: e.address,
+                        sampled_count: e.sampled_count,
+                        estimated_count: e.estimated_count,
+                        max_overestimate: e.max_overestimate,
+                    })
+                    .collect(),
+                top_code: a
+                    .top_code
+                    .into_iter()
+                    .map(|e| RpcHotCodeEntry {
+                        code_hash: e.code_hash,
+                        sampled_count: e.sampled_count,
+                        estimated_count: e.estimated_count,
+                        max_overestimate: e.max_overestimate,
+                    })
+                    .collect(),
+            });
+
+        let sampling_rate = storage.as_ref().map(|s| s.sampling_rate).unwrap_or(0);
+        Ok(RpcHotKeyReport {
+            sampling_enabled: storage.is_some(),
+            sampling_rate,
+            top_n,
+            storage,
+            accounts,
+        })
+    }
 }
 
 /// ABI helper: encode registerAgent(string,uint8[],uint256,uint256) calldata.
@@ -5177,5 +5259,91 @@ mod tests_model_governance_rpcs {
             assembled_hash: qfc_crypto::blake3_hash(&data),
         };
         assert!(manifest.validate().is_err());
+    }
+}
+
+#[cfg(test)]
+mod tests_hot_key_rpc {
+    use crate::qfc::{
+        RpcCfHotKeys, RpcHotAccountEntry, RpcHotAccounts, RpcHotKeyEntry, RpcHotKeyReport,
+        RpcHotKeyStorage,
+    };
+
+    /// The combined report round-trips through JSON with camelCase keys (the
+    /// field names operators and the dashboard reference).
+    #[test]
+    fn test_hot_key_report_serde_camel_case() {
+        let report = RpcHotKeyReport {
+            sampling_enabled: true,
+            sampling_rate: 64,
+            top_n: 16,
+            storage: Some(RpcHotKeyStorage {
+                sampling_rate: 64,
+                sketch_capacity: 256,
+                window_start_unix_ms: 1_765_000_000_000,
+                cfs: vec![RpcCfHotKeys {
+                    cf: "state".into(),
+                    reads_sampled: 10,
+                    writes_sampled: 3,
+                    estimated_reads: 640,
+                    estimated_writes: 192,
+                    top_keys: vec![RpcHotKeyEntry {
+                        key_hex: "0xabcd".into(),
+                        sampled_count: 5,
+                        estimated_count: 320,
+                        max_overestimate: 64,
+                    }],
+                }],
+            }),
+            accounts: Some(RpcHotAccounts {
+                sampling_rate: 64,
+                sketch_capacity: 256,
+                window_start_unix_ms: 1_765_000_000_000,
+                estimated_account_reads: 1280,
+                estimated_account_writes: 0,
+                estimated_code_reads: 64,
+                top_accounts: vec![RpcHotAccountEntry {
+                    address: "0x0000000000000000000000000000000000000003".into(),
+                    sampled_count: 8,
+                    estimated_count: 512,
+                    max_overestimate: 64,
+                }],
+                top_code: vec![],
+            }),
+        };
+
+        let json = serde_json::to_string(&report).unwrap();
+        // camelCase field names on the wire.
+        assert!(json.contains("\"samplingEnabled\":true"));
+        assert!(json.contains("\"samplingRate\":64"));
+        assert!(json.contains("\"topN\":16"));
+        assert!(json.contains("\"keyHex\":\"0xabcd\""));
+        assert!(json.contains("\"maxOverestimate\":64"));
+        assert!(json.contains("\"estimatedAccountReads\":1280"));
+
+        let parsed: RpcHotKeyReport = serde_json::from_str(&json).unwrap();
+        assert!(parsed.sampling_enabled);
+        assert_eq!(parsed.sampling_rate, 64);
+        assert_eq!(parsed.storage.as_ref().unwrap().cfs[0].cf, "state");
+        assert_eq!(
+            parsed.accounts.as_ref().unwrap().top_accounts[0].estimated_count,
+            512
+        );
+    }
+
+    /// Sampling-off shape: detail fields are null, not omitted.
+    #[test]
+    fn test_hot_key_report_disabled_shape() {
+        let report = RpcHotKeyReport {
+            sampling_enabled: false,
+            sampling_rate: 0,
+            top_n: 16,
+            storage: None,
+            accounts: None,
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("\"samplingEnabled\":false"));
+        assert!(json.contains("\"storage\":null"));
+        assert!(json.contains("\"accounts\":null"));
     }
 }

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -214,7 +214,9 @@ Add `--hot-key-window-secs <N>` (env `QFC_HOT_KEY_WINDOW_SECS`, 0 = cumulative)
 to make sampling **windowed**: every N seconds the node logs a ranked report
 (`tracing` target `qfc::hot_keys`) and resets the sketches, so estimates stay
 accurate and these gauges read per-window (a sawtooth) rather than
-cumulative-since-start.
+cumulative-since-start. The full ranked report (the hot *identities* kept out
+of the labels here) is also available on demand via the `qfc_hotKeyReport`
+JSON-RPC method (optional `topN`).
 
 **Cardinality:** the top-N hot *identities* (raw keys, account addresses, code
 hashes) are deliberately **not** Prometheus labels — the hot set churns

--- a/docs/profiling/HOT-KEYS.md
+++ b/docs/profiling/HOT-KEYS.md
@@ -203,5 +203,18 @@ gauges read per-window. With a window set the gauges are a sawtooth; the
 dashboard's traffic panels already apply `deriv()`, so they read correctly
 either way.
 
-Still open: an RPC method to fetch the full ranked `hot_key_report` on demand
-(the windowed `qfc::hot_keys` log is the current record of ranked identities).
+**On-demand RPC — done.** `qfc_hotKeyReport` (optional `topN`, default 16,
+clamped to 1..=256) returns the full ranked report — per-CF traffic with the
+hottest keys, plus the hottest accounts and contract bytecode — as camelCase
+JSON. When sampling is off it returns `{samplingEnabled: false, storage: null,
+accounts: null}`. This is the on-demand counterpart to the windowed
+`qfc::hot_keys` log; the ranked identities live here rather than in the
+Prometheus labels.
+
+```
+curl -s $RPC -X POST -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"qfc_hotKeyReport","params":[10],"id":1}'
+```
+
+T8 is complete: sampling library (#116) → exporter + flag (#117) → Grafana
+panel (#118) → window-reset scheduler (#119) → this RPC.


### PR DESCRIPTION
The on-demand RPC — the last item from the #117 follow-up list. T8 complete after this.

## What
`qfc_hotKeyReport` (namespace `qfc`), optional `topN` param (default 16, clamped 1..=256). Returns the full ranked report as camelCase JSON: per-CF traffic with the hottest keys, plus the hottest accounts and contract bytecode — i.e. the ranked **identities** that are deliberately kept out of the Prometheus labels. The on-demand counterpart to the windowed `qfc::hot_keys` log.

```jsonc
// sampling on:
{ "samplingEnabled": true, "samplingRate": 4, "topN": 3,
  "storage": { "cfs": [ { "cf": "state", "estimatedWrites": 48,
    "topKeys": [ { "keyHex": "0xd568…", "estimatedCount": 4, "maxOverestimate": 0 } ] } ] },
  "accounts": { "estimatedAccountReads": 40, "topAccounts": [ … ], "topCode": [ … ] } }
// sampling off:
{ "samplingEnabled": false, "samplingRate": 0, "topN": 16, "storage": null, "accounts": null }
```

## Implementation
- `qfc.rs`: trait method + camelCase DTOs (`RpcHotKeyReport` + nested storage/account/key/code structs), matching the existing Rpc* DTO convention.
- `server.rs`: maps `chain.db().hot_key_report()` and `chain.state().hot_account_report()` into the DTOs. No `main.rs` wiring — the RPC server already holds the `Arc<Chain>`.

## Tests / evidence
- Two serde round-trips: camelCase keys on the wire (`samplingEnabled`, `keyHex`, `maxOverestimate`, …) and the disabled shape with explicit `null` details. **qfc-rpc 39 tests pass**; `cargo fmt --all --check` + clippy clean.
- Live dev-node smoke (`--hot-key-sampling 4`, `params:[3]`): returns the ranked per-CF report with `topN` honored. Sampling-off node returns the null-detail shape with default `topN:16`.

## Docs
`HOT-KEYS.md` (RPC done — T8 marked complete with the full #116→#119→this chain), `observability/README.md`, and the `CLAUDE.md` RPC endpoint list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)