### PR TITLE
docs(roadmap): mark AI-V3 progress — B-1, Feature A (A0–A6), B-2 spike shipped

### DIFF
--- a/docs/ROADMAP-AI-V3.md
+++ b/docs/ROADMAP-AI-V3.md
@@ -2,8 +2,8 @@
 
 *🌐 [中文](ROADMAP-AI-V3.zh.md)*
 
-**Status:** design roadmap, not scheduled. Builds on the shipped v2.x AI-compute stack.
-**Owner:** Larry. **Created:** 2026-06-10.
+**Status:** in progress — B-1 shipped, Feature A core (A0–A6) shipped, B-2 gating spike done. Remaining work (B-2 build, Feature A node integration) is gated on live multi-region / testnet infrastructure, not pure-library code. See [Progress](#progress).
+**Owner:** Larry. **Created:** 2026-06-10. **Last updated:** 2026-06-14.
 
 ## Where v2.x leaves us
 
@@ -15,6 +15,31 @@ The pieces this roadmap builds on, all live today:
 - Consensus integration — `WorkProof { flops_estimated, … }` per epoch, `inference_score` on validators.
 
 **The two v3 features below share one principle: the chain stores *commitments and incentives*; heavy ML data flows off-chain.** A parameter server's relaxed consistency can never sit on the consensus path (state must be deterministically re-derivable), so every design here keeps PS-shaped components strictly off-chain with on-chain anchoring.
+
+---
+
+## Progress
+
+_Updated 2026-06-14. Every milestone shipped via the same flow — dedicated git worktree → implement → adversarial review → fix → PR; each review caught and fixed real issues (poisoning, sampling-grind, free-jail griefing, integer overflow, aggregation-unit mismatch) before merge._
+
+### Shipped
+
+| Milestone | PR | What landed |
+|---|---|---|
+| **B-1** (B0–B2) | [#102](https://github.com/qfc-network/qfc-core/pull/102) | ADR-0001; registry shard manifest; per-shard-verified resumable IPFS download; cross-version shard cache reuse |
+| **A0** | [#107](https://github.com/qfc-network/qfc-core/pull/107) | ADRs 0002–0008 (**7**, not 5 — review added data-availability + verification-economics) |
+| **A1 + A2** | [#107](https://github.com/qfc-network/qfc-core/pull/107) | `qfc-ps` crate: range-sharded `ShardStore`, SSP `SspClock`, `ShardService`; coordinate-wise trimmed-mean aggregation + seeded poisoning property tests |
+| **A3** | [#110](https://github.com/qfc-network/qfc-core/pull/110) | training-job type + deterministic epoch assignment in `qfc-ai-coordinator`; per-worker gradient accumulation (n = workers, not rows) |
+| **A4** | [#114](https://github.com/qfc-network/qfc-core/pull/114) | sampled training-step re-execution; grind-proof sampling (entropy = committed `params_hash`); exact + per-coordinate tolerance-band compare |
+| **A5** | [#120](https://github.com/qfc-network/qfc-core/pull/120) | ADR-0009; deterministic `settle_epoch` → version commitment + pro-rata rewards + slashing; `TrainingChainStore`; `SlashableOffense::InvalidTraining` |
+| **A6** | [#122](https://github.com/qfc-network/qfc-core/pull/122) | ADR-0010; `qfc-training-pilot` — in-process ≥3-miner end-to-end pilot over the real A1–A5 APIs (deterministic CPU model, cheater caught + slashed, loss 5.67→0.11) |
+| **B-2 spike** | [#124](https://github.com/qfc-network/qfc-core/pull/124) | ADR-0011; real WAN measurements + reproducible calculator (`cargo run -p qfc-inference --example pipeline_latency`); B-2 go/no-go |
+
+### Not started — gated on live infrastructure (not pure-library work)
+
+- **B-2 build (B3–B5).** The spike verdict ([ADR-0011](adr/0011-b2-pipeline-scope.md)): interactive inference over WAN is a **no-go** (RTT-dominated — a 7B model split 4 ways needs ~37 s of network alone for 100 tokens intercontinentally); batch is viable but **bandwidth-gated, not just RTT-gated** (a 7B prefill hop is ~12 s at the measured 20 Mbit/s). B-2 is re-scoped to **batch-only** with bandwidth/locality-aware assignment + activation compression. **Hard gate before building:** re-run the calculator against real cross-region *miner-to-miner* measurements — needs ≥2 miners in different regions (the single-region testnet can't produce them).
+- **Feature A node integration.** A6 proves the loop in-process; landing it on a live network needs `qfc-node`/`qfc-consensus`/`qfc-state`/`qfc-network` changes + a real testnet: applying `settle_epoch` output to chain state (balance credit + an absolute-amount slash entry point), P2P broadcast, N-of-M operator agreement on the canonical outcome + penalty set, VRF sampling entropy, per-job stake-locking enforcement, signed `ParamUpdate`. All grep-able as `A6` / `live` / `node` markers in the code; the pilot is their executable spec.
+- **Live multi-region testnet pilot** (A6's literal "≥3 miners on testnet" form) and **candle / BERT-class GPU models + A4b GPU tolerance-band verification** — external infra plus the GPU-determinism problem A4 deliberately deferred.
 
 ---
 
@@ -86,17 +111,17 @@ Key design decisions (each needs an ADR before code):
 
 ### Milestones (estimates = Claude session hours, not human time)
 
-| # | Milestone | Deliverable | Est. (Claude session h) |
-|---|---|---|---|
-| A0 | ADRs for decisions 1–5 | `docs/adr/` ×5 | 2–3 h |
-| A1 | `qfc-ps` crate skeleton | range-sharded KV, push/pull API, ps-lite-style timestamps; reuses `qfc-storage` as the shard's local persistence | 4–6 h |
-| A2 | Byzantine-robust aggregation | trimmed-mean aggregator + property tests vs poisoning scenarios | 3–4 h |
-| A3 | Training task type | extend `qfc-ai-coordinator` task pool + assignment for training jobs (data-shard manifest via IPFS) | 3–4 h |
-| A4 | Verification path | sampled step re-execution in `verification.rs`; tolerance-band gradient compare | 4–6 h |
-| A5 | Chain integration | model-version commitments, contribution records, reward/slash hooks in consensus | 4–6 h |
-| A6 | Testnet pilot | tiny model (e.g. BERT-class) trained across ≥3 miners on testnet | 3–4 h |
+| # | Milestone | Deliverable | Est. (Claude session h) | Status |
+|---|---|---|---|---|
+| A0 | ADRs for decisions 1–5 | `docs/adr/` (shipped as **7** ADRs, 0002–0008) | 2–3 h | ✅ [#107](https://github.com/qfc-network/qfc-core/pull/107) |
+| A1 | `qfc-ps` crate skeleton | range-sharded KV, push/pull API, ps-lite-style timestamps; reuses `qfc-storage` as the shard's local persistence | 4–6 h | ✅ [#107](https://github.com/qfc-network/qfc-core/pull/107) |
+| A2 | Byzantine-robust aggregation | trimmed-mean aggregator + property tests vs poisoning scenarios | 3–4 h | ✅ [#107](https://github.com/qfc-network/qfc-core/pull/107) |
+| A3 | Training task type | extend `qfc-ai-coordinator` task pool + assignment for training jobs (data-shard manifest via IPFS) | 3–4 h | ✅ [#110](https://github.com/qfc-network/qfc-core/pull/110) |
+| A4 | Verification path | sampled step re-execution in `verification.rs`; tolerance-band gradient compare | 4–6 h | ✅ [#114](https://github.com/qfc-network/qfc-core/pull/114) |
+| A5 | Chain integration | model-version commitments, contribution records, reward/slash hooks in consensus | 4–6 h | ✅ [#120](https://github.com/qfc-network/qfc-core/pull/120) — settlement layer; node-side application gated (see Progress) |
+| A6 | Testnet pilot | tiny model (e.g. BERT-class) trained across ≥3 miners on testnet | 3–4 h | ✅ [#122](https://github.com/qfc-network/qfc-core/pull/122) — in-process ≥3-miner pilot; live multi-machine gated |
 
-Wall-clock depends on session spacing; total ≈ **23–33 Claude session hours**. Sequencing: A0 → A1/A2 in parallel → A3 → A4 → A5 → A6.
+Wall-clock depends on session spacing; total ≈ **23–33 Claude session hours**. Sequencing: A0 → A1/A2 in parallel → A3 → A4 → A5 → A6. **All A0–A6 shipped** (the in-process realization); live testnet deployment + node integration remain — see [Progress](#progress).
 
 ---
 
@@ -113,7 +138,7 @@ Wall-clock depends on session spacing; total ≈ **23–33 Claude session hours*
 - Miners with enough total memory assemble the model from IPFS shard-by-shard with per-shard verification (today's whole-file hash check generalized) — resumable downloads, partial caching, and shared shard reuse across model versions (most layers don't change between fine-tunes).
 - No new execution semantics; pure distribution win.
 
-**B-2: Multi-miner *pipeline execution*** (the hard part, gated on B-1 learnings)
+**B-2: Multi-miner *pipeline execution*** (the hard part — WAN-latency spike done, [ADR-0011](adr/0011-b2-pipeline-scope.md): **interactive over WAN = no-go; batch-only, bandwidth/locality-aware, activation-compressed.** Build gated on real cross-region measurement.)
 - Coordinator assigns a **shard group**: an ordered set of miners each holding a layer range; activations flow miner→miner (pipeline parallelism).
 - Honest constraint to state up front: pipeline parallelism over WAN latencies is unproven for interactive inference — target batch/async workloads first (the task pool already models async tasks), interactive only if latency data supports it.
 - Verification: per-stage activation commitments (hash of layer-boundary tensors) so a spot-check can re-execute *one stage*, not the whole pipeline.
@@ -155,21 +180,22 @@ flowchart LR
 
 ### Milestones (estimates = Claude session hours)
 
-| # | Milestone | Deliverable | Est. (Claude session h) |
-|---|---|---|---|
-| B0 | ADR: shard manifest format + assignment changes | `docs/adr/` | 1–2 h |
-| B1 | Shard manifest in registry + sharded IPFS download with per-shard verify | `registry.rs`, `download.rs` | 3–4 h |
-| B2 | Assembly + cache reuse across versions | `qfc-inference` data_store | 2–3 h |
-| B3 | Shard-group assignment | `assignment.rs` extension | 3–4 h |
-| B4 | Pipeline execution prototype (2 miners, batch task) | `qfc-inference` runtime + coordinator router | 6–8 h |
-| B5 | Per-stage verification | activation commitments + staged spot-check | 3–4 h |
+| # | Milestone | Deliverable | Est. (Claude session h) | Status |
+|---|---|---|---|---|
+| B0 | ADR: shard manifest format + assignment changes | `docs/adr/` (ADR-0001) | 1–2 h | ✅ [#102](https://github.com/qfc-network/qfc-core/pull/102) |
+| B1 | Shard manifest in registry + sharded IPFS download with per-shard verify | `registry.rs`, `download.rs` (`shard.rs`) | 3–4 h | ✅ [#102](https://github.com/qfc-network/qfc-core/pull/102) |
+| B2 | Assembly + cache reuse across versions | `qfc-inference` data_store | 2–3 h | ✅ [#102](https://github.com/qfc-network/qfc-core/pull/102) |
+| — | **WAN-latency spike** (B-2 gate) | real measurements + reproducible calculator + go/no-go | 1 h | ✅ [#124](https://github.com/qfc-network/qfc-core/pull/124) (ADR-0011) |
+| B3 | Shard-group assignment | `assignment.rs` extension — now **bandwidth + locality** aware (ADR-0011) | 3–4 h | ⛔ gated on cross-region measurement |
+| B4 | Pipeline execution prototype (2 miners, **batch** task) | `qfc-inference` runtime + coordinator router; **activation compression** required (ADR-0011) | 6–8 h | ⛔ gated |
+| B5 | Per-stage verification | activation commitments (over **quantized** transported bytes) + staged spot-check | 3–4 h | ⛔ gated |
 
-B-1 (B0–B2) ≈ **6–9 Claude session hours** and is independently shippable. B-2 (B3–B5) ≈ **12–16 h**, gated on a WAN-latency measurement spike before committing.
+B-1 (B0–B2) ≈ **6–9 Claude session hours** — **shipped** ([#102](https://github.com/qfc-network/qfc-core/pull/102)). B-2 (B3–B5) ≈ **12–16 h**: the WAN-latency spike is done ([ADR-0011](adr/0011-b2-pipeline-scope.md)) and re-scoped B-2 to batch-only + bandwidth/locality-aware + activation-compressed; **building B3–B5 is gated on re-running the calculator against real cross-region miner-to-miner RTT+bandwidth** (needs ≥2 miners in different regions).
 
 ---
 
 ## Sequencing & non-goals
 
-- **Recommended order: B-1 → A → B-2.** B-1 is small, immediately useful (bigger models on today's network), and builds the shard-manifest plumbing A5/B-2 both want. A is the strategic feature. B-2 is gated on latency reality.
+- **Recommended order: B-1 → A → B-2.** ✅ **Executed in this order:** B-1 first ([#102](https://github.com/qfc-network/qfc-core/pull/102)), then Feature A core ([#107](https://github.com/qfc-network/qfc-core/pull/107)–[#122](https://github.com/qfc-network/qfc-core/pull/122)), then the B-2 latency spike ([#124](https://github.com/qfc-network/qfc-core/pull/124)). B-1's shard-manifest plumbing was indeed reused by Feature A (snapshot/version distribution, ADR-0007) and is the basis for B-2's compressed-activation transport. B-2 remains gated on latency reality, now quantified.
 - **Non-goals, permanently:** PS semantics on the consensus path (determinism is non-negotiable); plain-FedAvg aggregation (poisonable); trusting any single PS operator (always ≥2-of-N verification or staked-slashable operators).
 - Estimates above are **Claude session hours** — wall-clock time depends on how sessions are spaced. External dependencies outside Claude's control: testnet miner volunteers for A6/B4, and IPFS gateway capacity for large shard sets.

--- a/docs/ROADMAP-AI-V3.zh.md
+++ b/docs/ROADMAP-AI-V3.zh.md
@@ -2,8 +2,8 @@
 
 *🌐 [English](ROADMAP-AI-V3.md)*
 
-**状态：** 设计路线图，未排期。基于已发布的 v2.x AI 算力栈。
-**Owner：** Larry。**创建：** 2026-06-10。
+**状态：** 进行中 — B-1 已交付、Feature A 核心（A0–A6）已交付、B-2 门控 spike 已完成。剩余工作（B-2 构建、Feature A 节点集成）受限于真实多区域 / 测试网基础设施，而非纯库代码。见 [进度](#进度)。
+**Owner：** Larry。**创建：** 2026-06-10。**最后更新：** 2026-06-14。
 
 ## v2.x 留给我们的基础
 
@@ -15,6 +15,31 @@
 - 共识集成 — 每 epoch 的 `WorkProof { flops_estimated, … }`、validator 上的 `inference_score`。
 
 **下面两个 v3 特性共享一条原则：链上只存*承诺与激励*；繁重的 ML 数据在链下流动。** Parameter server 的松弛一致性永远不能进共识路径（状态必须可确定性重放），因此这里的所有设计都把 PS 形状的组件严格放在链下，用链上锚定。
+
+---
+
+## 进度
+
+_更新于 2026-06-14。每个里程碑都按同一流程交付——专用 git worktree → 实现 → 对抗式评审 → 修复 → PR；每次评审都在合并前抓出并修复了真实问题（投毒、抽样刷分、free-jail 骚扰、整数溢出、聚合单位不匹配）。_
+
+### 已交付
+
+| 里程碑 | PR | 落地内容 |
+|---|---|---|
+| **B-1**（B0–B2） | [#102](https://github.com/qfc-network/qfc-core/pull/102) | ADR-0001；注册表分片 manifest；逐分片校验的可断点续传 IPFS 下载；跨版本分片缓存复用 |
+| **A0** | [#107](https://github.com/qfc-network/qfc-core/pull/107) | ADR 0002–0008（**7 篇**，而非 5 篇——评审追加了数据可用性 + 验证经济学） |
+| **A1 + A2** | [#107](https://github.com/qfc-network/qfc-core/pull/107) | `qfc-ps` crate：区间分片 `ShardStore`、SSP `SspClock`、`ShardService`；坐标级 trimmed-mean 聚合 + 带种子的投毒属性测试 |
+| **A3** | [#110](https://github.com/qfc-network/qfc-core/pull/110) | `qfc-ai-coordinator` 中的训练作业类型 + 确定性 epoch 分配；按 worker 的梯度累加（n = worker 数，而非行数） |
+| **A4** | [#114](https://github.com/qfc-network/qfc-core/pull/114) | 抽样训练步重执行；防刷分抽样（熵 = 已承诺的 `params_hash`）；精确比较 + 逐坐标容差带比较 |
+| **A5** | [#120](https://github.com/qfc-network/qfc-core/pull/120) | ADR-0009；确定性 `settle_epoch` → 版本承诺 + 按比例奖励 + 罚没；`TrainingChainStore`；`SlashableOffense::InvalidTraining` |
+| **A6** | [#122](https://github.com/qfc-network/qfc-core/pull/122) | ADR-0010；`qfc-training-pilot`——基于真实 A1–A5 API 的进程内 ≥3-miner 端到端试点（确定性 CPU 模型，作弊者被抓并罚没，loss 5.67→0.11） |
+| **B-2 spike** | [#124](https://github.com/qfc-network/qfc-core/pull/124) | ADR-0011；真实 WAN 实测 + 可复现 calculator（`cargo run -p qfc-inference --example pipeline_latency`）；B-2 go/no-go |
+
+### 未开始 — 受限于真实基础设施（非纯库代码）
+
+- **B-2 构建（B3–B5）。** spike 结论（[ADR-0011](adr/0011-b2-pipeline-scope.md)）：交互式 WAN 推理是 **no-go**（RTT 主导——一个 7B 模型切 4 份，洲际间跑 100 token 光网络传输就要 ~37s）；批处理可行，但**受带宽门控、而非仅受 RTT 门控**（7B prefill 单跳在实测 20 Mbit/s 下约 12s）。B-2 重新定为**仅批处理** + 带宽 / 局部性感知分配 + 激活压缩。**开建前的硬门槛：** 用真实跨区 *miner-to-miner* 测量重跑 calculator——需要 ≥2 个位于不同区域的 miner（单区域测试网产生不了这种数据）。
+- **Feature A 节点集成。** A6 在进程内证明了整个回路；要把它落到真实网络上，需要 `qfc-node`/`qfc-consensus`/`qfc-state`/`qfc-network` 改动 + 真实测试网：把 `settle_epoch` 输出应用到链状态（余额入账 + 一个绝对额罚没入口）、P2P 广播、N-of-M 运营者对规范结果 + 惩罚集合达成一致、VRF 抽样熵、按作业的质押锁定执行、签名的 `ParamUpdate`。这些在代码里都可 grep 为 `A6` / `live` / `node` 标记；试点就是它们的可执行规范。
+- **真实多区域测试网试点**（A6 字面上的"测试网 ≥3 miner"形态）以及 **candle / BERT 级 GPU 模型 + A4b GPU 容差带验证**——这是外部基础设施加上 A4 刻意推迟的 GPU 确定性问题。
 
 ---
 
@@ -86,17 +111,17 @@ flowchart TB
 
 ### 里程碑（估算 = Claude session 小时，不是人力时间）
 
-| # | 里程碑 | 交付物 | 估算（Claude session h） |
-|---|---|---|---|
-| A0 | 决策 1–5 的 ADR | `docs/adr/` ×5 | 2–3 h |
-| A1 | `qfc-ps` crate 骨架 | 区间分片 KV、push/pull API、ps-lite 风格 timestamp；复用 `qfc-storage` 作分片本地持久层 | 4–6 h |
-| A2 | 拜占庭鲁棒聚合 | trimmed-mean 聚合器 + 针对投毒场景的属性测试 | 3–4 h |
-| A3 | 训练任务类型 | 扩展 `qfc-ai-coordinator` 任务池 + 训练作业分配（数据分片 manifest 走 IPFS） | 3–4 h |
-| A4 | 验证路径 | `verification.rs` 中的抽样步重执行；容差带梯度比较 | 4–6 h |
-| A5 | 链集成 | 模型版本承诺、贡献记录、共识中的奖励/罚没钩子 | 4–6 h |
-| A6 | Testnet 试点 | 小模型（如 BERT 级）在 testnet 上跨 ≥3 个矿工训练 | 3–4 h |
+| # | 里程碑 | 交付物 | 估算（Claude session h） | 状态 |
+|---|---|---|---|---|
+| A0 | 决策 1–5 的 ADR | `docs/adr/`（实际交付 **7** 篇 ADR，0002–0008） | 2–3 h | ✅ [#107](https://github.com/qfc-network/qfc-core/pull/107) |
+| A1 | `qfc-ps` crate 骨架 | 区间分片 KV、push/pull API、ps-lite 风格 timestamp；复用 `qfc-storage` 作分片本地持久层 | 4–6 h | ✅ [#107](https://github.com/qfc-network/qfc-core/pull/107) |
+| A2 | 拜占庭鲁棒聚合 | trimmed-mean 聚合器 + 针对投毒场景的属性测试 | 3–4 h | ✅ [#107](https://github.com/qfc-network/qfc-core/pull/107) |
+| A3 | 训练任务类型 | 扩展 `qfc-ai-coordinator` 任务池 + 训练作业分配（数据分片 manifest 走 IPFS） | 3–4 h | ✅ [#110](https://github.com/qfc-network/qfc-core/pull/110) |
+| A4 | 验证路径 | `verification.rs` 中的抽样步重执行；容差带梯度比较 | 4–6 h | ✅ [#114](https://github.com/qfc-network/qfc-core/pull/114) |
+| A5 | 链集成 | 模型版本承诺、贡献记录、共识中的奖励/罚没钩子 | 4–6 h | ✅ [#120](https://github.com/qfc-network/qfc-core/pull/120) — 结算层；节点侧应用受门控（见进度） |
+| A6 | Testnet 试点 | 小模型（如 BERT 级）在 testnet 上跨 ≥3 个矿工训练 | 3–4 h | ✅ [#122](https://github.com/qfc-network/qfc-core/pull/122) — 进程内 ≥3-miner 试点；真实多机受门控 |
 
-墙钟时间取决于 session 间隔；合计约 **23–33 Claude session 小时**。顺序：A0 → A1/A2 并行 → A3 → A4 → A5 → A6。
+墙钟时间取决于 session 间隔；合计约 **23–33 Claude session 小时**。顺序：A0 → A1/A2 并行 → A3 → A4 → A5 → A6。**全部 A0–A6 已交付**（进程内实现）；真实测试网部署 + 节点集成仍待完成——见 [进度](#进度)。
 
 ---
 
@@ -113,7 +138,7 @@ flowchart TB
 - 总内存足够的矿工从 IPFS 逐分片组装模型并逐分片校验（今天的整文件 hash 检查推广而来）——可断点续传、部分缓存、跨模型版本共享分片复用（fine-tune 之间大多数层不变）。
 - 没有新的执行语义；纯分发收益。
 
-**B-2：多矿工*流水线执行***（难的部分，gate 在 B-1 的经验上）
+**B-2：多矿工*流水线执行***（难的部分——WAN 延迟 spike 已完成，[ADR-0011](adr/0011-b2-pipeline-scope.md)：**交互式 WAN = no-go；仅批处理、带宽 / 局部性感知、激活压缩。** 构建受真实跨区测量门控。）
 - Coordinator 分配一个**分片组**：一组有序矿工各持一段层区间；activation 在矿工间流动（流水线并行）。
 - 预先声明的诚实约束：广域网延迟下的流水线并行对交互式推理未经证明——先做批量/异步负载（任务池本来就建模异步任务），交互式只有在延迟数据支持时才做。
 - 验证：每 stage 的 activation 承诺（层边界张量的 hash），让抽查能只重执行*一个 stage* 而不是整条流水线。
@@ -155,21 +180,22 @@ flowchart LR
 
 ### 里程碑（估算 = Claude session 小时）
 
-| # | 里程碑 | 交付物 | 估算（Claude session h） |
-|---|---|---|---|
-| B0 | ADR：分片 manifest 格式 + assignment 改动 | `docs/adr/` | 1–2 h |
-| B1 | 注册表分片 manifest + 逐分片校验的 IPFS 分片下载 | `registry.rs`、`download.rs` | 3–4 h |
-| B2 | 组装 + 跨版本缓存复用 | `qfc-inference` data_store | 2–3 h |
-| B3 | 分片组分配 | `assignment.rs` 扩展 | 3–4 h |
-| B4 | 流水线执行原型（2 矿工，批量任务） | `qfc-inference` runtime + coordinator router | 6–8 h |
-| B5 | 每 stage 验证 | activation 承诺 + 分段抽查 | 3–4 h |
+| # | 里程碑 | 交付物 | 估算（Claude session h） | 状态 |
+|---|---|---|---|---|
+| B0 | ADR：分片 manifest 格式 + assignment 改动 | `docs/adr/`（ADR-0001） | 1–2 h | ✅ [#102](https://github.com/qfc-network/qfc-core/pull/102) |
+| B1 | 注册表分片 manifest + 逐分片校验的 IPFS 分片下载 | `registry.rs`、`download.rs`（`shard.rs`） | 3–4 h | ✅ [#102](https://github.com/qfc-network/qfc-core/pull/102) |
+| B2 | 组装 + 跨版本缓存复用 | `qfc-inference` data_store | 2–3 h | ✅ [#102](https://github.com/qfc-network/qfc-core/pull/102) |
+| — | **WAN 延迟 spike**（B-2 门控） | 真实实测 + 可复现 calculator + go/no-go | 1 h | ✅ [#124](https://github.com/qfc-network/qfc-core/pull/124)（ADR-0011） |
+| B3 | 分片组分配 | `assignment.rs` 扩展——现在**带宽 + 局部性**感知（ADR-0011） | 3–4 h | ⛔ 受跨区测量门控 |
+| B4 | 流水线执行原型（2 矿工，**批处理**任务） | `qfc-inference` runtime + coordinator router；需**激活压缩**（ADR-0011） | 6–8 h | ⛔ 受门控 |
+| B5 | 每 stage 验证 | activation 承诺（对**量化后**传输字节）+ 分段抽查 | 3–4 h | ⛔ 受门控 |
 
-B-1（B0–B2）约 **6–9 Claude session 小时**，可独立发布。B-2（B3–B5）约 **12–16 h**，承诺投入前先做一次 WAN 延迟实测 spike。
+B-1（B0–B2）约 **6–9 Claude session 小时**——**已交付**（[#102](https://github.com/qfc-network/qfc-core/pull/102)）。B-2（B3–B5）约 **12–16 h**：WAN 延迟 spike 已完成（[ADR-0011](adr/0011-b2-pipeline-scope.md)），并把 B-2 重新定为仅批处理 + 带宽 / 局部性感知 + 激活压缩；**构建 B3–B5 受门控于用真实跨区 miner-to-miner RTT + 带宽重跑 calculator**（需要 ≥2 个位于不同区域的 miner）。
 
 ---
 
 ## 顺序与非目标
 
-- **推荐顺序：B-1 → A → B-2。** B-1 小、立刻有用（今天的网络就能上更大的模型），而且铺好了 A5/B-2 都需要的分片 manifest 管线。A 是战略特性。B-2 gate 在延迟现实上。
+- **推荐顺序：B-1 → A → B-2。** ✅ **已按此顺序执行：** 先 B-1（[#102](https://github.com/qfc-network/qfc-core/pull/102)），再 Feature A 核心（[#107](https://github.com/qfc-network/qfc-core/pull/107)–[#122](https://github.com/qfc-network/qfc-core/pull/122)），最后 B-2 延迟 spike（[#124](https://github.com/qfc-network/qfc-core/pull/124)）。B-1 的分片 manifest 管线确实被 Feature A 复用（快照 / 版本分发，ADR-0007），也是 B-2 压缩激活传输的基础。B-2 仍受门控于延迟现实，但现已量化。
 - **永久非目标：** 共识路径上的 PS 语义（确定性不可妥协）；裸 FedAvg 聚合（可投毒）；信任任何单个 PS 运营者（永远 ≥2-of-N 验证或有质押可罚没的运营者）。
 - 上述估算是 **Claude session 小时**——墙钟时间取决于 session 怎么排。Claude 控制之外的外部依赖：A6/B4 的 testnet 矿工志愿者、大分片集的 IPFS 网关容量。


### PR DESCRIPTION
Updates `docs/ROADMAP-AI-V3.md` and its Chinese mirror to reflect what's actually been built, so the roadmap stops reading as "design, not scheduled."

## Changes (docs only)

- **Status line** → in-progress, with last-updated date and a pointer to the new Progress section.
- **New `## Progress` section** — a shipped-milestones table with PR links and one-line summaries, plus an explicit "not started — gated on live infrastructure" list so the boundary between done-in-code and needs-real-infra is unambiguous.
- **Status column** on both milestone tables:
  - Feature A: A0–A6 all ✅ ([#107](https://github.com/qfc-network/qfc-core/pull/107)/[#110](https://github.com/qfc-network/qfc-core/pull/110)/[#114](https://github.com/qfc-network/qfc-core/pull/114)/[#120](https://github.com/qfc-network/qfc-core/pull/120)/[#122](https://github.com/qfc-network/qfc-core/pull/122)); A0 noted as 7 ADRs (not the planned 5 — review added data-availability + verification-economics); A5/A6 flag the node-side/live-deployment parts still gated.
  - Feature B: B0–B2 ✅ ([#102](https://github.com/qfc-network/qfc-core/pull/102)); new WAN-spike row ✅ ([#124](https://github.com/qfc-network/qfc-core/pull/124)); B3–B5 ⛔ gated.
- **B-2 narrative** now carries the spike verdict ([ADR-0011](https://github.com/qfc-network/qfc-core/blob/main/docs/adr/0011-b2-pipeline-scope.md)): interactive over WAN = no-go; batch-only, bandwidth/locality-aware, activation-compressed; build gated on real cross-region measurement.
- **Sequencing note**: the recommended B-1 → A → B-2 order was executed.
- **zh mirror** kept in sync with the same edits.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)