### PR TITLE
ci(docker): bump pinned rustc to rust:1-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # ============================================
 # Stage 1: Chef planner — analyse dependencies
 # ============================================
-FROM rust:1.88-bookworm AS chef
+FROM rust:1-bookworm AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /build
 


### PR DESCRIPTION
One-line fix: the Dockerfile pinned `rust:1.88-bookworm`, but `ruint@1.18.0` (and other deps on current `main`) now require **rustc ≥ 1.90**, so the release image build fails at `cargo chef cook`. CI passes because it uses `dtolnay/rust-toolchain@stable` + `rust-toolchain.toml` (channel `stable`), so the gap only shows up in the Docker build.

Tracking the latest 1.x stable (`rust:1-bookworm`) matches CI's `@stable` intent and prevents future MSRV bumps from breaking deploys.

This was already applied on `staging` (commit there) to unblock the deploy image build; this PR brings `main` in line so the next `main`→`staging` promote doesn't reintroduce the `1.88` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)